### PR TITLE
add edition crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
 
 [[package]]
+name = "edition"
+version = "0.0.0"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/edition/Cargo.toml
+++ b/crates/edition/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "edition"
+version = "0.0.0"
+description = "Shader language edition support crate for wgsl-analyzer."
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/edition/src/lib.rs
+++ b/crates/edition/src/lib.rs
@@ -1,0 +1,95 @@
+//! The edition of the shader language.
+//! This should live here in a separate crate because we use it in both actual code and codegen.
+
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum Edition {
+    // The syntax context stuff needs the discriminants to start from 0 and be consecutive.
+    Wgsl = 0,
+    Wesl0_0_1,
+}
+
+impl Edition {
+    pub const DEFAULT: Self = Self::Wgsl;
+    pub const LATEST: Self = Self::Wgsl;
+    pub const CURRENT: Self = Self::Wgsl;
+    /// The current latest stable edition, note this is usually not the right choice in code.
+    pub const CURRENT_FIXME: Self = Self::Wgsl;
+
+    /// # Panics
+    ///
+    /// Panics if the value does not correspond to a variant of [`Edition`].
+    #[must_use]
+    #[inline]
+    pub fn from_u32(u32: u32) -> Self {
+        match u32 {
+            0 => Self::Wgsl,
+            1 => Self::Wesl0_0_1,
+            _ => panic!("invalid edition"),
+        }
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn at_least_wesl_0_0_1(self) -> bool {
+        self >= Self::Wesl0_0_1
+    }
+
+    #[inline]
+    pub fn iter() -> impl Iterator<Item = Self> {
+        [Self::Wgsl, Self::Wesl0_0_1].iter().copied()
+    }
+}
+
+#[derive(Debug)]
+pub struct ParseEditionError {
+    invalid_input: String,
+}
+
+impl std::error::Error for ParseEditionError {}
+
+impl fmt::Display for ParseEditionError {
+    #[inline]
+    fn fmt(
+        &self,
+        #[expect(clippy::min_ident_chars, reason = "trait impl")] f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(f, "invalid edition: {}", self.invalid_input)
+    }
+}
+
+impl std::str::FromStr for Edition {
+    type Err = ParseEditionError;
+
+    #[inline]
+    fn from_str(
+        #[expect(clippy::min_ident_chars, reason = "trait impl")] s: &str
+    ) -> Result<Self, Self::Err> {
+        let res = match s {
+            "WGSL" => Self::Wgsl,
+            "WESL 0.0.1" => Self::Wesl0_0_1,
+            _ => {
+                return Err(ParseEditionError {
+                    invalid_input: s.to_owned(),
+                });
+            },
+        };
+        Ok(res)
+    }
+}
+
+impl fmt::Display for Edition {
+    #[inline]
+    fn fmt(
+        &self,
+        #[expect(clippy::min_ident_chars, reason = "trait impl")] f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        f.write_str(match self {
+            Self::Wgsl => "WGSL",
+            Self::Wesl0_0_1 => "WESL 0.0.1",
+        })
+    }
+}

--- a/crates/edition/src/lib.rs
+++ b/crates/edition/src/lib.rs
@@ -68,16 +68,13 @@ impl std::str::FromStr for Edition {
     fn from_str(
         #[expect(clippy::min_ident_chars, reason = "trait impl")] s: &str
     ) -> Result<Self, Self::Err> {
-        let res = match s {
-            "WGSL" => Self::Wgsl,
-            "WESL 0.0.1" => Self::Wesl0_0_1,
-            _ => {
-                return Err(ParseEditionError {
-                    invalid_input: s.to_owned(),
-                });
-            },
-        };
-        Ok(res)
+        match s {
+            "WGSL" => Ok(Self::Wgsl),
+            "WESL 0.0.1" => Ok(Self::Wesl0_0_1),
+            _ => Err(ParseEditionError {
+                invalid_input: s.to_owned(),
+            }),
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

Add a crate to provide an enum for "editions" of the language being analyzed.
This can be expanded upon and used to support different versions of the WGSL specification (maybe once stability is a major concern) and also to support extension to the language such as WESL and extensions thereupon.

This will also make it simpler to port and update other crates from r-a because there is something to fill that gap, even if it isn't very useful at the moment.

The first crate that will use this is an update to `crates/parser`.

`xtask` may also use it in the future in order to generate documentation about lints (after wgsl lints become a feature)

Contributes to #182 

## Solution

Port edition crate from r-a

## Testing

N/A
