### PR TITLE
Clear diagnostics for a file on close

### DIFF
--- a/crates/wgsl_analyzer/src/main_loop.rs
+++ b/crates/wgsl_analyzer/src/main_loop.rs
@@ -223,8 +223,8 @@ impl GlobalState {
 mod text_notifications {
     use anyhow::Context;
     use lsp_types::{
-        DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-        DidSaveTextDocumentParams,
+        notification::PublishDiagnostics, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
+        DidOpenTextDocumentParams, DidSaveTextDocumentParams, PublishDiagnosticsParams,
     };
     use tracing::error;
 
@@ -275,6 +275,12 @@ mod text_notifications {
     ) -> Result<()> {
         let _path = from_proto::vfs_path(&params.text_document.uri)
             .context("invalid path in did_change_text_document")?;
+
+        _state.send_notification::<PublishDiagnostics>(PublishDiagnosticsParams {
+            uri: params.text_document.uri,
+            diagnostics: vec![],
+            version: None,
+        });
 
         Ok(())
     }


### PR DESCRIPTION
See https://github.com/microsoft/language-server-protocol/issues/463

Since we don't implement file watching, this should be good enough to avoid phantom diagnoses (diagnosises?).