### PR TITLE
Fix built-in function refract return type

### DIFF
--- a/crates/hir_ty/builtins.wgsl
+++ b/crates/hir_ty/builtins.wgsl
@@ -74,7 +74,7 @@ pow(vecN<f32>, vecN<f32>) -> vecN<f32>
 quantizeToF16(f32) -> f32
 quantizeToF16(vecN<f32>) -> vecN<f32>
 reflect(vecN<f32>, vecN<f32>) -> vecN<f32>
-refract(vecN<f32>, vecN<f32>, f32) -> f32
+refract(vecN<f32>, vecN<f32>, f32) -> vecN<f32>
 round(f32) -> f32
 round(vecN<f32>) -> vecN<f32>
 saturate(e: f32) -> f32


### PR DESCRIPTION
According to the specification, `refract`'s return type should be vecN.
 [refract-builtin](https://www.w3.org/TR/WGSL/#refract-builtin)
 