### PR TITLE
Close code block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ cargo install --git https://github.com/wgsl-analyzer/wgsl-analyzer wgsl_analyzer
   (lsp-register-client (make-lsp-client :new-connection (lsp-stdio-connection "wgsl_analyzer")
                                         :activation-fn (lsp-activate-on "wgsl")
                                         :server-id 'wgsl_analyzer)))
+```
 
 ## Configuration
 


### PR DESCRIPTION
I just noticed the Emacs `init.el` code block was missing the closing delimiter, causing the rest of the README to be missing it's formatting when viewed on GitHub.