### PR TITLE
Add workgroupUniformLoad builtin

### DIFF
--- a/crates/hir_ty/builtins.wgsl
+++ b/crates/hir_ty/builtins.wgsl
@@ -364,7 +364,7 @@ unpack2x16float(u32) -> vec2<f32>
 // synchronization
 storageBarrier()
 workgroupBarrier()
-
+workgroupUniformLoad(ptr<T>) -> T
 
 // TODO: T should only match i32, f32, u32 in a lot of ops
 


### PR DESCRIPTION
This builtin exists in naga 0.13. The entry is a bit too permissive, allowing all ptr types, not just workgroup scope, but the mechanism for parsing `ptr<workgroup, T>` is not present.