### PR TITLE
Implement formatting for if, for, function call, assignment and infix…

### DIFF
--- a/crates/ide/src/formatting.rs
+++ b/crates/ide/src/formatting.rs
@@ -129,9 +129,12 @@ fn format_syntax_node(syntax: SyntaxNode) -> Option<()> {
         SyntaxKind::FunctionCall => {
             let function_call = ast::FunctionCall::cast(syntax)?;
 
-            remove_if_whitespace(function_call.expr()?.syntax().last_token()?);
+            if let Some(expr) = function_call.expr() {
+                remove_if_whitespace(expr.syntax().last_token()?);
+            }
 
             if let Some(type_initializer) = function_call.type_initializer() {
+                remove_if_whitespace(type_initializer.syntax().first_token()?.next_token()?);
                 remove_if_whitespace(type_initializer.syntax().last_token()?);
             }
 
@@ -550,6 +553,19 @@ mod tests {
             expect![[r#"
                 fn main() {
                     min(x, y);
+                }"#]],
+        );
+    }
+
+    #[test]
+    fn format_function_call_2() {
+        check(
+            "fn main() {
+    vec3  <f32>  (  x,y,z );
+}",
+            expect![[r#"
+                fn main() {
+                    vec3<f32>(x, y, z);
                 }"#]],
         );
     }

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -329,6 +329,8 @@ ast_node!(VariableIdentDecl:
     ty: Option<Type>;
 );
 ast_node!(FunctionParamList:
+    left_paren_token: Option<SyntaxToken ParenLeft>;
+    right_paren_token: Option<SyntaxToken ParenRight>;
     args: AstChildren<Expr>;
 );
 ast_node!(ReturnType:
@@ -520,7 +522,9 @@ ast_node!(CompoundStatement:
     right_brace_token: Option<SyntaxToken BraceRight>;
     statements: AstChildren<Statement>;
 );
-ast_node!(AssignmentStmt);
+ast_node!(AssignmentStmt:
+    equal_token: Option<SyntaxToken Equal>;
+);
 impl AssignmentStmt {
     pub fn lhs(&self) -> Option<Expr> {
         crate::support::children(self.syntax()).next()
@@ -576,6 +580,9 @@ impl CompoundAssignmentStmt {
     pub fn rhs(&self) -> Option<Expr> {
         crate::support::children(self.syntax()).nth(1)
     }
+    pub fn op_token(&self) -> Option<SyntaxToken> {
+        self.lhs()?.syntax().last_token()?.next_token()
+    }
     pub fn op(&self) -> Option<CompoundOp> {
         let kind: CompoundAssignmentOperator = support::child_token(self.syntax())?;
         let op = match kind {
@@ -594,12 +601,17 @@ impl CompoundAssignmentStmt {
     }
 }
 ast_node!(ElseIfBlock:
+    else_token: Option<SyntaxToken Else>;
+    if_token: Option<SyntaxToken If>;
+    condition: Option<Expr>;
     block: Option<CompoundStatement>;
 );
 ast_node!(ElseBlock:
+    else_token: Option<SyntaxToken Else>;
     block: Option<CompoundStatement>;
 );
 ast_node!(IfStatement:
+    if_token: Option<SyntaxToken If>;
     condition: Option<Expr>;
     block: Option<CompoundStatement>;
     else_if_blocks: AstChildren<ElseIfBlock>;
@@ -615,6 +627,7 @@ ast_node!(VariableStatement:
     variable_qualifier: Option<VariableQualifier>;
     binding: Option<Binding>;
     ty: Option<Type>;
+    equal_token: Option<SyntaxToken Equal>;
     initializer: Option<Expr>;
 );
 impl VariableStatement {
@@ -634,7 +647,9 @@ pub enum VariableStatementKind {
     Var,
 }
 
-ast_node!(ForStatement);
+ast_node!(ForStatement:
+    for_token: Option<SyntaxToken For>;
+);
 impl ForStatement {
     pub fn block(&self) -> Option<CompoundStatement> {
         support::child(self.syntax())
@@ -799,6 +814,9 @@ impl InfixExpr {
     }
     pub fn rhs(&self) -> Option<Expr> {
         crate::support::children(self.syntax()).nth(1)
+    }
+    pub fn op_token(&self) -> Option<SyntaxToken> {
+        self.lhs()?.syntax().last_token()?.next_token()
     }
     pub fn op_kind(&self) -> Option<BinaryOp> {
         let kind: BinaryOpKind = support::child_token(self.syntax())?;


### PR DESCRIPTION
- Format if statement as `if (expr) {} else if (expr) {} else {}`.
- Format for statement as `for (var i = 0; i < 100; i = i + 1)`.
- Format function calls as `func(expr, expr);`. Argument list are formatted as in function decl, but no newlines.
- Add whitespace around binary ops and assignment `=`.