### PR TITLE
Rebase support-input-paths on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "smallvec",
  "syntax",
  "tracing",
+ "vfs",
 ]
 
 [[package]]
@@ -396,6 +397,8 @@ dependencies = [
  "smallvec",
  "smol_str",
  "syntax",
+ "tracing",
+ "vfs",
 ]
 
 [[package]]

--- a/crates/base_db/src/change.rs
+++ b/crates/base_db/src/change.rs
@@ -19,7 +19,10 @@ impl Change {
         Self::default()
     }
 
-    pub fn set_roots(&mut self, roots: Vec<SourceRoot>) {
+    pub fn set_roots(
+        &mut self,
+        roots: Vec<SourceRoot>,
+    ) {
         self.roots = Some(roots);
     }
 

--- a/crates/base_db/src/change.rs
+++ b/crates/base_db/src/change.rs
@@ -1,12 +1,17 @@
 use std::sync::Arc;
 
-use vfs::FileId;
+use salsa::Durability;
+use vfs::{FileId, VfsPath};
 
-use crate::SourceDatabase;
+use crate::{
+    input::{SourceRoot, SourceRootId},
+    SourceDatabase,
+};
 
 #[derive(Default)]
 pub struct Change {
-    pub files_changed: Vec<(FileId, Option<Arc<String>>)>,
+    pub roots: Option<Vec<SourceRoot>>,
+    pub files_changed: Vec<(FileId, Option<Arc<String>>, VfsPath)>,
 }
 
 impl Change {
@@ -14,20 +19,37 @@ impl Change {
         Self::default()
     }
 
+    pub fn set_roots(&mut self, roots: Vec<SourceRoot>) {
+        self.roots = Some(roots);
+    }
+
     pub fn change_file(
         &mut self,
         file_id: FileId,
         new_text: Option<Arc<String>>,
+        new_path: VfsPath,
     ) {
-        self.files_changed.push((file_id, new_text));
+        self.files_changed.push((file_id, new_text, new_path));
     }
 
     pub fn apply(
         self,
         db: &mut dyn SourceDatabase,
     ) {
-        for (file_id, text) in self.files_changed {
+        if let Some(roots) = self.roots {
+            for (root_id, root) in roots.into_iter().enumerate() {
+                let root_id = SourceRootId(root_id as u32);
+                for file_id in root.iter() {
+                    db.set_file_source_root_with_durability(file_id, root_id, Durability::LOW);
+                }
+                db.set_source_root_with_durability(root_id, Arc::new(root), Durability::LOW);
+            }
+        }
+
+        for (file_id, text, path) in self.files_changed {
             db.set_file_text(file_id, text.unwrap_or_default());
+            db.set_file_path(file_id, path.clone());
+            db.set_file_id(path, file_id);
         }
     }
 }

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -1,0 +1,53 @@
+use vfs::{file_set::FileSet, AnchoredPath, FileId, VfsPath};
+
+/// Files are grouped into source roots. A source root is a directory on the
+/// file systems which is watched for changes. Typically it corresponds to a
+/// Rust crate. Source roots *might* be nested: in this case, a file belongs to
+/// the nearest enclosing source root. Paths to files are always relative to a
+/// source root, and the analyzer does not know the root path of the source root at
+/// all. So, a file from one source root can't refer to a file in another source
+/// root by path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SourceRootId(pub u32);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceRoot {
+    /// Sysroot or crates.io library.
+    ///
+    /// Libraries are considered mostly immutable, this assumption is used to
+    /// optimize salsa's query structure
+    pub is_library: bool,
+    file_set: FileSet,
+}
+
+impl SourceRoot {
+    pub fn new_local(file_set: FileSet) -> SourceRoot {
+        SourceRoot {
+            is_library: false,
+            file_set,
+        }
+    }
+
+    pub fn new_library(file_set: FileSet) -> SourceRoot {
+        SourceRoot {
+            is_library: true,
+            file_set,
+        }
+    }
+
+    pub fn path_for_file(&self, file: &FileId) -> Option<&VfsPath> {
+        self.file_set.path_for_file(file)
+    }
+
+    pub fn file_for_path(&self, path: &VfsPath) -> Option<&FileId> {
+        self.file_set.file_for_path(path)
+    }
+
+    pub fn resolve_path(&self, path: AnchoredPath<'_>) -> Option<FileId> {
+        self.file_set.resolve_path(path)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = FileId> + '_ {
+        self.file_set.iter()
+    }
+}

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -35,15 +35,24 @@ impl SourceRoot {
         }
     }
 
