### PR TITLE
Correct the case where diagnostics are lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-### Unreleased
+## Unreleased
+ - Show pre-existing diagnostics on file open
+
+### Version 0.6.0
  - lint for parsing precedence issues
  - support type construction expressions properly
  - avoid panicking in cases where there are more `endif`s than `if`s

--- a/crates/wgsl_analyzer/src/diagnostics.rs
+++ b/crates/wgsl_analyzer/src/diagnostics.rs
@@ -98,6 +98,10 @@ impl DiagnosticCollection {
         }
         Some(mem::take(&mut self.changes))
     }
+
+    pub(crate) fn make_updated(&mut self, file_id: FileId) {
+        self.changes.insert(file_id);
+    }
 }
 
 fn are_diagnostics_equal(left: &lsp_types::Diagnostic, right: &lsp_types::Diagnostic) -> bool {


### PR DESCRIPTION
When closing the file, since #47 we drop diagnostics. This means that when the file is opened, the diagnostics aren't shown again.

Correct that case by marking the file as changed according to the diagnostics, even if it's the same as before.