### PR TITLE
Fix CI run on MacOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
           # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           npm_config_arch: ${{ matrix.npm_config_arch }}
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.rust_target }}
       - shell: pwsh
         run: |
           echo "target=${{ matrix.platform }}-${{ matrix.arch }}" >> $env:GITHUB_ENV


### PR DESCRIPTION
newer MacOS machines run on Aarch64 instead of x64_86 which caused the bug. I also added the `workflow_dispatch` thingy to manually test the run. I think it's worth keeping.