### PR TITLE
Fixed README: for nvim lsp setup, wgsl_analyzer.setup must take table param

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
 3. Configure the nvim lsp
 ```lua
 local lspconfig = require('lspconfig')
-lspconfig.wgsl_analyzer.setup()
+lspconfig.wgsl_analyzer.setup({})
 ```
 
 ## Configuration


### PR DESCRIPTION
Without this 2 character change, the setup function errors out.