### PR TITLE
Exit with 1 on failed formatting check

### DIFF
--- a/crates/wgslfmt/src/main.rs
+++ b/crates/wgslfmt/src/main.rs
@@ -63,6 +63,7 @@ fn main() -> Result<(), anyhow::Error> {
                 let diff = prettydiff::diff_lines(&input, &output);
 
                 println!("Diff in {}\n{}:", file.display(), diff);
+                std::process::exit(1);
             }
         } else {
             if is_stdin {


### PR DESCRIPTION
Currently if the formatter detects a diff during usage with `--check`, it still returns exit code 0.
This PR fixes that.

Fixes https://github.com/wgsl-analyzer/wgsl-analyzer/issues/67#issuecomment-1789630846.