### PR TITLE
Add a new --tabs option to the wgslfmt CLI (to enable indenting with tabs instead of spaces)

### DIFF
--- a/crates/wgsl_formatter/src/lib.rs
+++ b/crates/wgsl_formatter/src/lib.rs
@@ -14,12 +14,14 @@ pub fn format_str(input: &str, options: &FormattingOptions) -> String {
 #[derive(Debug)]
 pub struct FormattingOptions {
     pub trailing_commas: Policy,
+    pub indent_symbol: String,
 }
 
 impl Default for FormattingOptions {
     fn default() -> Self {
         Self {
             trailing_commas: Policy::Ignore,
+            indent_symbol: "    ".to_string(),
         }
     }
 }
@@ -93,7 +95,7 @@ fn format_syntax_node(
                 create_whitespace(&format!(
                     "{}{}",
                     "\n".repeat(n_newlines),
-                    "    ".repeat(indentation)
+                    options.indent_symbol.repeat(indentation)
                 )),
             );
         }
@@ -126,6 +128,7 @@ fn format_syntax_node(
                 has_newline,
                 1,
                 options.trailing_commas,
+                &options.indent_symbol,
             );
 
             if has_newline {
@@ -203,7 +206,7 @@ fn format_syntax_node(
                     stmt.right_brace_token()?,
                     create_whitespace(&format!(
                         "\n{}",
-                        "    ".repeat(indentation.saturating_sub(1))
+                        options.indent_symbol.repeat(indentation.saturating_sub(1))
                     )),
                 );
             }
@@ -308,11 +311,12 @@ fn format_params(
         has_newline,
         indentation + 1,
         options.trailing_commas,
+        &options.indent_symbol,
     );
     Some(if has_newline {
         set_whitespace_before(
             param_list.right_paren_token()?,
-            create_whitespace(&format!("\n{}", "    ".repeat(indentation))),
+            create_whitespace(&format!("\n{}", options.indent_symbol.repeat(indentation))),
         );
     } else {
         remove_if_whitespace(param_list.right_paren_token()?.prev_token()?);
@@ -325,6 +329,7 @@ fn format_param_list<T: AstNode>(
     has_newline: bool,
     n_indentations: usize,
     trailing_comma_policy: Policy,
+    indent_symbol: &str,
 ) -> Option<()> {
     let mut first = true;
     for (i, param) in params.enumerate() {
@@ -337,7 +342,7 @@ fn format_param_list<T: AstNode>(
 
         let ws = match (first, previous_had_newline) {
             (true, false) => create_whitespace(""),
-            (_, true) => create_whitespace(&format!("\n{}", "    ".repeat(n_indentations))),
+            (_, true) => create_whitespace(&format!("\n{}", indent_symbol.repeat(n_indentations))),
             (false, false) => create_whitespace(" "),
         };
 

--- a/crates/wgsl_formatter/src/tests.rs
+++ b/crates/wgsl_formatter/src/tests.rs
@@ -6,6 +6,11 @@ use expect_test::{expect, Expect};
 fn check(before: &str, after: Expect) {
     check_with_options(before, after, &FormattingOptions::default())
 }
+fn check_tabs(before: &str, after: Expect) {
+    let mut options = FormattingOptions::default();
+    options.indent_symbol = "\t".to_string();
+    check_with_options(before, after, &options)
+}
 #[track_caller]
 fn check_with_options(before: &str, after: Expect, options: &FormattingOptions) {
     let syntax = syntax::parse(before.trim_start())
@@ -495,4 +500,26 @@ fn main() {
                 );
             }"#]],
     );
+}
+
+#[test]
+fn leave_matrix_alone_tabs() {
+    check_tabs(
+		r#"
+fn main() {
+	let x = mat3x3(
+		cosR,  0.0, sinR,
+		0.0, 1.0, 0.0,
+		-sinR, 0.0, cosR,
+	);
+}"#,
+        expect![[r#"
+			fn main() {
+				let x = mat3x3(
+					cosR, 0.0, sinR,
+					0.0, 1.0, 0.0,
+					-sinR, 0.0, cosR,
+				);
+			}"#]],
+	);
 }

--- a/crates/wgslfmt/src/main.rs
+++ b/crates/wgslfmt/src/main.rs
@@ -10,10 +10,12 @@ Options:
     --check     Run in 'check' mode. Exists with 0 if input is
                 formatted correctly. Exits with 1 and prints a diff if
                 formatting is requried.
+    --tabs      Use tabs for indentation (instead of spaces)
 "#;
 
 struct Args {
     check: bool,
+    tab_indent: bool,
     files: Vec<PathBuf>,
 }
 
@@ -21,6 +23,7 @@ fn parse_args() -> Result<Args, lexopt::Error> {
     let mut parser = lexopt::Parser::from_env();
     let mut args = Args {
         check: false,
+        tab_indent: false,
         files: Vec::new(),
     };
 
@@ -31,6 +34,7 @@ fn parse_args() -> Result<Args, lexopt::Error> {
                 std::process::exit(0);
             }
             Long("check") => args.check = true,
+            Long("tabs") => args.tab_indent = true,
             Value(file) => args.files.push(PathBuf::from(file)),
             _ => return Err(arg.unexpected()),
         }
@@ -54,7 +58,10 @@ fn main() -> Result<(), anyhow::Error> {
             std::fs::read_to_string(&file)?
         };
 
-        let formatting_options = FormattingOptions::default();
+        let mut formatting_options = FormattingOptions::default();
+        if args.tab_indent {
+            formatting_options.indent_symbol = "\t".to_string();
+        }
         let output = wgsl_formatter::format_str(&input, &formatting_options);
 
         if args.check {


### PR DESCRIPTION
It's trivial to add a mode for using two spaces instead of four as well, but I haven't gone that far since it seemed a little excessive.