### PR TITLE
Add unsigned `array_index`

### DIFF
--- a/crates/hir_ty/builtins.wgsl
+++ b/crates/hir_ty/builtins.wgsl
@@ -226,37 +226,49 @@ textureDimensions(texture_external) -> vec2<u32>
 textureLoad(texture_1d<T>, i32, i32) -> vec4<T>
 textureLoad(texture_2d<T>, vec2<i32>, i32) -> vec4<T>
 textureLoad(texture_2d_array<T>, vec2<i32>, i32, i32) -> vec4<T>
+textureLoad(texture_2d_array<T>, vec2<i32>, u32, i32) -> vec4<T>
 textureLoad(texture_3d<T>, vec3<i32>, i32) -> vec4<T>
 textureLoad(texture_multisampled_2d<T>, vec2<i32>, i32) -> vec4<T>
 textureLoad(texture_depth_2d, vec2<i32>, i32) -> f32
 textureLoad(texture_depth_2d_array, vec2<i32>, i32, i32) -> f32
+textureLoad(texture_depth_2d_array, vec2<i32>, u32, i32) -> f32
 textureLoad(texture_depth_multisampled_2d, vec2<i32>, i32) -> f32
 textureLoad(texture_external, vec2<i32>) -> vec4<f32>
 
 textureLoad(texture_storage_1d<F;read>, i32) -> F::StorageType
 textureLoad(texture_storage_2d<F;read>, vec2<i32>) -> F::StorageType
 textureLoad(texture_storage_2d_array<F;read>, vec2<i32>, i32) -> F::StorageType
+textureLoad(texture_storage_2d_array<F;read>, vec2<i32>, u32) -> F::StorageType
 textureLoad(texture_storage_3d<F;read>, vec3<i32>) -> F::StorageType
 
 textureGather(i32, texture_2d<T>, sampler, vec2<f32>) -> vec4<T>
 textureGather(i32, texture_2d<T>, sampler, vec2<f32>, vec2<i32>) -> vec4<T>
 textureGather(i32, texture_2d_array<T>, sampler, vec2<f32>, i32) -> vec4<T>
+textureGather(i32, texture_2d_array<T>, sampler, vec2<f32>, u32) -> vec4<T>
 textureGather(i32, texture_2d_array<T>, sampler, vec2<f32>, i32, vec2<i32>) -> vec4<T>
+textureGather(i32, texture_2d_array<T>, sampler, vec2<f32>, u32, vec2<i32>) -> vec4<T>
 textureGather(i32, texture_cube<T>, sampler, vec3<f32>) -> vec4<T>
 textureGather(i32, texture_cube_array<T>, sampler, vec3<f32>, i32) -> vec4<T>
+textureGather(i32, texture_cube_array<T>, sampler, vec3<f32>, u32) -> vec4<T>
 textureGather(texture_depth_2d, sampler, vec2<f32>) -> vec4<f32>
 textureGather(texture_depth_2d, sampler, vec2<f32>, vec2<i32>) -> vec4<f32>
 textureGather(texture_depth_2d_array, sampler, vec2<f32>, i32) -> vec4<f32>
+textureGather(texture_depth_2d_array, sampler, vec2<f32>, u32) -> vec4<f32>
 textureGather(texture_depth_2d_array, sampler, vec2<f32>, i32, vec2<i32>) -> vec4<f32>
+textureGather(texture_depth_2d_array, sampler, vec2<f32>, u32, vec2<i32>) -> vec4<f32>
 textureGather(texture_depth_cube, sampler, vec3<f32>) -> vec4<f32>
 textureGather(texture_depth_cube_array, sampler, vec3<f32>, i32) -> vec4<f32>
+textureGather(texture_depth_cube_array, sampler, vec3<f32>, u32) -> vec4<f32>
 
 textureGatherCompare(texture_depth_2d, sampler_comparison, vec2<f32>, f32) -> vec4<f32>
 textureGatherCompare(texture_depth_2d, sampler_comparison, vec2<f32>, f32, vec2<i32>) -> vec4<f32>
 textureGatherCompare(texture_depth_2d_array, sampler_comparison, vec2<f32>, i32, f32) -> vec4<f32>
