### PR TITLE
Fix red highlighting of angle brackets when not part of a bracket.

### DIFF
--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -1,62 +1,124 @@
 {
-    "comments": {
-        "blockComment": [
-            "/*",
-            "*/"
-        ],
-        "lineComment": "//"
-    },
-    "brackets": [
-        [
-            "(",
-            ")"
-        ],
-        [
-            "[",
-            "]"
-        ],
-        [
-            "{",
-            "}"
-        ]
-    ],
-    "colorizedBracketPairs": [
-        [
-            "{",
-            "}"
-        ],
-        [
-            "[",
-            "]"
-        ],
-        [
-            "(",
-            ")"
-        ]
-    ],
-    "autoClosingPairs": [
-        {
-            "open": "{",
-            "close": "}"
-        },
-        {
-            "open": "[",
-            "close": "]"
-        },
-        {
-            "open": "(",
-            "close": ")"
-        },
-        {
-            "open": "\"",
-            "close": "\"",
-            "notIn": [
-                "string"
-            ]
-        },
-        {
-            "open": "/*",
-            "close": " */"
-        }
-    ],
+	"comments": {
+		"lineComment": "//",
+		"blockComment": [
+			"/*",
+			"*/"
+		]
+	},
+	"brackets": [
+		[
+			"{",
+			"}"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"(",
+			")"
+		]
+	],
+	"colorizedBracketPairs": [
+		[
+			"{",
+			"}"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"(",
+			")"
+		]
+	],
+	"autoClosingPairs": [
+		{
+			"open": "{",
+			"close": "}"
+		},
+		{
+			"open": "[",
+			"close": "]"
+		},
+		{
+			"open": "(",
+			"close": ")"
+		},
+		{
+			"open": "\"",
+			"close": "\"",
+			"notIn": [
+				"string"
+			]
+		},
+		{
+			"open": "/*",
+			"close": " */",
+			"notIn": [
+				"string"
+			]
+		},
+		{
+			"open": "`",
+			"close": "`",
+			"notIn": [
+				"string"
+			]
+		},
+		{
+			"open": "```",
+			"close": "```",
+			"notIn": [
+				"string"
+			]
+		}
+	],
+	"autoCloseBefore": ";:.,=}])> \n\t",
+	"surroundingPairs": [
+		[
+			"{",
+			"}"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"(",
+			")"
+		],
+		[
+			"<",
+			">"
+		],
+		[
+			"\"",
+			"\""
+		],
+		[
+			"'",
+			"'"
+		],
+		[
+			"`",
+			"`"
+		],
+		[
+			"```",
+			"```"
+		]
+	],
+	"indentationRules": {
+		"increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$",
+		"decreaseIndentPattern": "^\\s*(\\s*\\/[*].*[*]\\/\\s*)*[})]"
+	},
+	"folding": {
+		"markers": {
+			"start": "^\\s*#ifn?def\\b",
+			"end": "^\\s*#endif\\b"
+		}
+	}
 }

--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -18,10 +18,6 @@
         [
             "{",
             "}"
-        ],
-        [
-            "<",
-            ">"
         ]
     ],
     "colorizedBracketPairs": [


### PR DESCRIPTION
# Objective

This extension has the same issue as described [here](https://github.com/PolyMeilex/vscode-wgsl/issues/20). This PR is a port of the fix that was eventually applied to `vscode-wgsl`.

## Solution

Remove the angle brackets from the language configuration file. This may affect highlighting of angle brackets when the cursor is on one side of a pair of angle brackets, but the red highlighting of other uses of angle brackets (return syntax, comparison operations) will no longer be present.

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you cannot test?

## Showcase

This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

```rust
println!("My super cool code.");
```