-    pub fn path_for_file(&self, file: &FileId) -> Option<&VfsPath> {
+    pub fn path_for_file(
+        &self,
+        file: &FileId,
+    ) -> Option<&VfsPath> {
         self.file_set.path_for_file(file)
     }
 
-    pub fn file_for_path(&self, path: &VfsPath) -> Option<&FileId> {
+    pub fn file_for_path(
+        &self,
+        path: &VfsPath,
+    ) -> Option<&FileId> {
         self.file_set.file_for_path(path)
     }
 
-    pub fn resolve_path(&self, path: AnchoredPath<'_>) -> Option<FileId> {
+    pub fn resolve_path(
+        &self,
+        path: AnchoredPath<'_>,
+    ) -> Option<FileId> {
         self.file_set.resolve_path(path)
     }
 

--- a/crates/base_db/src/lib.rs
+++ b/crates/base_db/src/lib.rs
@@ -1,9 +1,14 @@
+pub mod input;
 mod shader_processor;
 
 pub mod change;
 pub mod line_index;
 
 mod util_types;
+use input::{SourceRoot, SourceRootId};
+pub use util_types::*;
+use vfs::{AnchoredPath, VfsPath};
+
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -11,15 +16,18 @@ use std::{
 
 use line_index::LineIndex;
 use syntax::{Parse, ParseEntryPoint};
-pub use util_types::*;
 pub use vfs::FileId;
 
 pub trait Upcast<T: ?Sized> {
     fn upcast(&self) -> &T;
 }
 
+pub trait FileLoader {
+    fn resolve_path(&self, path: AnchoredPath<'_>) -> Option<FileId>;
+}
+
 #[salsa::query_group(SourceDatabaseStorage)]
-pub trait SourceDatabase {
+pub trait SourceDatabase: FileLoader {
     #[salsa::input]
     fn file_text(
         &self,
@@ -27,10 +35,24 @@ pub trait SourceDatabase {
     ) -> Arc<String>;
 
     #[salsa::input]
+    fn file_path(&self, file_id: FileId) -> VfsPath;
+
+    #[salsa::input]
+    fn file_id(&self, path: VfsPath) -> FileId;
+
+    #[salsa::input]
     fn custom_imports(&self) -> Arc<HashMap<String, String>>;
 
     #[salsa::input]
     fn shader_defs(&self) -> Arc<HashSet<String>>;
+
+    /// Path to a file, relative to the root of its source root.
+    /// Source root of the file.
+    #[salsa::input]
+    fn file_source_root(&self, file_id: FileId) -> SourceRootId;
+    /// Contents of the source root.
+    #[salsa::input]
+    fn source_root(&self, id: SourceRootId) -> Arc<SourceRoot>;
 
     #[salsa::invoke(parse_no_preprocessor_query)]
     fn parse_no_preprocessor(
@@ -146,4 +168,16 @@ fn parse_import_query(
         &processed_source,
         parse_entrypoint,
     ))
+}
+
+/// Silly workaround for cyclic deps between the traits
+pub struct FileLoaderDelegate<T>(pub T);
+
+impl<T: SourceDatabase> FileLoader for FileLoaderDelegate<&'_ T> {
+    fn resolve_path(&self, path: AnchoredPath<'_>) -> Option<FileId> {
+        // FIXME: this *somehow* should be platform agnostic...
+        let source_root = self.0.file_source_root(path.anchor);
+        let source_root = self.0.source_root(source_root);
+        source_root.resolve_path(path)
+    }
 }

--- a/crates/base_db/src/lib.rs
+++ b/crates/base_db/src/lib.rs
@@ -23,7 +23,10 @@ pub trait Upcast<T: ?Sized> {
 }
 
 pub trait FileLoader {
-    fn resolve_path(&self, path: AnchoredPath<'_>) -> Option<FileId>;
+    fn resolve_path(
+        &self,
+        path: AnchoredPath<'_>,
+    ) -> Option<FileId>;
 }
 
 #[salsa::query_group(SourceDatabaseStorage)]
@@ -35,10 +38,16 @@ pub trait SourceDatabase: FileLoader {
     ) -> Arc<String>;
 
     #[salsa::input]
-    fn file_path(&self, file_id: FileId) -> VfsPath;
+    fn file_path(
+        &self,
+        file_id: FileId,
+    ) -> VfsPath;
 
     #[salsa::input]
-    fn file_id(&self, path: VfsPath) -> FileId;
+    fn file_id(
+        &self,
+        path: VfsPath,
+    ) -> FileId;
 
     #[salsa::input]
     fn custom_imports(&self) -> Arc<HashMap<String, String>>;
@@ -49,10 +58,16 @@ pub trait SourceDatabase: FileLoader {
     /// Path to a file, relative to the root of its source root.
     /// Source root of the file.
     #[salsa::input]
-    fn file_source_root(&self, file_id: FileId) -> SourceRootId;
+    fn file_source_root(
+        &self,
+        file_id: FileId,
+    ) -> SourceRootId;
     /// Contents of the source root.
     #[salsa::input]
-    fn source_root(&self, id: SourceRootId) -> Arc<SourceRoot>;
+    fn source_root(
+        &self,
+        id: SourceRootId,
+    ) -> Arc<SourceRoot>;
 
     #[salsa::invoke(parse_no_preprocessor_query)]
     fn parse_no_preprocessor(
@@ -174,7 +189,10 @@ fn parse_import_query(
 pub struct FileLoaderDelegate<T>(pub T);
 
 impl<T: SourceDatabase> FileLoader for FileLoaderDelegate<&'_ T> {
-    fn resolve_path(&self, path: AnchoredPath<'_>) -> Option<FileId> {
+    fn resolve_path(
+        &self,
+        path: AnchoredPath<'_>,
+    ) -> Option<FileId> {
         // FIXME: this *somehow* should be platform agnostic...
         let source_root = self.0.file_source_root(path.anchor);
         let source_root = self.0.source_root(source_root);

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -21,3 +21,4 @@ syntax = { path = "../syntax", version = "0.0.0" }
 tracing = "0.1.41"
 la-arena = { git = "https://github.com/rust-lang/rust-analyzer", rev = "8a23314", version = "0.3.1" }
 smallvec = "1.14.0"
+vfs = { git = "https://github.com/rust-lang/rust-analyzer", rev = "8a23314", version = "0.0.0" }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -15,7 +15,7 @@ use hir_def::{
         Location, Lookup, OverrideId, StructId, TypeAliasId,
     },
     expr::{ExprId, StatementId},
-    hir_file_id::ImportFile,
+    hir_file_id::{relative_file, ImportFile},
     module_data::{self, ImportValue, ModuleInfo, ModuleItem, Name},
     resolver::{ResolveValue, Resolver},
     HasSource as _, HirFileId, InFile,
@@ -228,14 +228,19 @@ fn module_item_to_def(
             let import_id = db.intern_import(loc);
 
             let import_file = HirFileId::from(ImportFile { import_id });
-
-            let module_info = db.module_info(import_file);
-            return module_info
-                .items()
-                .iter()
-                .flat_map(|item| module_item_to_def(db, import_file, item))
-                .collect();
-        },
+            match import_file.original_file(db.upcast()) {
+                Some(original_file) => {
+                    let original_file = original_file.into();
+                    let module_info = db.module_info(original_file);
+                    return module_info
+                        .items()
+                        .iter()
+                        .flat_map(|item| module_item_to_def(db, original_file, item))
+                        .collect();
+                }
+                _ => return smallvec::smallvec![],
+            }
+        }
         ModuleItem::TypeAlias(type_alias) => {
             let loc = Location::new(file_id, type_alias);
             let id = db.intern_type_alias(loc);
@@ -641,6 +646,13 @@ pub struct Import {
 }
 
 impl Import {
+    pub fn is_path(&self, db: &dyn HirDatabase) -> bool {
+        let import_loc = self.id.lookup(db.upcast());
+        let module_info = db.module_info(import_loc.file_id);
+        let import = module_info.get(import_loc.value);
+        matches!(import.value, ImportValue::Path(_))
+    }
+
     pub fn file_text(
         &self,
         db: &dyn HirDatabase,
@@ -651,7 +663,10 @@ impl Import {
         let import = module_info.get(import_loc.value);
 
         match &import.value {
-            ImportValue::Path(_) => None, // TODO: path imports
+            ImportValue::Path(path) => {
+                let file_id = relative_file(db.upcast(), import_loc.file_id, path)?;
+                Some(db.file_text(file_id).to_string())
+            }
             ImportValue::Custom(key) => {
                 let imports = db.custom_imports();
                 let source = imports.get(key)?;
@@ -670,8 +685,13 @@ impl Import {
         let module_info = db.module_info(import_loc.file_id);
         let import = module_info.get(import_loc.value);
 
+        tracing::info!("resolving import {:?}", import);
+
         match &import.value {
-            ImportValue::Path(_) => Err(()),
+            ImportValue::Path(path) => {
+                relative_file(db.upcast(), import_loc.file_id, path).ok_or(())?;
+                Ok(())
+            }
             ImportValue::Custom(key) => {
                 let imports = db.custom_imports();
                 if imports.contains_key(key) {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -237,10 +237,10 @@ fn module_item_to_def(
                         .iter()
                         .flat_map(|item| module_item_to_def(db, original_file, item))
                         .collect();
-                }
+                },
                 _ => return smallvec::smallvec![],
             }
-        }
+        },
         ModuleItem::TypeAlias(type_alias) => {
             let loc = Location::new(file_id, type_alias);
             let id = db.intern_type_alias(loc);
@@ -646,7 +646,10 @@ pub struct Import {
 }
 
 impl Import {
-    pub fn is_path(&self, db: &dyn HirDatabase) -> bool {
+    pub fn is_path(
+        &self,
+        db: &dyn HirDatabase,
+    ) -> bool {
         let import_loc = self.id.lookup(db.upcast());
         let module_info = db.module_info(import_loc.file_id);
         let import = module_info.get(import_loc.value);
@@ -666,7 +669,7 @@ impl Import {
             ImportValue::Path(path) => {
                 let file_id = relative_file(db.upcast(), import_loc.file_id, path)?;
                 Some(db.file_text(file_id).to_string())
-            }
+            },
             ImportValue::Custom(key) => {
                 let imports = db.custom_imports();
                 let source = imports.get(key)?;
@@ -691,7 +694,7 @@ impl Import {
             ImportValue::Path(path) => {
                 relative_file(db.upcast(), import_loc.file_id, path).ok_or(())?;
                 Ok(())
-            }
+            },
             ImportValue::Custom(key) => {
                 let imports = db.custom_imports();
                 if imports.contains_key(key) {

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 
 [dependencies]
 la-arena = { git = "https://github.com/rust-lang/rust-analyzer", rev = "8a23314", version = "0.3.1" }
+vfs = { git = "https://github.com/rust-lang/rust-analyzer", rev = "8a23314", version = "0.0.0" }
 salsa = "0.17.0-pre.2"
 syntax = { path = "../syntax", version = "0.0.0" }
 base-db = { path = "../base_db", version = "0.0.0" }
@@ -22,3 +23,4 @@ rustc-hash = "2.1.0"
 either = "1.13.0"
 smallvec = "1.14.0"
 rowan = "0.16.1"
+tracing = "0.1"

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -5,6 +5,7 @@ use super::{Binding, BindingId, Body, BodySourceMap, SyntheticSyntax};
 use crate::{
     db::DefDatabase,
     expr::{parse_literal, Callee, Expr, ExprId, Statement, StatementId},
+    hir_file_id::relative_file,
     module_data::Name,
     type_ref::{matrix_dimensions, vector_dimensions, TypeRef},
     HirFileId, InFile,
@@ -111,7 +112,11 @@ impl Collector<'_> {
                                 let import = module_info.get(import_loc.value);
 
                                 match &import.value {
-                                    crate::module_data::ImportValue::Path(_) => None, // TODO: path imports
+                                    crate::module_data::ImportValue::Path(path) => {
+                                        let file_id =
+                                            relative_file(self.db, import_loc.file_id, path)?;
+                                        Some(self.db.parse(file_id))
+                                    }
                                     crate::module_data::ImportValue::Custom(key) => self
                                         .db
                                         .parse_import(

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -116,7 +116,7 @@ impl Collector<'_> {
                                         let file_id =
                                             relative_file(self.db, import_loc.file_id, path)?;
                                         Some(self.db.parse(file_id))
-                                    }
+                                    },
                                     crate::module_data::ImportValue::Custom(key) => self
                                         .db
                                         .parse_import(

--- a/crates/hir_def/src/db.rs
+++ b/crates/hir_def/src/db.rs
@@ -33,9 +33,15 @@ pub trait DefDatabase: InternDatabase + Upcast<dyn SourceDatabase> {
         file_id: HirFileId,
     ) -> Result<Parse, ()>;
 
-    fn get_path(&self, file_id: HirFileId) -> Result<VfsPath, ()>;
+    fn get_path(
+        &self,
+        file_id: HirFileId,
+    ) -> Result<VfsPath, ()>;
 
-    fn get_file_id(&self, path: VfsPath) -> Result<FileId, ()>;
+    fn get_file_id(
+        &self,
+        path: VfsPath,
+    ) -> Result<FileId, ()>;
 
     fn ast_id_map(
         &self,
@@ -120,14 +126,20 @@ pub trait DefDatabase: InternDatabase + Upcast<dyn SourceDatabase> {
     ) -> Arc<AttrsWithOwner>;
 }
 
-fn get_path(db: &dyn DefDatabase, file_id: HirFileId) -> Result<VfsPath, ()> {
+fn get_path(
+    db: &dyn DefDatabase,
+    file_id: HirFileId,
+) -> Result<VfsPath, ()> {
     match file_id.0 {
         HirFileIdRepr::FileId(file_id) => Ok(db.file_path(file_id)),
         _ => Err(()),
     }
 }
 
-fn get_file_id(db: &dyn DefDatabase, path: VfsPath) -> Result<FileId, ()> {
+fn get_file_id(
+    db: &dyn DefDatabase,
+    path: VfsPath,
+) -> Result<FileId, ()> {
     Ok(db.file_id(path))
 }
 
@@ -146,7 +158,7 @@ fn parse_or_resolve(
                 crate::module_data::ImportValue::Path(path) => {
                     let file_id = relative_file(db, import_loc.file_id, path).ok_or(())?;
                     Ok(db.parse(file_id))
-                }
+                },
                 crate::module_data::ImportValue::Custom(key) => {
                     db.parse_import(key.clone(), syntax::ParseEntryPoint::File)
                 },

--- a/crates/hir_def/src/db.rs
+++ b/crates/hir_def/src/db.rs
@@ -1,11 +1,12 @@
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
-use base_db::{SourceDatabase, TextRange, TextSize, Upcast};
+use base_db::{FileId, SourceDatabase, TextRange, TextSize, Upcast};
 use salsa::InternKey;
 use syntax::{
     ast::{self, Item},
     AstNode, Parse,
 };
+use vfs::VfsPath;
 
 use crate::{
     ast_id::AstIdMap,
@@ -15,7 +16,7 @@ use crate::{
         FunctionData, GlobalConstantData, GlobalVariableData, OverrideData, StructData,
         TypeAliasData,
     },
-    hir_file_id::{HirFileIdRepr, ImportFile},
+    hir_file_id::{relative_file, HirFileIdRepr, ImportFile},
     module_data::{
         Function, GlobalConstant, GlobalVariable, Import, ModuleInfo, ModuleItemId, Override,
         Struct, TypeAlias,
@@ -31,6 +32,10 @@ pub trait DefDatabase: InternDatabase + Upcast<dyn SourceDatabase> {
         &self,
         file_id: HirFileId,
     ) -> Result<Parse, ()>;
+
+    fn get_path(&self, file_id: HirFileId) -> Result<VfsPath, ()>;
+
+    fn get_file_id(&self, path: VfsPath) -> Result<FileId, ()>;
 
     fn ast_id_map(
         &self,
@@ -115,6 +120,17 @@ pub trait DefDatabase: InternDatabase + Upcast<dyn SourceDatabase> {
     ) -> Arc<AttrsWithOwner>;
 }
 
+fn get_path(db: &dyn DefDatabase, file_id: HirFileId) -> Result<VfsPath, ()> {
+    match file_id.0 {
+        HirFileIdRepr::FileId(file_id) => Ok(db.file_path(file_id)),
+        _ => Err(()),
+    }
+}
+
+fn get_file_id(db: &dyn DefDatabase, path: VfsPath) -> Result<FileId, ()> {
+    Ok(db.file_id(path))
+}
+
 fn parse_or_resolve(
     db: &dyn DefDatabase,
     file_id: HirFileId,
@@ -127,7 +143,10 @@ fn parse_or_resolve(
             let import: &Import = module_info.get(import_loc.value);
 
             match &import.value {
-                crate::module_data::ImportValue::Path(_) => Err(()), // TODO: path imports
+                crate::module_data::ImportValue::Path(path) => {
+                    let file_id = relative_file(db, import_loc.file_id, path).ok_or(())?;
+                    Ok(db.parse(file_id))
+                }
                 crate::module_data::ImportValue::Custom(key) => {
                     db.parse_import(key.clone(), syntax::ParseEntryPoint::File)
                 },

--- a/crates/hir_def/src/hir_file_id.rs
+++ b/crates/hir_def/src/hir_file_id.rs
@@ -34,22 +34,20 @@ impl HirFileId {
         self,
         db: &dyn DefDatabase,
     ) -> Option<FileId> {
-        loop {
-            match self.0 {
-                HirFileIdRepr::FileId(id) => break Some(id),
-                HirFileIdRepr::MacroFile(ImportFile { import_id }) => {
-                    let import_loc = db.lookup_intern_import(import_id);
-                    let module_info = db.module_info(import_loc.file_id);
-                    let import = module_info.get(import_loc.value);
+        match self.0 {
+            HirFileIdRepr::FileId(id) => Some(id),
+            HirFileIdRepr::MacroFile(ImportFile { import_id }) => {
+                let import_loc = db.lookup_intern_import(import_id);
+                let module_info = db.module_info(import_loc.file_id);
+                let import = module_info.get(import_loc.value);
 
-                    match &import.value {
-                        ImportValue::Path(path) => {
-                            return relative_file(db, import_loc.file_id, path)
-                        },
-                        _ => unimplemented!(),
-                    }
-                },
-            }
+                match &import.value {
+                    ImportValue::Path(path) => {
+                        relative_file(db, import_loc.file_id, path)
+                    },
+                    _ => unimplemented!(),
+                }
+            },
         }
     }
 }

--- a/crates/hir_def/src/hir_file_id.rs
+++ b/crates/hir_def/src/hir_file_id.rs
@@ -42,9 +42,7 @@ impl HirFileId {
                 let import = module_info.get(import_loc.value);
 
                 match &import.value {
-                    ImportValue::Path(path) => {
-                        relative_file(db, import_loc.file_id, path)
-                    },
+                    ImportValue::Path(path) => relative_file(db, import_loc.file_id, path),
                     _ => unimplemented!(),
                 }
             },

--- a/crates/hir_def/src/hir_file_id.rs
+++ b/crates/hir_def/src/hir_file_id.rs
@@ -1,6 +1,10 @@
 use base_db::FileId;
+use vfs::AnchoredPath;
 
-use crate::db::ImportId;
+use crate::{
+    db::{DefDatabase, ImportId},
+    module_data::ImportValue,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HirFileId(pub(crate) HirFileIdRepr);
@@ -23,7 +27,45 @@ impl From<ImportFile> for HirFileId {
     }
 }
 
+impl HirFileId {
+    /// For import files, returns the file id of the file that needs to be imported
+    /// or `None` if that file has not been opened yet
+    pub fn original_file(self, db: &dyn DefDatabase) -> Option<FileId> {
+        loop {
+            match self.0 {
+                HirFileIdRepr::FileId(id) => break Some(id),
+                HirFileIdRepr::MacroFile(ImportFile { import_id }) => {
+                    let import_loc = db.lookup_intern_import(import_id);
+                    let module_info = db.module_info(import_loc.file_id);
+                    let import = module_info.get(import_loc.value);
+
+                    match &import.value {
+                        ImportValue::Path(path) => {
+                            return relative_file(db, import_loc.file_id, path)
+                        }
+                        _ => unimplemented!(),
+                    }
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ImportFile {
     pub import_id: ImportId,
+}
+
+pub fn relative_file(db: &dyn DefDatabase, call_id: HirFileId, path_str: &str) -> Option<FileId> {
+    let call_site = call_id.original_file(db)?;
+    let path = AnchoredPath {
+        anchor: call_site,
+        path: path_str,
+    };
+    match db.resolve_path(path) {
+        // Prevent including itself
+        Some(res) if res != call_site => Some(res),
+        // Possibly file not imported yet
+        _ => None,
+    }
 }

--- a/crates/hir_def/src/hir_file_id.rs
+++ b/crates/hir_def/src/hir_file_id.rs
@@ -30,7 +30,10 @@ impl From<ImportFile> for HirFileId {
 impl HirFileId {
     /// For import files, returns the file id of the file that needs to be imported
     /// or `None` if that file has not been opened yet
-    pub fn original_file(self, db: &dyn DefDatabase) -> Option<FileId> {
+    pub fn original_file(
+        self,
+        db: &dyn DefDatabase,
+    ) -> Option<FileId> {
         loop {
             match self.0 {
                 HirFileIdRepr::FileId(id) => break Some(id),
@@ -42,10 +45,10 @@ impl HirFileId {
                     match &import.value {
                         ImportValue::Path(path) => {
                             return relative_file(db, import_loc.file_id, path)
-                        }
+                        },
                         _ => unimplemented!(),
                     }
-                }
+                },
             }
         }
     }
@@ -56,7 +59,11 @@ pub struct ImportFile {
     pub import_id: ImportId,
 }
 
-pub fn relative_file(db: &dyn DefDatabase, call_id: HirFileId, path_str: &str) -> Option<FileId> {
+pub fn relative_file(
+    db: &dyn DefDatabase,
+    call_id: HirFileId,
+    path_str: &str,
+) -> Option<FileId> {
     let call_site = call_id.original_file(db)?;
     let path = AnchoredPath {
         anchor: call_site,

--- a/crates/hir_def/src/module_data/lower.rs
+++ b/crates/hir_def/src/module_data/lower.rs
@@ -85,7 +85,7 @@ impl<'a> Ctx<'a> {
                     .filter(|&c| c != '"')
                     .collect();
                 ImportValue::Path(import_path)
-            }
+            },
             ast::ImportKind::ImportCustom(custom) => ImportValue::Custom(custom.key()),
         };
 
@@ -262,7 +262,7 @@ impl<'a> Ctx<'a> {
                         tracing::info!("attempted import {:?}", path);
                         let file_id = relative_file(self.db, self.file_id, path)?;
                         Ok(self.db.parse(file_id))
-                    }
+                    },
                     crate::module_data::ImportValue::Custom(key) => self
                         .db
                         .parse_import(key.clone(), syntax::ParseEntryPoint::FnParamList),

--- a/crates/hir_def/src/module_data/lower.rs
+++ b/crates/hir_def/src/module_data/lower.rs
@@ -1,6 +1,10 @@
+use crate::hir_file_id::relative_file;
+use crate::module_data::{Function, ModuleData, ModuleItem, ModuleItemId, Param};
+use crate::HirFileId;
+use crate::{ast_id::AstIdMap, db::DefDatabase, type_ref::TypeRef};
+use la_arena::{Idx, IdxRange};
 use std::sync::Arc;
 
-use la_arena::{Idx, IdxRange};
 use syntax::{
     ast::{self, Item, SourceFile},
     AstNode, HasName,
@@ -9,16 +13,10 @@ use syntax::{
 use super::{
     Field, GlobalConstant, GlobalVariable, Import, ImportValue, Name, Override, Struct, TypeAlias,
 };
-use crate::{
-    ast_id::AstIdMap,
-    db::DefDatabase,
-    module_data::{Function, ModuleData, ModuleItem, ModuleItemId, Param},
-    type_ref::TypeRef,
-    HirFileId,
-};
 
 pub(crate) struct Ctx<'a> {
     db: &'a dyn DefDatabase,
+    file_id: HirFileId,
     source_ast_id_map: Arc<AstIdMap>,
     pub module_data: ModuleData,
     pub items: Vec<ModuleItem>,
@@ -31,6 +29,7 @@ impl<'a> Ctx<'a> {
     ) -> Self {
         Self {
             db,
+            file_id,
             source_ast_id_map: db.ast_id_map(file_id),
             module_data: ModuleData::default(),
             items: vec![],
@@ -79,8 +78,14 @@ impl<'a> Ctx<'a> {
 
         let value = match import.import()? {
             ast::ImportKind::ImportPath(path) => {
-                ImportValue::Path(path.string_literal()?.text().to_string())
-            },
+                let import_path = path
+                    .string_literal()?
+                    .text()
+                    .chars()
+                    .filter(|&c| c != '"')
+                    .collect();
+                ImportValue::Path(import_path)
+            }
             ast::ImportKind::ImportCustom(custom) => ImportValue::Custom(custom.key()),
         };
 
@@ -253,7 +258,11 @@ impl<'a> Ctx<'a> {
                 let import = self.lower_import(&import)?;
                 let import = &self.module_data.imports[import.index];
                 let parse = match &import.value {
-                    crate::module_data::ImportValue::Path(_) => Err(()), // TODO: path imports
+                    crate::module_data::ImportValue::Path(path) => {
+                        tracing::info!("attempted import {:?}", path);
+                        let file_id = relative_file(self.db, self.file_id, path)?;
+                        Ok(self.db.parse(file_id))
+                    }
                     crate::module_data::ImportValue::Custom(key) => self
                         .db
                         .parse_import(key.clone(), syntax::ParseEntryPoint::FnParamList),

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use tracing::info;
+
 use crate::{
     body::{
         scope::{ExprScopes, ScopeId},
@@ -104,8 +106,11 @@ impl Resolver {
                 let import_id = db.intern_import(loc);
                 let import_file = HirFileId::from(ImportFile { import_id });
                 let module_info = db.module_info(import_file);
-
-                self = self.push_module_scope(db, import_file, module_info);
+                if let Some(file_id) = import_file.original_file(db) {
+                    self = self.push_module_scope(db, file_id.into(), module_info);
+                } else {
+                    info!("Failed to resolve import file for {file_id:?}");
+                }
             }
         }
 

--- a/crates/ide/src/db.rs
+++ b/crates/ide/src/db.rs
@@ -77,7 +77,10 @@ impl Upcast<dyn SourceDatabase> for RootDatabase {
 }
 
 impl FileLoader for RootDatabase {
-    fn resolve_path(&self, path: AnchoredPath<'_>) -> Option<FileId> {
+    fn resolve_path(
+        &self,
+        path: AnchoredPath<'_>,
+    ) -> Option<FileId> {
         FileLoaderDelegate(self).resolve_path(path)
     }
 }

--- a/crates/ide/src/db.rs
+++ b/crates/ide/src/db.rs
@@ -1,7 +1,8 @@
 use std::{mem::ManuallyDrop, sync::Arc};
 
-use base_db::{change::Change, SourceDatabase, Upcast};
+use base_db::{change::Change, FileId, FileLoader, FileLoaderDelegate, SourceDatabase, Upcast};
 use hir_def::db::DefDatabase;
+use vfs::AnchoredPath;
 
 #[salsa::database(
     base_db::SourceDatabaseStorage,
@@ -72,5 +73,11 @@ impl Upcast<dyn DefDatabase> for RootDatabase {
 impl Upcast<dyn SourceDatabase> for RootDatabase {
     fn upcast(&self) -> &(dyn SourceDatabase + 'static) {
         self
+    }
+}
+
+impl FileLoader for RootDatabase {
+    fn resolve_path(&self, path: AnchoredPath<'_>) -> Option<FileId> {
+        FileLoaderDelegate(self).resolve_path(path)
     }
 }

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -27,10 +27,12 @@ pub fn hover(
     if let Some(import) = import {
         let import = sema.resolve_import(InFile::new(file_range.file_id.into(), import))?;
 
-        return Some(RangeInfo {
-            range: file_range.range,
-            info: HoverResult::SourceCode(import.file_text(db)?),
-        });
+        if !import.is_path(db) {
+            return Some(RangeInfo {
+                range: file_range.range,
+                info: HoverResult::SourceCode(import.file_text(db)?),
+            });
+        }
     }
 
     None

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -31,6 +31,9 @@ pub type Cancellable<T> = Result<T, Cancelled>;
 
 pub use db::RootDatabase;
 
+/// `base_db` is normally also needed in places where `ide_db` is used, so this re-export is for convenience.
+pub use base_db;
+
 #[derive(Debug)]
 pub struct AnalysisHost {
     db: RootDatabase,

--- a/crates/ide/src/tests.rs
+++ b/crates/ide/src/tests.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use base_db::{change::Change, FileId};
 use expect_test::{expect, Expect};
 use hir_def::db::DefDatabase;
+use vfs::VfsPath;
 
 use crate::RootDatabase;
 
@@ -10,7 +11,11 @@ fn single_file_db(source: &str) -> (RootDatabase, FileId) {
     let mut db = RootDatabase::new();
     let mut change = Change::new();
     let file_id = FileId(0);
-    change.change_file(file_id, Some(Arc::new(source.to_string())));
+    change.change_file(
+        file_id,
+        Some(Arc::new(source.to_string())),
+        VfsPath::new_virtual_path("/".into()),
+    );
     db.apply_change(change);
 
     (db, file_id)

--- a/crates/wgsl_analyzer/src/bin/main.rs
+++ b/crates/wgsl_analyzer/src/bin/main.rs
@@ -1,8 +1,9 @@
-use std::{env::args, io::stderr};
+use std::{env::{self, args}, io::stderr};
 
 use lsp_server::Connection;
 use lsp_types::InitializeParams;
-use tracing::info;
+use paths::AbsPathBuf;
+use tracing::{info, warn};
 use tracing_subscriber::fmt::Subscriber;
 use wgsl_analyzer::{
     config::{Config, TraceConfig},
@@ -12,6 +13,12 @@ use wgsl_analyzer::{
 };
 
 const VERSION: &str = "0.9.4";
+
+fn get_cwd_as_abs_path() -> Result<AbsPathBuf, std::io::Error> {
+    info!("Getting current working directory as absolute path");
+    let cwd = env::current_dir()?;
+    Ok(AbsPathBuf::assert(cwd))
+}
 
 fn main() -> Result<()> {
     if args().any(|arg| arg == "--version") {
@@ -26,6 +33,28 @@ fn main() -> Result<()> {
     let (initialize_id, initialize_params) = connection.initialize_start()?;
     let initialize_params: InitializeParams = from_json("InitializeParams", &initialize_params)?;
 
+    // Root path of current open folder
+    let root_path = match &initialize_params.workspace_folders {
+        Some(workspace_folders) => {
+            if workspace_folders.len() > 1 {
+                warn!("Multiple workspace folders detected. Using the first one.");
+            }
+
+            if let Some(first_folder) = workspace_folders.get(0) {
+                match first_folder.uri.to_file_path() {
+                    Ok(path) => match AbsPathBuf::try_from(path) {
+                        Ok(abs_path) => abs_path,
+                        Err(_) => get_cwd_as_abs_path()?,
+                    },
+                    Err(_) => get_cwd_as_abs_path()?,
+                }
+            } else {
+                get_cwd_as_abs_path()?
+            }
+        }
+        None => get_cwd_as_abs_path()?,
+    };
+
     let initialize_result = lsp_types::InitializeResult {
         capabilities: wgsl_analyzer::server_capabilities(),
         server_info: Some(lsp_types::ServerInfo {
@@ -36,12 +65,12 @@ fn main() -> Result<()> {
     let initialize_result = serde_json::to_value(initialize_result)?;
     connection.initialize_finish(initialize_id, initialize_result)?;
 
-    let mut config = Config::default();
+    let mut config = Config::new(root_path);
     if let Some(options) = initialize_params.initialization_options {
-        config.update(&options);
+        config.data.update(&options);
     }
 
-    setup_logging(&config.trace);
+    setup_logging(&config.data.trace);
     info!("Initialized");
     main_loop(config, connection)
 }

--- a/crates/wgsl_analyzer/src/bin/main.rs
+++ b/crates/wgsl_analyzer/src/bin/main.rs
@@ -1,4 +1,7 @@
-use std::{env::{self, args}, io::stderr};
+use std::{
+    env::{self, args},
+    io::stderr,
+};
 
 use lsp_server::Connection;
 use lsp_types::InitializeParams;
@@ -51,7 +54,7 @@ fn main() -> Result<()> {
             } else {
                 get_cwd_as_abs_path()?
             }
-        }
+        },
         None => get_cwd_as_abs_path()?,
     };
 

--- a/crates/wgsl_analyzer/src/bin/main.rs
+++ b/crates/wgsl_analyzer/src/bin/main.rs
@@ -43,13 +43,13 @@ fn main() -> Result<()> {
                 warn!("Multiple workspace folders detected. Using the first one.");
             }
 
-            if let Some(first_folder) = workspace_folders.get(0) {
+            if let Some(first_folder) = workspace_folders.first() {
                 match first_folder.uri.to_file_path() {
                     Ok(path) => match AbsPathBuf::try_from(path) {
                         Ok(abs_path) => abs_path,
                         Err(_) => get_cwd_as_abs_path()?,
                     },
-                    Err(_) => get_cwd_as_abs_path()?,
+                    Err(()) => get_cwd_as_abs_path()?,
                 }
             } else {
                 get_cwd_as_abs_path()?

--- a/crates/wgsl_analyzer/src/config.rs
+++ b/crates/wgsl_analyzer/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use hir::diagnostics;
 use hir_ty::ty::pretty::TypeVerbosity;
+use paths::AbsPathBuf;
 use ide::{inlay_hints, inlay_hints::StructLayoutHints};
 use serde::Deserialize;
 
@@ -33,14 +34,29 @@ pub enum InlayHintsTypeVerbosity {
     Inner, // f32
 }
 
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub root_path: AbsPathBuf,
+    pub data: ConfigData,
+}
+
 #[derive(Default, Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Config {
+pub struct ConfigData {
     pub custom_imports: HashMap<String, String>,
     pub shader_defs: HashSet<String>,
     pub trace: TraceConfig,
     pub inlay_hints: InlayHintsConfig,
     pub diagnostics: DiagnosticsConfig,
+}
+
+impl Config {
+    pub fn new(root_path: AbsPathBuf) -> Self {
+        Self {
+            root_path,
+            data: ConfigData::default(),
+        }
+    }
 }
 
 #[derive(Default, Clone, Debug, Deserialize)]
@@ -52,12 +68,11 @@ pub struct DiagnosticsConfig {
     pub naga_version: NagaVersion,
 }
 
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize)]
 pub enum NagaVersion {
     #[serde(rename = "0.14")]
     Naga14,
     #[serde(rename = "0.19")]
-    #[default]
     Naga19,
     #[serde(rename = "0.22")]
     Naga22,
@@ -65,11 +80,14 @@ pub enum NagaVersion {
     NagaMain,
 }
 
-impl Config {
-    fn try_update(
-        &mut self,
-        value: serde_json::Value,
-    ) -> Result<(), serde_json::Error> {
+impl Default for NagaVersion {
+    fn default() -> Self {
+        NagaVersion::Naga14
+    }
+}
+
+impl ConfigData {
+    fn try_update(&mut self, value: serde_json::Value) -> Result<(), serde_json::Error> {
         *self = serde_json::from_value(value)?;
         Ok(())
     }

--- a/crates/wgsl_analyzer/src/config.rs
+++ b/crates/wgsl_analyzer/src/config.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use hir::diagnostics;
 use hir_ty::ty::pretty::TypeVerbosity;
-use paths::AbsPathBuf;
 use ide::{inlay_hints, inlay_hints::StructLayoutHints};
+use paths::AbsPathBuf;
 use serde::Deserialize;
 
 use crate::line_index::OffsetEncoding;
@@ -87,7 +87,10 @@ impl Default for NagaVersion {
 }
 
 impl ConfigData {
-    fn try_update(&mut self, value: serde_json::Value) -> Result<(), serde_json::Error> {
+    fn try_update(
+        &mut self,
+        value: serde_json::Value,
+    ) -> Result<(), serde_json::Error> {
         *self = serde_json::from_value(value)?;
         Ok(())
     }

--- a/crates/wgsl_analyzer/src/config.rs
+++ b/crates/wgsl_analyzer/src/config.rs
@@ -51,6 +51,8 @@ pub struct ConfigData {
 }
 
 impl Config {
+    #[inline]
+    #[must_use]
     pub fn new(root_path: AbsPathBuf) -> Self {
         Self {
             root_path,
@@ -81,8 +83,9 @@ pub enum NagaVersion {
 }
 
 impl Default for NagaVersion {
+    #[inline]
     fn default() -> Self {
-        NagaVersion::Naga14
+        Self::Naga14
     }
 }
 

--- a/crates/wgsl_analyzer/src/diagnostics.rs
+++ b/crates/wgsl_analyzer/src/diagnostics.rs
@@ -10,6 +10,8 @@ use vfs::FileId;
 // PERF: FxHashMap/Set
 // pub(crate) type CheckFixes = Arc<HashMap<FileId, Vec<Fix>>>;
 
+#[derive(Debug, Default, Clone)]
+
 // #[derive(Debug, Default, Clone)]
 // pub struct DiagnosticsMapConfig {
 //     pub remap_prefix: HashMap<String, String>,
@@ -17,7 +19,6 @@ use vfs::FileId;
 //     pub warnings_as_hint: Vec<String>,
 // }
 
-#[derive(Debug, Default, Clone)]
 pub struct DiagnosticCollection {
     // FIXME: should be FxHashMap<FileId, Vec<ra_id::Diagnostic>>
     pub(crate) native: HashMap<FileId, Vec<lsp_types::Diagnostic>>,

--- a/crates/wgsl_analyzer/src/global_state.rs
+++ b/crates/wgsl_analyzer/src/global_state.rs
@@ -11,7 +11,14 @@ use rustc_hash::FxHashMap;
 use vfs::{FileId, Vfs};
 
 use crate::{
-    config::Config, diagnostics::DiagnosticCollection, from_proto, line_index::{LineEndings, LineIndex}, main_loop::Task, reload::SourceRootConfig, task_pool::TaskPool, to_proto, Result
+    config::Config,
+    diagnostics::DiagnosticCollection,
+    from_proto,
+    line_index::{LineEndings, LineIndex},
+    main_loop::Task,
+    reload::SourceRootConfig,
+    task_pool::TaskPool,
+    to_proto, Result,
 };
 
 type ReqHandler = fn(&mut GlobalState, lsp_server::Response);
@@ -30,12 +37,10 @@ pub struct GlobalState {
 
     pub vfs: Arc<RwLock<(Vfs, FxHashMap<FileId, LineEndings>)>>,
     // pub vfs_config_version: u32,
-
     pub analysis_host: AnalysisHost,
     pub diagnostics: DiagnosticCollection,
     pub config: Arc<Config>,
     pub source_root_config: SourceRootConfig,
-
     // `workspaces` field stores the data we actually use, while the `OpQueue`
     // stores the result of the last fetch.
     // If the fetch (partially) fails, we do not update the current value.

--- a/crates/wgsl_analyzer/src/global_state.rs
+++ b/crates/wgsl_analyzer/src/global_state.rs
@@ -11,13 +11,7 @@ use rustc_hash::FxHashMap;
 use vfs::{FileId, Vfs};
 
 use crate::{
-    config::Config,
-    diagnostics::DiagnosticCollection,
-    from_proto,
-    line_index::{LineEndings, LineIndex},
-    main_loop::Task,
-    task_pool::TaskPool,
-    to_proto, Result,
+    config::Config, diagnostics::DiagnosticCollection, from_proto, line_index::{LineEndings, LineIndex}, main_loop::Task, reload::SourceRootConfig, task_pool::TaskPool, to_proto, Result
 };
 
 type ReqHandler = fn(&mut GlobalState, lsp_server::Response);
@@ -33,10 +27,19 @@ pub struct GlobalState {
     pub sender: Sender<lsp_server::Message>,
     pub req_queue: ReqQueue,
     pub task_pool: Handle<TaskPool<Task>, Receiver<Task>>,
+
     pub vfs: Arc<RwLock<(Vfs, FxHashMap<FileId, LineEndings>)>>,
+    // pub vfs_config_version: u32,
+
     pub analysis_host: AnalysisHost,
     pub diagnostics: DiagnosticCollection,
     pub config: Arc<Config>,
+    pub source_root_config: SourceRootConfig,
+
+    // `workspaces` field stores the data we actually use, while the `OpQueue`
+    // stores the result of the last fetch.
+    // If the fetch (partially) fails, we do not update the current value.
+    // pub workspaces: Arc<Vec<ProjectWorkspace>>,
 }
 
 pub struct GlobalStateSnapshot {
@@ -61,9 +64,12 @@ impl GlobalState {
             req_queue: ReqQueue::default(),
             task_pool,
             vfs: Arc::new(RwLock::new((Vfs::default(), FxHashMap::default()))),
+            // vfs_config_version: 0,
             analysis_host: AnalysisHost::new(),
             diagnostics: DiagnosticCollection::default(),
-            config: Arc::new(Config::default()),
+            // workspaces: Arc::new(Vec::new()),
+            config: Arc::new(config.clone()),
+            source_root_config: SourceRootConfig::default(),
         };
         this.update_configuration(config);
         this
@@ -89,8 +95,13 @@ impl GlobalState {
                 } else {
                     None
                 };
-                change.change_file(file.file_id, text);
+                let path = vfs.file_path(file.file_id);
+                change.change_file(file.file_id, text, path);
             }
+
+            let roots = self.source_root_config.partition(vfs);
+            change.set_roots(roots);
+
             change
         };
 
@@ -198,7 +209,7 @@ impl GlobalStateSnapshot {
         let res = LineIndex {
             index,
             endings,
-            encoding: self.config.offset_encoding(),
+            encoding: self.config.data.offset_encoding(),
         };
         Ok(res)
     }

--- a/crates/wgsl_analyzer/src/handlers.rs
+++ b/crates/wgsl_analyzer/src/handlers.rs
@@ -164,7 +164,7 @@ pub fn handle_inlay_hints(
 
     Ok(Some(
         snap.analysis
-            .inlay_hints(&snap.config.inlay_hints(), file_id, range.ok())?
+            .inlay_hints(&snap.config.data.inlay_hints(), file_id, range.ok())?
             .iter()
             .map(|it| to_proto::inlay_hint(true, &line_index, it))
             .collect(),

--- a/crates/wgsl_analyzer/src/lib.rs
+++ b/crates/wgsl_analyzer/src/lib.rs
@@ -9,6 +9,7 @@ mod line_index;
 mod lsp_ext;
 mod lsp_utils;
 pub mod main_loop;
+mod reload;
 mod task_pool;
 mod to_proto;
 

--- a/crates/wgsl_analyzer/src/lsp_ext.rs
+++ b/crates/wgsl_analyzer/src/lsp_ext.rs
@@ -56,3 +56,80 @@ impl Request for RequestConfiguration {
 
     const METHOD: &'static str = "wgsl-analyzer/requestConfiguration";
 }
+pub enum InlayHints {}
+
+impl Request for InlayHints {
+    type Params = inlay_hints::InlayHintsParams;
+    type Result = Vec<inlay_hints::InlayHint>;
+    const METHOD: &'static str = "experimental/inlayHints";
+}
+
+pub mod inlay_hints {
+    use lsp_types::{Position, TextDocumentIdentifier};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct InlayHintsParams {
+        pub text_document: TextDocumentIdentifier,
+        pub range: Option<lsp_types::Range>,
+    }
+
+    #[derive(Eq, PartialEq, Debug, Copy, Clone, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct InlayHintKind(u8);
+
+    #[allow(dead_code)]
+    impl InlayHintKind {
+        pub const TYPE: InlayHintKind = InlayHintKind(1);
+        pub const PARAMETER: InlayHintKind = InlayHintKind(2);
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct InlayHint {
+        pub label: InlayHintLabel,
+        pub position: Position,
+        pub kind: Option<InlayHintKind>,
+        pub tooltip: Option<String>,
+        pub padding_left: Option<bool>,
+        pub padding_right: Option<bool>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    #[serde(untagged)]
+    pub enum InlayHintLabel {
+        String(String),
+        Parts(Vec<InlayHintLabelPart>),
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct InlayHintLabelPart {
+        pub value: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub tooltip: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub location: Option<lsp_types::LocationLink>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub command: Option<lsp_types::Command>,
+    }
+}
+
+pub enum ImportTextDocument {}
+
+impl Request for ImportTextDocument {
+    type Params = import_text_document::ImportTextDocumentParams;
+    type Result = ();
+    const METHOD: &'static str = "wgsl-analyzer/importTextDocument";
+}
+
+pub mod import_text_document {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ImportTextDocumentParams {
+        pub uri: String,
+    }
+}

--- a/crates/wgsl_analyzer/src/lsp_ext.rs
+++ b/crates/wgsl_analyzer/src/lsp_ext.rs
@@ -79,10 +79,9 @@ pub mod inlay_hints {
     #[serde(transparent)]
     pub struct InlayHintKind(u8);
 
-    #[allow(dead_code)]
     impl InlayHintKind {
-        pub const TYPE: InlayHintKind = InlayHintKind(1);
-        pub const PARAMETER: InlayHintKind = InlayHintKind(2);
+        pub const TYPE: Self = Self(1);
+        pub const PARAMETER: Self = Self(2);
     }
 
     #[derive(Debug, Deserialize, Serialize)]

--- a/crates/wgsl_analyzer/src/main_loop.rs
+++ b/crates/wgsl_analyzer/src/main_loop.rs
@@ -18,8 +18,7 @@ use crate::{
     config::Config,
     dispatch::{NotificationDispatcher, RequestDispatcher},
     global_state::{file_id_to_url, GlobalState},
-    handlers, lsp_ext,
-    Result,
+    handlers, lsp_ext, Result,
 };
 
 #[inline]
@@ -48,7 +47,6 @@ impl GlobalState {
         mut self,
         receiver: &Receiver<lsp_server::Message>,
     ) -> Result<()> {
-        
         let mut event = self.next_event(receiver);
         while let Some(e) = event {
             self.handle_event(e)?;
@@ -91,7 +89,7 @@ impl GlobalState {
                         self.diagnostics
                             .set_native_diagnostics(file_id, diagnostics);
                     }
-                }
+                },
                 Task::FetchWorkspace(progress) => {
                     let (state, msg) = match progress {
                         ProjectWorkspaceProgress::Begin => (Progress::Begin, None),
@@ -99,11 +97,11 @@ impl GlobalState {
                         ProjectWorkspaceProgress::End(_) => {
                             self.switch_workspaces();
                             (Progress::End, None)
-                        }
+                        },
                     };
 
                     self.report_progress("Fetching", &state, msg, None);
-                }
+                },
             },
         }
 
@@ -116,35 +114,41 @@ impl GlobalState {
 
         if state_changed {
             // Update import paths?
-            match changes.as_ref() { Some(changes) => {
-                for file_id in changes {
-                    let module = self
-                        .analysis_host
-                        .raw_database()
-                        .module_info(HirFileId::from(*file_id));
-                    for item in module.items() {
-                        if let ModuleItem::Import(import) = item {
-                            let import = module.get(*import);
-                            if let ImportValue::Path(path) = &import.value {
-                                let parent_path = self
-                                    .analysis_host
-                                    .raw_database()
-                                    .file_path(*file_id)
-                                    .parent()
-                                    .unwrap();
-                                let import_path = parent_path.join(path).unwrap();
+            match changes.as_ref() {
+                Some(changes) => {
+                    for file_id in changes {
+                        let module = self
+                            .analysis_host
+                            .raw_database()
+                            .module_info(HirFileId::from(*file_id));
+                        for item in module.items() {
+                            if let ModuleItem::Import(import) = item {
+                                let import = module.get(*import);
+                                if let ImportValue::Path(path) = &import.value {
+                                    let parent_path = self
+                                        .analysis_host
+                                        .raw_database()
+                                        .file_path(*file_id)
+                                        .parent()
+                                        .unwrap();
+                                    let import_path = parent_path.join(path).unwrap();
 
-                                let params =
-                                    lsp_ext::import_text_document::ImportTextDocumentParams {
-                                        uri: import_path.to_string(),
-                                    };
+                                    let params =
+                                        lsp_ext::import_text_document::ImportTextDocumentParams {
+                                            uri: import_path.to_string(),
+                                        };
 
-                                self.send_request::<lsp_ext::ImportTextDocument>(params, |_, _| {});
+                                    self.send_request::<lsp_ext::ImportTextDocument>(
+                                        params,
+                                        |_, _| {},
+                                    );
+                                }
                             }
                         }
                     }
-                }
-            } _ => {}}
+                },
+                _ => {},
+            }
         }
 
         if let Some(diagnostic_changes) = changes {
@@ -274,10 +278,13 @@ impl GlobalState {
             })?
             .on::<lsp_types::notification::DidChangeWatchedFiles>(|_, params| {
                 for change in params.changes {
-                    match from_proto::abs_path(&change.uri) { Ok(path) => {
-                        info!("Changed {}", path);
-                        //this.loader.handle.invalidate(path);
-                    } _ => {}}
+                    match from_proto::abs_path(&change.uri) {
+                        Ok(path) => {
+                            info!("Changed {}", path);
+                            //this.loader.handle.invalidate(path);
+                        },
+                        _ => {},
+                    }
                 }
                 Ok(())
             })?

--- a/crates/wgsl_analyzer/src/main_loop.rs
+++ b/crates/wgsl_analyzer/src/main_loop.rs
@@ -113,7 +113,10 @@ impl GlobalState {
 
         if state_changed {
             // Update import paths?
-            #[expect(clippy::single_match, reason = "changing to if let gives a warning about drop order")]
+            #[expect(
+                clippy::single_match,
+                reason = "changing to if let gives a warning about drop order"
+            )]
             match changes.as_ref() {
                 Some(changes) => {
                     for file_id in changes {
@@ -278,7 +281,10 @@ impl GlobalState {
             })?
             .on::<lsp_types::notification::DidChangeWatchedFiles>(|_, params| {
                 for change in params.changes {
-                    #[expect(clippy::single_match, reason = "changing to if let gives a warning about drop order")]
+                    #[expect(
+                        clippy::single_match,
+                        reason = "changing to if let gives a warning about drop order"
+                    )]
                     match from_proto::abs_path(&change.uri) {
                         Ok(path) => {
                             info!("Changed {}", path);

--- a/crates/wgsl_analyzer/src/main_loop.rs
+++ b/crates/wgsl_analyzer/src/main_loop.rs
@@ -1,12 +1,11 @@
 use crate::from_proto;
 use crate::lsp_utils::{is_cancelled, Progress};
 use crate::reload::ProjectWorkspaceProgress;
-use base_db::SourceDatabase;
+use base_db::SourceDatabase as _;
 use std::{sync::Arc, time::Instant};
 
-use base_db::SourceDatabase as _;
 use crossbeam_channel::{select, Receiver};
-use hir_def::db::DefDatabase;
+use hir_def::db::DefDatabase as _;
 use hir_def::module_data::{ImportValue, ModuleItem};
 use hir_def::HirFileId;
 use lsp_server::Connection;
@@ -48,8 +47,8 @@ impl GlobalState {
         receiver: &Receiver<lsp_server::Message>,
     ) -> Result<()> {
         let mut event = self.next_event(receiver);
-        while let Some(e) = event {
-            self.handle_event(e)?;
+        while let Some(current) = event {
+            self.handle_event(current)?;
             event = self.next_event(receiver);
         }
 
@@ -114,6 +113,7 @@ impl GlobalState {
 
         if state_changed {
             // Update import paths?
+            #[expect(clippy::single_match, reason = "changing to if let gives a warning about drop order")]
             match changes.as_ref() {
                 Some(changes) => {
                     for file_id in changes {
@@ -278,6 +278,7 @@ impl GlobalState {
             })?
             .on::<lsp_types::notification::DidChangeWatchedFiles>(|_, params| {
                 for change in params.changes {
+                    #[expect(clippy::single_match, reason = "changing to if let gives a warning about drop order")]
                     match from_proto::abs_path(&change.uri) {
                         Ok(path) => {
                             info!("Changed {}", path);

--- a/crates/wgsl_analyzer/src/main_loop.rs
+++ b/crates/wgsl_analyzer/src/main_loop.rs
@@ -1,9 +1,17 @@
+use crate::from_proto;
+use crate::lsp_utils::{is_cancelled, Progress};
+use crate::reload::ProjectWorkspaceProgress;
+use base_db::SourceDatabase;
 use std::{sync::Arc, time::Instant};
 
 use base_db::SourceDatabase as _;
 use crossbeam_channel::{select, Receiver};
+use hir_def::db::DefDatabase;
+use hir_def::module_data::{ImportValue, ModuleItem};
+use hir_def::HirFileId;
 use lsp_server::Connection;
 use salsa::Durability;
+use tracing::info;
 use vfs::FileId;
 
 use crate::{
@@ -11,7 +19,6 @@ use crate::{
     dispatch::{NotificationDispatcher, RequestDispatcher},
     global_state::{file_id_to_url, GlobalState},
     handlers, lsp_ext,
-    lsp_utils::is_cancelled,
     Result,
 };
 
@@ -33,6 +40,7 @@ pub enum Event {
 pub enum Task {
     Response(lsp_server::Response),
     Diagnostics(Vec<(FileId, Vec<lsp_types::Diagnostic>)>),
+    FetchWorkspace(ProjectWorkspaceProgress),
 }
 
 impl GlobalState {
@@ -40,8 +48,11 @@ impl GlobalState {
         mut self,
         receiver: &Receiver<lsp_server::Message>,
     ) -> Result<()> {
-        while let Some(event) = self.next_event(receiver) {
-            self.handle_event(event)?;
+        
+        let mut event = self.next_event(receiver);
+        while let Some(e) = event {
+            self.handle_event(e)?;
+            event = self.next_event(receiver);
         }
 
         Err(anyhow::anyhow!(
@@ -80,7 +91,19 @@ impl GlobalState {
                         self.diagnostics
                             .set_native_diagnostics(file_id, diagnostics);
                     }
-                },
+                }
+                Task::FetchWorkspace(progress) => {
+                    let (state, msg) = match progress {
+                        ProjectWorkspaceProgress::Begin => (Progress::Begin, None),
+                        ProjectWorkspaceProgress::Report(msg) => (Progress::Report, Some(msg)),
+                        ProjectWorkspaceProgress::End(_) => {
+                            self.switch_workspaces();
+                            (Progress::End, None)
+                        }
+                    };
+
+                    self.report_progress("Fetching", &state, msg, None);
+                }
             },
         }
 
@@ -89,8 +112,42 @@ impl GlobalState {
             self.update_diagnostics();
         }
 
-        if let Some(diagnostic_changes) = self.diagnostics.take_changes() {
-            // TODO is order important here?
+        let changes = self.diagnostics.take_changes();
+
+        if state_changed {
+            // Update import paths?
+            match changes.as_ref() { Some(changes) => {
+                for file_id in changes {
+                    let module = self
+                        .analysis_host
+                        .raw_database()
+                        .module_info(HirFileId::from(*file_id));
+                    for item in module.items() {
+                        if let ModuleItem::Import(import) = item {
+                            let import = module.get(*import);
+                            if let ImportValue::Path(path) = &import.value {
+                                let parent_path = self
+                                    .analysis_host
+                                    .raw_database()
+                                    .file_path(*file_id)
+                                    .parent()
+                                    .unwrap();
+                                let import_path = parent_path.join(path).unwrap();
+
+                                let params =
+                                    lsp_ext::import_text_document::ImportTextDocumentParams {
+                                        uri: import_path.to_string(),
+                                    };
+
+                                self.send_request::<lsp_ext::ImportTextDocument>(params, |_, _| {});
+                            }
+                        }
+                    }
+                }
+            } _ => {}}
+        }
+
+        if let Some(diagnostic_changes) = changes {
             for file_id in diagnostic_changes {
                 let url = file_id_to_url(&self.vfs.read().unwrap().0, file_id);
                 let diagnostics = self.diagnostics.diagnostics_for(file_id).cloned().collect();
@@ -117,7 +174,7 @@ impl GlobalState {
             .map(|(file_id, _)| file_id)
             .collect();
 
-        let diagnostics_config = self.config.diagnostics();
+        let diagnostics_config = self.config.data.diagnostics();
 
         self.task_pool.handle.spawn(move || {
             let diagnostics = relevant_files
@@ -205,7 +262,7 @@ impl GlobalState {
                             // Note that json can be null according to the spec if the client can't
                             // provide a configuration. This is handled in Config::update below.
                             let mut config = Config::clone(&*this.config);
-                            config.update(&configs);
+                            config.data.update(&configs);
                             this.update_configuration(config);
                         },
                         (None, None) => tracing::error!(
@@ -213,6 +270,15 @@ impl GlobalState {
                         ),
                     }
                 });
+                Ok(())
+            })?
+            .on::<lsp_types::notification::DidChangeWatchedFiles>(|_, params| {
+                for change in params.changes {
+                    match from_proto::abs_path(&change.uri) { Ok(path) => {
+                        info!("Changed {}", path);
+                        //this.loader.handle.invalidate(path);
+                    } _ => {}}
+                }
                 Ok(())
             })?
             .finish();
@@ -225,20 +291,20 @@ impl GlobalState {
     ) {
         let old_config = std::mem::replace(&mut self.config, Arc::new(config));
 
-        if old_config.custom_imports != self.config.custom_imports {
+        if old_config.data.custom_imports != self.config.data.custom_imports {
             self.analysis_host
                 .raw_database_mut()
                 .set_custom_imports_with_durability(
-                    Arc::new(self.config.custom_imports.clone()),
+                    Arc::new(self.config.data.custom_imports.clone()),
                     Durability::HIGH,
                 );
         }
 
-        if old_config.shader_defs != self.config.shader_defs {
+        if old_config.data.shader_defs != self.config.data.shader_defs {
             self.analysis_host
                 .raw_database_mut()
                 .set_shader_defs_with_durability(
-                    Arc::new(self.config.shader_defs.clone()),
+                    Arc::new(self.config.data.shader_defs.clone()),
                     Durability::HIGH,
                 );
         }

--- a/crates/wgsl_analyzer/src/reload.rs
+++ b/crates/wgsl_analyzer/src/reload.rs
@@ -1,0 +1,103 @@
+use paths::AbsPathBuf;
+use tracing::info;
+use vfs::file_set::FileSetConfig;
+
+use ide::base_db::input::SourceRoot;
+
+use crate::{global_state::GlobalState, main_loop::Task};
+
+/// `PackageRoot` describes a package root folder.
+/// Which may be an external dependency, or a member of
+/// the current workspace.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct PackageRoot {
+    /// Is from the local filesystem and may be edited
+    pub is_local: bool,
+    pub include: Vec<AbsPathBuf>,
+    pub exclude: Vec<AbsPathBuf>,
+}
+
+#[derive(Clone, Debug)]
+pub enum ProjectWorkspace {
+    Test,
+}
+
+impl ProjectWorkspace {
+    /// Returns the roots for the current `ProjectWorkspace`
+    /// The return type contains the path and whether or not
+    /// the root is a member of the current workspace
+    pub fn to_roots(&self) -> Vec<PackageRoot> {
+        Vec::new()
+    }
+}
+
+#[derive(Debug)]
+pub enum ProjectWorkspaceProgress {
+    Begin,
+    Report(String),
+    End(Vec<anyhow::Result<ProjectWorkspace>>),
+}
+
+impl GlobalState {
+    pub fn fetch_workspaces(&mut self) {
+        self.task_pool.handle.spawn_with_sender(move |sender| {
+            sender
+                .send(Task::FetchWorkspace(ProjectWorkspaceProgress::Begin))
+                .unwrap();
+            let workspaces = vec![Ok(ProjectWorkspace::Test)];
+            sender
+                .send(Task::FetchWorkspace(ProjectWorkspaceProgress::End(
+                    workspaces,
+                )))
+                .unwrap();
+        });
+    }
+
+    pub fn switch_workspaces(&mut self) {
+        let glob_pattern = format!("{}/**/*.wgsl", self.config.root_path);
+
+        let registration_options = lsp_types::DidChangeWatchedFilesRegistrationOptions {
+            watchers: vec![lsp_types::FileSystemWatcher {
+                glob_pattern: lsp_types::GlobPattern::String(glob_pattern),
+                kind: None,
+            }],
+        };
+        let registration = lsp_types::Registration {
+            id: "workspace/didChangeWatchedFiles".to_string(),
+            method: "workspace/didChangeWatchedFiles".to_string(),
+            register_options: Some(serde_json::to_value(registration_options).unwrap()),
+        };
+        self.send_request::<lsp_types::request::RegisterCapability>(
+            lsp_types::RegistrationParams {
+                registrations: vec![registration],
+            },
+            |_, _| (),
+        );
+        info!("Registered");
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct SourceRootConfig {
+    pub fsc: FileSetConfig,
+    pub local_filesets: Vec<usize>,
+}
+
+impl SourceRootConfig {
+    pub(crate) fn partition(&self, vfs: &vfs::Vfs) -> Vec<SourceRoot> {
+        //let _p = profile::span("SourceRootConfig::partition");
+        self.fsc
+            .partition(vfs)
+            .into_iter()
+            .enumerate()
+            .map(|(idx, file_set)| {
+                let is_local = self.local_filesets.contains(&idx);
+                if is_local {
+                    SourceRoot::new_local(file_set)
+                } else {
+                    SourceRoot::new_library(file_set)
+                }
+            })
+            .collect()
+    }
+}

--- a/crates/wgsl_analyzer/src/reload.rs
+++ b/crates/wgsl_analyzer/src/reload.rs
@@ -84,7 +84,10 @@ pub struct SourceRootConfig {
 }
 
 impl SourceRootConfig {
-    pub(crate) fn partition(&self, vfs: &vfs::Vfs) -> Vec<SourceRoot> {
+    pub(crate) fn partition(
+        &self,
+        vfs: &vfs::Vfs,
+    ) -> Vec<SourceRoot> {
         //let _p = profile::span("SourceRootConfig::partition");
         self.fsc
             .partition(vfs)

--- a/crates/wgsl_analyzer/src/reload.rs
+++ b/crates/wgsl_analyzer/src/reload.rs
@@ -26,7 +26,7 @@ impl ProjectWorkspace {
     /// Returns the roots for the current `ProjectWorkspace`
     /// The return type contains the path and whether or not
     /// the root is a member of the current workspace
-    pub fn to_roots(&self) -> Vec<PackageRoot> {
+    pub const fn to_roots() -> Vec<PackageRoot> {
         Vec::new()
     }
 }
@@ -39,7 +39,7 @@ pub enum ProjectWorkspaceProgress {
 }
 
 impl GlobalState {
-    pub fn fetch_workspaces(&mut self) {
+    pub fn fetch_workspaces(&self) {
         self.task_pool.handle.spawn_with_sender(move |sender| {
             sender
                 .send(Task::FetchWorkspace(ProjectWorkspaceProgress::Begin))
@@ -63,8 +63,8 @@ impl GlobalState {
             }],
         };
         let registration = lsp_types::Registration {
-            id: "workspace/didChangeWatchedFiles".to_string(),
-            method: "workspace/didChangeWatchedFiles".to_string(),
+            id: "workspace/didChangeWatchedFiles".to_owned(),
+            method: "workspace/didChangeWatchedFiles".to_owned(),
             register_options: Some(serde_json::to_value(registration_options).unwrap()),
         };
         self.send_request::<lsp_types::request::RegisterCapability>(

--- a/crates/wgsl_parser/src/syntax_kind.rs
+++ b/crates/wgsl_parser/src/syntax_kind.rs
@@ -126,7 +126,7 @@ pub enum SyntaxKind {
     UnofficialPreprocessorEndif,
     #[regex("#else.*")]
     UnofficialPreprocessorElse,
-    #[regex("#import.*")]
+    #[regex("#import")]
     UnofficialPreprocessorImport,
     #[regex("#define_import_path.*")]
     UnofficialPreprocessorDefineImportPath,

--- a/crates/wgsl_parser/src/tests.rs
+++ b/crates/wgsl_parser/src/tests.rs
@@ -2515,9 +2515,12 @@ fn parse_import() {
     check(
         "#import test",
         expect![[r##"
-            SourceFile@0..12
-              Import@0..12
-                UnofficialPreprocessorImport@0..12 "#import test""##]],
+          SourceFile@0..12
+            Import@0..12
+              UnofficialPreprocessorImport@0..7 "#import"
+              Whitespace@7..8 " "
+              ImportCustom@8..12
+                Ident@8..12 "test""##]],
     );
 }
 
@@ -2528,7 +2531,12 @@ fn parse_import_colon() {
         expect![[r##"
             SourceFile@0..29
               Import@0..29
-                UnofficialPreprocessorImport@0..29 "#import bevy_pbr::mes ...""##]],
+                UnofficialPreprocessorImport@0..7 "#import"
+                Whitespace@7..8 " "
+                ImportCustom@8..29
+                  Ident@8..16 "bevy_pbr"
+                  ColonColon@16..18 "::"
+                  Ident@18..29 "mesh_struct""##]],
     );
 }
 
@@ -2538,9 +2546,12 @@ fn parse_string_import() {
     check(
         r#"#import "file.wgsl""#,
         expect![[r##"
-            SourceFile@0..19
-              Import@0..19
-                UnofficialPreprocessorImport@0..19 "#import \"file.wgsl\"""##]],
+          SourceFile@0..19
+            Import@0..19
+              UnofficialPreprocessorImport@0..7 "#import"
+              Whitespace@7..8 " "
+              ImportPath@8..19
+                StringLiteral@8..19 "\"file.wgsl\"""##]],
     );
 }
 

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -69,11 +69,16 @@ export class Ctx {
 
         client.start();
 
-        ctx.subscriptions.push(client.onRequest(lsp_ext.requestConfiguration, async (_, ct) => {
-            let options = await lspOptions(config);
-            return options;
-        }));
-
+        ctx.subscriptions.push(
+            client.onRequest(lsp_ext.requestConfiguration, async (_, ct) => {
+                let options = await lspOptions(config);
+                return options;
+            }),
+            client.onRequest(lsp_ext.importTextDocument, async (params, ct) => {
+                vscode.workspace.openTextDocument(params.uri);
+                return;
+            })
+        );
 
         return new Ctx(config, ctx, client);
     }

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -20,3 +20,14 @@ export interface FullSourceParams {
 export const fullSource = new lc.RequestType<FullSourceParams, string, void>("wgsl-analyzer/fullSource");
 
 export const requestConfiguration = new lc.RequestType<void, unknown, void>("wgsl-analyzer/requestConfiguration");
+
+export interface InlayHintsParams {
+    textDocument: lc.TextDocumentIdentifier;
+    range: lc.Range;
+}
+export const inlayHints = new lc.RequestType<InlayHintsParams, InlayHint[], void>("experimental/inlayHints");
+
+export interface ImportTextDocumentParams {
+    uri: lc.DocumentUri;
+}
+export const importTextDocument = new lc.RequestType<ImportTextDocumentParams, unknown, void>("wgsl-analyzer/importTextDocument");


### PR DESCRIPTION
# Objective

Rebase on `main` and fix up errors from https://github.com/wgsl-analyzer/wgsl-analyzer/pull/82.

There were also some warnings & lint issues to fix.

There was also a change to the AST parser that broke imports that we need to revert: [ fix ](https://github.com/wgsl-analyzer/wgsl-analyzer/issues/100) by reverting https://github.com/wgsl-analyzer/wgsl-analyzer/commit/ea2c51e73df0fa9ca45d8bb2b4851b2ec70bd08d & this means changing some of the test assertions regarding the AST.

# Testing
Relative imports should now work, like so
```
#import "../../shared/core-structs.wgsl"
```