### PR TITLE
Include storage class and access mode in the pretty print for `ref` and `ptr` types

### DIFF
--- a/crates/hir_ty/src/ty/pretty.rs
+++ b/crates/hir_ty/src/ty/pretty.rs
@@ -123,14 +123,14 @@ fn write_ty(db: &dyn HirDatabase, ty: Ty, f: &mut String) -> std::fmt::Result {
             false => write!(f, "sampler"),
         },
         TyKind::Ref(t) => {
-            write!(f, "ref<")?;
+            write!(f, "ref<{}, ", t.storage_class)?;
             write_ty(db, t.inner, f)?;
-            write!(f, ">")
+            write!(f, ", {}>", t.access_mode)
         }
         TyKind::Ptr(t) => {
-            write!(f, "ptr<")?;
+            write!(f, "ptr<{}, ", t.storage_class)?;
             write_ty(db, t.inner, f)?;
-            write!(f, ">")
+            write!(f, ", {}>", t.access_mode)
         }
         TyKind::Function(function) => {
             write!(f, "fn(")?;


### PR DESCRIPTION
If you paste the following PoC into a WGSL file in VS Code with wgsl-analyzer installed, `&foo[0]` is highlighted with the confusing tooltip `expected ptr<i32>, found ptr<i32>`:
```wgsl
var<storage, read_write> foo: array<i32>;
let bar: ptr<storage, i32, read_write> = &foo[0];
```

The type is mismatched only because the storage class doesn't match (expected `storage` vs actual `private`). (Ironically, this mismatch is due to [a TODO item](https://github.com/wgsl-analyzer/wgsl-analyzer/blob/72fee945af9134b3abae9962a774ebba2a2601f4/crates/hir_ty/src/infer.rs#L640) where array indexes are always inferred to be of storage class `private`, something I might make yet another pull request for.)

This pull request modifies `hir_ty::ty::pretty::write_ty` to display the storage class and access mode for `ref` and `ptr` types along with the inner type, which produces less confusing tooltips like `expected ptr<storage, i32, read_write>, found ptr<private, i32, read_write>` for the PoC above.