### PR TITLE
[Need Discussion] Refactor custom import of Bevy

### DIFF
--- a/crates/base_db/src/translator.rs
+++ b/crates/base_db/src/translator.rs
@@ -1,0 +1,164 @@
+pub use rowan::{TextRange, TextSize};
+use std::collections::BTreeMap;
+use syntax::TextRangeTranslator;
+
+/// the strategy used for translating text offset before & after preprocessor.
+/// - `Normal`: translate one-to-one based on the offset at beginning of the
+///   block.
+/// - `Import`: if translating a single position, translate it to the beginning
+///   of the block. if translating a range, translate it from the beginning of
+///   the block to the end of the block.
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub(crate) enum TranslationStrategy {
+    Normal,
+    Import,
+}
+
+impl Default for TranslationStrategy {
+    fn default() -> Self {
+        TranslationStrategy::Normal
+    }
+}
+
+/// record the text offset translation from a processed string to original
+/// string. used for converting the text range for the parsed data, since it
+/// will use the processed string as input.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct PreProcessTranslator {
+    data: BTreeMap<u32, (u32, TranslationStrategy)>,
+}
+
+impl PreProcessTranslator {
+    /// create a new translation table
+    pub fn new() -> Self {
+        let mut res = PreProcessTranslator {
+            data: BTreeMap::new(),
+        };
+        res.insert(0, 0);
+        return res;
+    }
+
+    /// insert the offset for a block of text
+    /// - `original`: the beginning position of the original text for this block
+    /// - `processed`: the beginning position of the translated text for this
+    ///   block
+    ///
+    /// the translating strategy used by default is the
+    /// `TranslationStrategy::default()`.
+    pub(crate) fn insert(&mut self, original: u32, processed: u32) {
+        self.data.insert(processed, (original, Default::default()));
+    }
+
+    /// set the strategy of the last block.
+    /// - `strategy`: the strategy for the last block
+    pub(crate) fn set_last_block_strategy(&mut self, strategy: TranslationStrategy) {
+        // unwrap here is safe because we initialize at least one entry in the data.
+        self.data.last_entry().unwrap().get_mut().1 = strategy;
+    }
+
+    /// translate a offset from processed position to original position. please
+    /// see `TranslationStrategy` for how to translate.
+    /// - `position`: the processed position
+    /// - `return`: the original position
+    pub fn translate_start(&self, position: u32) -> u32 {
+        // unwrap here is safe because we initialize at least one entry in the data.
+        self.data
+            .range(0..=position)
+            .max_by_key(|(key, _)| *key)
+            .map(|(proc, (orig, strategy))| match strategy {
+                TranslationStrategy::Normal => orig + position - proc,
+                TranslationStrategy::Import => *orig,
+            })
+            .unwrap()
+            .to_owned()
+    }
+
+    /// get the end offset of original text for the current block
+    /// - `position`: current offset of processed text
+    /// - `return`: end offset of current block of original text
+    /// # panic
+    /// panic if no next block
+    fn get_block_end(&self, position: u32) -> u32 {
+        let (_, (orig, _)) = self
+            .data
+            .range((position + 1)..)
+            .min_by_key(|(key, _)| *key)
+            .unwrap();
+
+        orig - 1
+    }
+
+    /// translate a offset from processed position to original position. please
+    /// see `TranslationStrategy` for how to translate.
+    /// - `position`: the processed position
+    /// - `return`: the original position
+    pub fn translate_end(&self, position: u32) -> u32 {
+        // unwrap here is safe because we initialize at least one entry in the data.
+        self.data
+            .range(0..=position)
+            .max_by_key(|(key, _)| *key)
+            .map(|(proc, (orig, strategy))| match strategy {
+                TranslationStrategy::Normal => orig + (position - proc),
+                TranslationStrategy::Import => self.get_block_end(position),
+            })
+            .unwrap()
+            .to_owned()
+    }
+
+    /// same as function `translate`, but use `TextSize` at parameter and return
+    /// value.
+    /// - `size`: the processed position
+    /// - `return`: the original position
+    #[allow(dead_code)]
+    pub fn translate_size(&self, size: TextSize) -> TextSize {
+        TextSize::from(self.translate_start(size.into()))
+    }
+
+    /// translate a range from processed position to original position. please
+    /// see `TranslationStrategy` for how to translate.
+    /// - `range`: the processed range
+    /// - `return`: the original range
+    pub fn translate_range(&self, range: TextRange) -> TextRange {
+        let start = self.translate_start(range.start().into());
+        let end = self.translate_end(range.end().into());
+        TextRange::new(TextSize::from(start), TextSize::from(end))
+    }
+}
+
+impl TextRangeTranslator for PreProcessTranslator {
+    fn translate_range(&self, input: rowan::TextRange) -> rowan::TextRange {
+        self.translate_range(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PreProcessTranslator;
+    use super::TranslationStrategy;
+
+    #[test]
+    fn translation() {
+        let mut table = PreProcessTranslator::new();
+
+        table.insert(7, 3);
+        table.insert(10, 18);
+        table.set_last_block_strategy(TranslationStrategy::Import);
+        table.insert(14, 20);
+
+        pretty_assertions::assert_eq!(table.translate_start(0), 0);
+        pretty_assertions::assert_eq!(table.translate_start(1), 1);
+        pretty_assertions::assert_eq!(table.translate_start(3), 7);
+        pretty_assertions::assert_eq!(table.translate_start(4), 8);
+        pretty_assertions::assert_eq!(table.translate_start(18), 10);
+        pretty_assertions::assert_eq!(table.translate_start(19), 10);
+        pretty_assertions::assert_eq!(table.translate_start(20), 14);
+
+        pretty_assertions::assert_eq!(table.translate_end(0), 0);
+        pretty_assertions::assert_eq!(table.translate_end(1), 1);
+        pretty_assertions::assert_eq!(table.translate_end(3), 7);
+        pretty_assertions::assert_eq!(table.translate_end(4), 8);
+        pretty_assertions::assert_eq!(table.translate_end(18), 13);
+        pretty_assertions::assert_eq!(table.translate_end(19), 13);
+        pretty_assertions::assert_eq!(table.translate_end(20), 14);
+    }
+}

--- a/crates/syntax/src/range.rs
+++ b/crates/syntax/src/range.rs
@@ -1,0 +1,51 @@
+use super::{ParseError, SyntaxNode, SyntaxToken, TextRangeTranslator};
+use rowan::{NodeOrToken, TextRange};
+
+trait HasTextRange {
+    fn text_range(&self) -> TextRange;
+}
+
+impl<T: HasTextRange> HasTextRange for &T {
+    fn text_range(&self) -> TextRange {
+        (*self).text_range()
+    }
+}
+
+impl HasTextRange for SyntaxToken {
+    fn text_range(&self) -> TextRange {
+        self.text_range()
+    }
+}
+impl HasTextRange for SyntaxNode {
+    fn text_range(&self) -> TextRange {
+        self.text_range()
+    }
+}
+impl<N: HasTextRange, T: HasTextRange> HasTextRange for NodeOrToken<N, T> {
+    fn text_range(&self) -> TextRange {
+        match self {
+            NodeOrToken::Node(n) => n.text_range(),
+            NodeOrToken::Token(t) => t.text_range(),
+        }
+    }
+}
+
+impl HasTextRange for ParseError {
+    fn text_range(&self) -> TextRange {
+        self.range
+    }
+}
+
+pub trait HasTranslatableTextRange {
+    fn translated_range<T: TextRangeTranslator + ?Sized>(&self, translator: &T)
+        -> rowan::TextRange;
+}
+
+impl<U: HasTextRange> HasTranslatableTextRange for U {
+    fn translated_range<T: TextRangeTranslator + ?Sized>(
+        &self,
+        translator: &T,
+    ) -> rowan::TextRange {
+        translator.translate_range(self.text_range())
+    }
+}


### PR DESCRIPTION
# Motivation
Right now the support for custom import does not work very well. We only support `#import` at the top level & at the function parameter. However, Bevy implements its custom import as a preprocessor, meaning an `#import` can happen anywhere between two tokens, and unfortunately Bevy source code is practicing this capability of the preprocessor.

# Proposed Solution
Instead of trying to solve the problem at the parsing level, we preprocess the file and remove all directives in the preprocessor stage, and then the parser can parse a clean input. While the preprocessor processes the file, it also records a table of position translation, called `TextRangeTranslator`. Later after the parser has parsed the file, we use the translator to translate the text position back to the original file position.

# Benifits
- we can solve the custom import once and for all, don't need to worry about someone using the `#import` in a new place we haven't implemented. 
- also easier to keep up-to-date with bevy preprocessor updates because we only need to worry about a single place `shader_processor.rs`.

# Drawbacks
- if we ever want to support jumping to another file by `go to definition` or to see the definition from another file by hovering, it becomes tricky, but should still be doable I guess.

# Alternative Solutions
- we manually add `#import` in the parse tree for every possible position.
- we accept a broken `#import`

# About PR
Note this PR is still incomplete, specifically, many places haven't translated the text position yet. however, I believe the current code, to some degree, can demonstrate the design. The main purpose of this PR is to open discussion to see if we should go in this direction or not. Any feedback/suggestion is welcomed.