### PR TITLE
Update naga

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ dependencies = [
  "ide_completion",
  "itertools",
  "lsp-types",
- "naga 0.8.0",
- "naga 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "naga 0.9.0 (git+https://github.com/gfx-rs/naga?rev=350171ed2f45612386cc91a0ee9ff79d918939a9)",
+ "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "naga 0.10.0 (git+https://github.com/gfx-rs/naga?rev=e7fc8e64f2f23397b149217ecce6e123c5aa5092)",
+ "naga 0.9.0",
  "rowan",
  "salsa",
  "smol_str",
@@ -450,22 +450,6 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.8.0"
-source = "git+https://github.com/jakobhellermann/naga?branch=expose-error-messages-0.8-backport#8dba15a357123d20bafadd9433788bc3c1599908"
-dependencies = [
- "bit-set",
- "bitflags",
- "codespan-reporting",
- "hexf-parse",
- "indexmap",
- "log",
- "num-traits",
- "rustc-hash",
- "thiserror",
-]
-
-[[package]]
-name = "naga"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f50357e1167a3ab92d6b3c7f4bf5f7fd13fde3f4b28bf0d5ea07b5100fdb6c0"
@@ -485,8 +469,27 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.9.0"
-source = "git+https://github.com/gfx-rs/naga?rev=350171ed2f45612386cc91a0ee9ff79d918939a9#350171ed2f45612386cc91a0ee9ff79d918939a9"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262d2840e72dbe250e8cf2f522d080988dfca624c4112c096238a4845f591707"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "num-traits",
+ "rustc-hash",
+ "termcolor",
+ "thiserror",
+ "unicode-xid",
+]
+
+[[package]]
+name = "naga"
+version = "0.10.0"
+source = "git+https://github.com/gfx-rs/naga?rev=e7fc8e64f2f23397b149217ecce6e123c5aa5092#e7fc8e64f2f23397b149217ecce6e123c5aa5092"
 dependencies = [
  "bit-set",
  "bitflags",

--- a/crates/hir/src/diagnostics/mod.rs
+++ b/crates/hir/src/diagnostics/mod.rs
@@ -28,8 +28,8 @@ pub struct DiagnosticsConfig {
 
 #[derive(Debug)]
 pub enum NagaVersion {
-    Naga08,
     Naga09,
+    Naga10,
     NagaMain,
 }
 

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -22,17 +22,17 @@ expect-test = "1.1.0"
 itertools = "0.10.1"
 smol_str = "0.1.21"
 
-naga08 = { package = "naga", git = "https://github.com/jakobhellermann/naga", branch = "expose-error-messages-0.8-backport", features = [
-  "wgsl-in",
-  "validate",
-  "span",
-] }
 naga09 = { package = "naga", version = "0.9", features = [
   "wgsl-in",
   "validate",
   "span",
 ] }
-nagamain = { package = "naga", git = "https://github.com/gfx-rs/naga", rev = "350171ed2f45612386cc91a0ee9ff79d918939a9", features = [
+naga10 = { package = "naga", version = "0.10", features = [
+  "wgsl-in",
+  "validate",
+  "span",
+] }
+nagamain = { package = "naga", git = "https://github.com/gfx-rs/naga", rev = "e7fc8e64f2f23397b149217ecce6e123c5aa5092", features = [
   "wgsl-in",
   "validate",
   "span",

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -63,46 +63,6 @@ trait NagaError: std::error::Error {
     fn has_spans(&self) -> bool;
 }
 
-struct Naga08;
-impl Naga for Naga08 {
-    type Module = naga08::Module;
-    type ParseError = naga08::front::wgsl::ParseError;
-    type ValidationError = naga08::WithSpan<naga08::valid::ValidationError>;
-
-    fn parse(source: &str) -> Result<Self::Module, Self::ParseError> {
-        naga08::front::wgsl::parse_str(source)
-    }
-
-    fn validate(module: &Self::Module) -> Result<(), Self::ValidationError> {
-        let flags = naga08::valid::ValidationFlags::all();
-        let capabilities = naga08::valid::Capabilities::all();
-        let mut validator = naga08::valid::Validator::new(flags, capabilities);
-        validator.validate(module).map(drop)
-    }
-}
-impl NagaError for naga08::front::wgsl::ParseError {
-    fn spans<'a>(&'a self) -> Box<dyn Iterator<Item = (Range<usize>, String)> + 'a> {
-        Box::new(
-            self.labels()
-                .map(|(range, label)| (range, label.to_string())),
-        )
-    }
-    fn has_spans(&self) -> bool {
-        self.labels().len() > 0
-    }
-}
-impl NagaError for naga08::WithSpan<naga08::valid::ValidationError> {
-    fn spans<'a>(&'a self) -> Box<dyn Iterator<Item = (Range<usize>, String)> + 'a> {
-        Box::new(
-            self.spans()
-                .filter_map(move |(span, label)| Some((span.to_range()?, label.clone()))),
-        )
-    }
-    fn has_spans(&self) -> bool {
-        self.spans().len() > 0
-    }
-}
-
 struct Naga09;
 impl Naga for Naga09 {
     type Module = naga09::Module;
@@ -132,6 +92,46 @@ impl NagaError for naga09::front::wgsl::ParseError {
     }
 }
 impl NagaError for naga09::WithSpan<naga09::valid::ValidationError> {
+    fn spans<'a>(&'a self) -> Box<dyn Iterator<Item = (Range<usize>, String)> + 'a> {
+        Box::new(
+            self.spans()
+                .filter_map(move |(span, label)| Some((span.to_range()?, label.clone()))),
+        )
+    }
+    fn has_spans(&self) -> bool {
+        self.spans().len() > 0
+    }
+}
+
+struct Naga10;
+impl Naga for Naga10 {
+    type Module = naga10::Module;
+    type ParseError = naga10::front::wgsl::ParseError;
+    type ValidationError = naga10::WithSpan<naga10::valid::ValidationError>;
+
+    fn parse(source: &str) -> Result<Self::Module, Self::ParseError> {
+        naga10::front::wgsl::parse_str(source)
+    }
+
+    fn validate(module: &Self::Module) -> Result<(), Self::ValidationError> {
+        let flags = naga10::valid::ValidationFlags::all();
+        let capabilities = naga10::valid::Capabilities::all();
+        let mut validator = naga10::valid::Validator::new(flags, capabilities);
+        validator.validate(module).map(drop)
+    }
+}
+impl NagaError for naga10::front::wgsl::ParseError {
+    fn spans<'a>(&'a self) -> Box<dyn Iterator<Item = (Range<usize>, String)> + 'a> {
+        Box::new(
+            self.labels()
+                .map(|(range, label)| (range, label.to_string())),
+        )
+    }
+    fn has_spans(&self) -> bool {
+        self.labels().len() > 0
+    }
+}
+impl NagaError for naga10::WithSpan<naga10::valid::ValidationError> {
     fn spans<'a>(&'a self) -> Box<dyn Iterator<Item = (Range<usize>, String)> + 'a> {
         Box::new(
             self.spans()
@@ -338,11 +338,11 @@ pub fn diagnostics(
 
     if config.naga_parsing_errors || config.naga_validation_errors {
         match &config.naga_version {
-            NagaVersion::Naga08 => {
-                let _ = naga_diagnostics::<Naga08>(db, file_id, config, &mut diagnostics);
-            }
             NagaVersion::Naga09 => {
                 let _ = naga_diagnostics::<Naga09>(db, file_id, config, &mut diagnostics);
+            }
+            NagaVersion::Naga10 => {
+                let _ = naga_diagnostics::<Naga10>(db, file_id, config, &mut diagnostics);
             }
             NagaVersion::NagaMain => {
                 let _ = naga_diagnostics::<NagaMain>(db, file_id, config, &mut diagnostics);

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -103,7 +103,6 @@ impl NagaError for naga08::WithSpan<naga08::valid::ValidationError> {
     }
 }
 
-
 struct Naga09;
 impl Naga for Naga09 {
     type Module = naga09::Module;
@@ -143,7 +142,6 @@ impl NagaError for naga09::WithSpan<naga09::valid::ValidationError> {
         self.spans().len() > 0
     }
 }
-
 
 struct NagaMain;
 impl Naga for NagaMain {
@@ -278,7 +276,7 @@ fn naga_diagnostics<N: Naga>(
         Err(_) => return Ok(()),
     };
 
-    let full_range = TextRange::new(0.into(), TextSize::from(source.len() as u32 - 1));
+    let full_range = TextRange::up_to(TextSize::of(&source));
 
     let policy = NagaErrorPolicy::Related;
     match N::parse(&source) {

--- a/crates/wgsl_analyzer/src/config.rs
+++ b/crates/wgsl_analyzer/src/config.rs
@@ -56,17 +56,17 @@ pub struct DiagnosticsConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 pub enum NagaVersion {
-    #[serde(rename = "0.8")]
-    Naga08,
     #[serde(rename = "0.9")]
     Naga09,
+    #[serde(rename = "0.10")]
+    Naga10,
     #[serde(rename = "main")]
     NagaMain,
 }
 
 impl Default for NagaVersion {
     fn default() -> Self {
-        NagaVersion::Naga08
+        NagaVersion::Naga10
     }
 }
 
@@ -92,8 +92,8 @@ impl Config {
             naga_parsing_errors: self.diagnostics.naga_parsing_errors,
             naga_validation_errors: self.diagnostics.naga_validation_errors,
             naga_version: match self.diagnostics.naga_version {
-                NagaVersion::Naga08 => hir::diagnostics::NagaVersion::Naga08,
                 NagaVersion::Naga09 => hir::diagnostics::NagaVersion::Naga09,
+                NagaVersion::Naga10 => hir::diagnostics::NagaVersion::Naga10,
                 NagaVersion::NagaMain => hir::diagnostics::NagaVersion::NagaMain,
             },
         }

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -122,7 +122,7 @@ You can also additionally enable diagnostics for naga parsing errors.
     "wgsl-analyzer.diagnostics.typeErrors": true,
     "wgsl-analyzer.diagnostics.nagaParsing": false,
     "wgsl-analyzer.diagnostics.nagaValidation": true,
-    "wgsl-analyzer.diagnostics.nagaVersion": "0.8", // either "0.8" or "main"
+    "wgsl-analyzer.diagnostics.nagaVersion": "0.10", // either "0.9", "0.10", or "main"
 }
 ```
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -114,11 +114,11 @@
                 "wgsl-analyzer.diagnostics.nagaVersion": {
                     "type": "string",
                     "enum": [
-                        "0.8",
                         "0.9",
+                        "0.10",
                         "main"
                     ],
-                    "default": "0.9",
+                    "default": "0.10",
                     "description": "Which version of naga to use for its diagnostics"
                 },
                 "wgsl-analyzer.customImports": {


### PR DESCRIPTION
I've kept naga 0.9 support, because the most recently released `bevy_render` still uses naga 0.9.

