### PR TITLE
CRITICAL: Properly report that we don't support non-`file` schemed paths

### DIFF
--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -55,7 +55,7 @@ export class Ctx {
         };
 
         const clientOptions: LanguageClientOptions = {
-            documentSelector: [{ language: "wgsl" }, { scheme: "file", pattern: "*.wgsl" }],
+            documentSelector: [{ language: "wgsl", scheme: "file" }, { scheme: "file", pattern: "*.wgsl" }],
             outputChannelName: "WGSL Analyzer",
             initializationOptions: await lspOptions(config),
         };


### PR DESCRIPTION
Without this, when viewing a file in the diff editor, we appear to overwrite our in-memory file contents with the LHS of the editor (generally the old version).
This is very bad; when you perform an edit, this means the change gets applied as-if it were on the wrong version of the file. This means that running formatting after applying this edit does bad things to your document.

If you run into this bug, the current fix is to close the file, then re-open the file (then run the standard `undo`  command (i.e. <kbd>CTRL</kbd> + <kbd>Z</kbd>).

This PR implements a hack to make this failure mode less likely to occur; it should be sufficient for now. In future, we should properly handle different schemes.
An observation along these lines is that for our project model, all paths provided by the LSP can be treated as entirely opaque. This makes things implementing this properly much easier.

I can confirm that normal operations still work with this change, and I can no longer reproduce the original bug.

@jakobhellermann I think this should probably land quite quickly, as there's a significant risk of data loss here.