### PR TITLE
Don't terminate the process on shutdown, as per LSP spec

### DIFF
--- a/crates/wgsl_analyzer/src/handlers.rs
+++ b/crates/wgsl_analyzer/src/handlers.rs
@@ -6,7 +6,6 @@ use lsp_types::{
     DiagnosticRelatedInformation, DiagnosticTag, GotoDefinitionResponse, LanguageString,
     MarkedString, TextDocumentIdentifier,
 };
-use std::process::exit;
 use vfs::FileId;
 
 use crate::global_state::GlobalStateSnapshot;
@@ -104,7 +103,7 @@ pub fn handle_hover(
 }
 
 pub fn handle_shutdown(_snap: GlobalStateSnapshot, _: ()) -> Result<()> {
-    exit(0);
+    Ok(())
 }
 
 pub fn full_source(snap: GlobalStateSnapshot, params: lsp_ext::FullSourceParams) -> Result<String> {


### PR DESCRIPTION
First of all, LOVE that there is a LSP server for WGSL! And that it has so many great features! <3 The below is not a critique of your work, just me wanting to make it work as good as possible for all editors 🙂 (I currently look into Emacs specificially)


## LSP Specification notes
In the [LSP specification, we have the following mentioned on shutdown](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown):
> The shutdown request is sent from the client to the server. It asks the server to shut down, but to not exit (otherwise the response might not be delivered correctly to the client). There is a separate exit notification that asks the server to exit.

From other LSP servers I have worked with, they have always just used the shutdown request to clean up resources. They have otherwise exited gracefully after that without any other operations needed. If needed, one often does the process exit in response to receiving an exit-notification from the client (more on this in the spec). Don't think this is needed, as the various clients seems to close the process successfully themselves. 

## Example
What happens if we do it like now? (i.e, exit the process). Then many clients will interpret that as a server crash, and some will ask if you want to restart the server. This is all according to the LSP specification. We can see this in Emacs using [lsp-mode](https://github.com/emacs-lsp/lsp-mode). If we try to start a LSP session, and end it normally with a shutdown, we get the following message:
<img width="1261" alt="image" src="https://github.com/wgsl-analyzer/wgsl-analyzer/assets/5732795/5ec25cf8-bd7a-4a8d-8fc5-138fa94c9ea1">

This should only happen in crashes. If we remove the system/process exit, then it works like expected and exits gracefully. (no remnants running either). 


---

Sorry for the block of text. Wanted to explain it in a good way to prove my point 🙂 