+textureGatherCompare(texture_depth_2d_array, sampler_comparison, vec2<f32>, u32, f32) -> vec4<f32>
 textureGatherCompare(texture_depth_2d_array, sampler_comparison, vec2<f32>, i32, f32, vec2<i32>) -> vec4<f32>
+textureGatherCompare(texture_depth_2d_array, sampler_comparison, vec2<f32>, u32, f32, vec2<i32>) -> vec4<f32>
 textureGatherCompare(texture_depth_cube, sampler_comparison, vec3<f32>, f32) -> vec4<f32>
 textureGatherCompare(texture_depth_cube_array, sampler_comparison, vec3<f32>, i32, f32) -> vec4<f32>
+textureGatherCompare(texture_depth_cube_array, sampler_comparison, vec3<f32>, u32, f32) -> vec4<f32>
 
 
 textureNumLayers(texture_2d_array<T>) -> i32
@@ -283,69 +295,94 @@ textureSample(texture_1d<f32>, sampler, f32) -> vec4<f32>
 textureSample(texture_2d<f32>, sampler, vec2<f32>) -> vec4<f32>
 textureSample(texture_2d<f32>, sampler, vec2<f32>, vec2<i32>) -> vec4<f32>
 textureSample(texture_2d_array<f32>, sampler, vec2<f32>, i32) -> vec4<f32>
+textureSample(texture_2d_array<f32>, sampler, vec2<f32>, u32) -> vec4<f32>
 textureSample(texture_2d_array<f32>, sampler, vec2<f32>, i32, vec2<i32>) -> vec4<f32>
+textureSample(texture_2d_array<f32>, sampler, vec2<f32>, u32, vec2<i32>) -> vec4<f32>
 textureSample(texture_3d<f32>, sampler, vec3<f32>) -> vec4<f32>
 textureSample(texture_3d<f32>, sampler, vec3<f32>, vec3<i32>) -> vec4<f32>
 textureSample(texture_cube<f32>, sampler, vec3<f32>) -> vec4<f32>
 textureSample(texture_cube_array<f32>, sampler, vec3<f32>, i32) -> vec4<f32>
+textureSample(texture_cube_array<f32>, sampler, vec3<f32>, u32) -> vec4<f32>
 textureSample(texture_depth_2d, sampler, vec2<f32>) -> f32
 textureSample(texture_depth_2d, sampler, vec2<f32>, vec2<i32>) -> f32
 textureSample(texture_depth_2d_array, sampler, vec2<f32>, i32) -> f32
+textureSample(texture_depth_2d_array, sampler, vec2<f32>, u32) -> f32
 textureSample(texture_depth_2d_array, sampler, vec2<f32>, i32, vec2<i32>) -> f32
+textureSample(texture_depth_2d_array, sampler, vec2<f32>, u32, vec2<i32>) -> f32
 textureSample(texture_depth_cube, sampler, vec3<f32>) -> f32
 textureSample(texture_depth_cube_array, sampler, vec3<f32>, i32) -> f32
+textureSample(texture_depth_cube_array, sampler, vec3<f32>, u32) -> f32
 
 textureSampleBias(texture_2d<f32>, sampler, vec2<f32>, f32) -> vec4<f32>
 textureSampleBias(texture_2d<f32>, sampler, vec2<f32>, f32, vec2<i32>) -> vec4<f32>
 textureSampleBias(texture_2d_array<f32>, sampler, vec2<f32>, i32, f32) -> vec4<f32>
+textureSampleBias(texture_2d_array<f32>, sampler, vec2<f32>, u32, f32) -> vec4<f32>
 textureSampleBias(texture_2d_array<f32>, sampler, vec2<f32>, i32, f32, vec2<i32>) -> vec4<f32>
