### PR TITLE
make colon optional in default clause of switch statement

### DIFF
--- a/crates/wgsl_parser/src/grammar/mod.rs
+++ b/crates/wgsl_parser/src/grammar/mod.rs
@@ -721,7 +721,9 @@ fn switch_body(p: &mut Parser) {
         m.complete(p, SyntaxKind::SwitchBodyCase);
     } else if p.at(SyntaxKind::Default) {
         p.expect(SyntaxKind::Default);
-        p.expect(SyntaxKind::Colon);
+        if p.at(SyntaxKind::Colon) {
+            p.bump();
+        }
         compound_statement(p);
         m.complete(p, SyntaxKind::SwitchBodyDefault);
     } else {


### PR DESCRIPTION
```wgsl
switch x {
  default {
    a = 1;
  }
}
```
The `default` selector without a `:` appended can also be compiled according to the specification.