+textureSampleBias(texture_2d_array<f32>, sampler, vec2<f32>, u32, f32, vec2<i32>) -> vec4<f32>
 textureSampleBias(texture_3d<f32>, sampler, vec3<f32>, f32) -> vec4<f32>
 textureSampleBias(texture_3d<f32>, sampler, vec3<f32>, f32, vec3<i32>) -> vec4<f32>
 textureSampleBias(texture_cube<f32>, sampler, vec3<f32>, f32) -> vec4<f32>
 textureSampleBias(texture_cube_array<f32>, sampler, vec3<f32>, i32, f32) -> vec4<f32>
+textureSampleBias(texture_cube_array<f32>, sampler, vec3<f32>, u32, f32) -> vec4<f32>
 
 textureSampleCompare(texture_depth_2d, sampler_comparison, vec2<f32>, f32) -> f32
 textureSampleCompare(texture_depth_2d, sampler_comparison, vec2<f32>, f32, vec2<i32>) -> f32
 textureSampleCompare(texture_depth_2d_array, sampler_comparison, vec2<f32>, i32, f32) -> f32
+textureSampleCompare(texture_depth_2d_array, sampler_comparison, vec2<f32>, u32, f32) -> f32
 textureSampleCompare(texture_depth_2d_array, sampler_comparison, vec2<f32>, i32, f32, vec2<i32>) -> f32
+textureSampleCompare(texture_depth_2d_array, sampler_comparison, vec2<f32>, u32, f32, vec2<i32>) -> f32
 textureSampleCompare(texture_depth_cube, sampler_comparison, vec3<f32>, f32) -> f32
 textureSampleCompare(texture_depth_cube_array, sampler_comparison, vec3<f32>, i32, f32) -> f32
+textureSampleCompare(texture_depth_cube_array, sampler_comparison, vec3<f32>, u32, f32) -> f32
 
 textureSampleCompareLevel(texture_depth_2d, sampler_comparison, vec2<f32>, f32) -> f32
 textureSampleCompareLevel(texture_depth_2d, sampler_comparison, vec2<f32>, f32, vec2<i32>) -> f32
 textureSampleCompareLevel(texture_depth_2d_array, sampler_comparison, vec2<f32>, i32, f32) -> f32
+textureSampleCompareLevel(texture_depth_2d_array, sampler_comparison, vec2<f32>, u32, f32) -> f32
 textureSampleCompareLevel(texture_depth_2d_array, sampler_comparison, vec2<f32>, i32, f32, vec2<i32>) -> f32
+textureSampleCompareLevel(texture_depth_2d_array, sampler_comparison, vec2<f32>, u32, f32, vec2<i32>) -> f32
 textureSampleCompareLevel(texture_depth_cube, sampler_comparison, vec3<f32>, f32) -> f32
 textureSampleCompareLevel(texture_depth_cube_array, sampler_comparison, vec3<f32>, i32, f32) -> f32
+textureSampleCompareLevel(texture_depth_cube_array, sampler_comparison, vec3<f32>, u32, f32) -> f32
 
 textureSampleGrad(texture_2d<f32>, sampler, vec2<f32>, vec2<f32>, vec2<f32>) -> vec4<f32>
 textureSampleGrad(texture_2d<f32>, sampler, vec2<f32>, vec2<f32>, vec2<f32>, vec2<i32>) -> vec4<f32>
 textureSampleGrad(texture_2d_array<f32>, sampler, vec2<f32>, i32, vec2<f32>, vec2<f32>) -> vec4<f32>
+textureSampleGrad(texture_2d_array<f32>, sampler, vec2<f32>, u32, vec2<f32>, vec2<f32>) -> vec4<f32>
 textureSampleGrad(texture_2d_array<f32>, sampler, vec2<f32>, i32, vec2<f32>, vec2<f32>, vec2<i32>) -> vec4<f32>
+textureSampleGrad(texture_2d_array<f32>, sampler, vec2<f32>, u32, vec2<f32>, vec2<f32>, vec2<i32>) -> vec4<f32>
 textureSampleGrad(texture_3d<f32>, sampler, vec3<f32>, vec3<f32>, vec3<f32>) -> vec4<f32>
 textureSampleGrad(texture_3d<f32>, sampler, vec3<f32>, vec3<f32>, vec3<f32>, vec3<i32>) -> vec4<f32>
 textureSampleGrad(texture_cube<f32>, sampler, vec3<f32>, vec3<f32>, vec3<f32>) -> vec4<f32>
 textureSampleGrad(texture_cube_array<f32>, sampler, vec3<f32>, i32, vec3<f32>, vec3<f32>) -> vec4<f32>
+textureSampleGrad(texture_cube_array<f32>, sampler, vec3<f32>, u32, vec3<f32>, vec3<f32>) -> vec4<f32>
 
 textureSampleLevel(texture_2d<f32>, sampler, vec2<f32>, f32) -> vec4<f32>
 textureSampleLevel(texture_2d<f32>, sampler, vec2<f32>, f32, vec2<i32>) -> vec4<f32>
 textureSampleLevel(texture_2d_array<f32>, sampler, vec2<f32>, i32, f32) -> vec4<f32>
+textureSampleLevel(texture_2d_array<f32>, sampler, vec2<f32>, u32, f32) -> vec4<f32>
 textureSampleLevel(texture_2d_array<f32>, sampler, vec2<f32>, i32, f32, vec2<i32>) -> vec4<f32>
+textureSampleLevel(texture_2d_array<f32>, sampler, vec2<f32>, u32, f32, vec2<i32>) -> vec4<f32>
 textureSampleLevel(texture_3d<f32>, sampler, vec3<f32>, f32) -> vec4<f32>
 textureSampleLevel(texture_3d<f32>, sampler, vec3<f32>, f32, vec3<i32>) -> vec4<f32>
 textureSampleLevel(texture_cube<f32>, sampler, vec3<f32>, f32) -> vec4<f32>
 textureSampleLevel(texture_cube_array<f32>, sampler, vec3<f32>, i32, f32) -> vec4<f32>
+textureSampleLevel(texture_cube_array<f32>, sampler, vec3<f32>, u32, f32) -> vec4<f32>
 textureSampleLevel(texture_depth_2d, sampler, vec2<f32>, i32) -> f32
 textureSampleLevel(texture_depth_2d, sampler, vec2<f32>, i32, vec2<i32>) -> f32
 textureSampleLevel(texture_depth_2d_array, sampler, vec2<f32>, i32, i32) -> f32
+textureSampleLevel(texture_depth_2d_array, sampler, vec2<f32>, u32, i32) -> f32
 textureSampleLevel(texture_depth_2d_array, sampler, vec2<f32>, i32, i32, vec2<i32>) -> f32
+textureSampleLevel(texture_depth_2d_array, sampler, vec2<f32>, u32, i32, vec2<i32>) -> f32
 textureSampleLevel(texture_depth_cube, sampler, vec3<f32>, i32) -> f32
 textureSampleLevel(texture_depth_cube_array, sampler, vec3<f32>, i32, i32) -> f32
+textureSampleLevel(texture_depth_cube_array, sampler, vec3<f32>, u32, i32) -> f32
 textureSampleLevel(texture_external, sampler, vec2<f32>) -> vec4<f32>
 
 textureStore(texture_storage_1d<F;write>, i32, F::StorageType)
 textureStore(texture_storage_2d<F;write>, vec2<i32>, F::StorageType)
 textureStore(texture_storage_2d_array<F;write>, vec2<i32>, i32, F::StorageType)
+textureStore(texture_storage_2d_array<F;write>, vec2<i32>, u32, F::StorageType)
 textureStore(texture_storage_3d<F;write>, vec3<i32>, F::StorageType)
 
 // TODO atomic


### PR DESCRIPTION
Some built-in functions which take a `array_index` parameter, were missing the unsigned version of it.
See https://github.com/gfx-rs/naga/pull/2298 for support in Naga.