### PR TITLE
Update nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1727824512,
-        "narHash": "sha256-DvFQd58W20BEqh0BUt33eZhzPKBXGO/r9aiSFIVMaWU=",
+        "lastModified": 1745022865,
+        "narHash": "sha256-tXL4qUlyYZEGOHUKUWjmmcvJjjLQ+4U38lPWSc8Cgdo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "a376dd1efac7bce448857c62961c6311be26cb09",
+        "rev": "25ca4c50039d91ad88cc0b8feacb9ad7f748dedf",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727811607,
-        "narHash": "sha256-2ByOBflaIUJKeF9q6efVcYHljZXGZ7MnCWtseRvmpm8=",
+        "lastModified": 1744868846,
+        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1839883cd0068572aed75fb9442b508bbd9ef09c",
+        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Objective

Update nix flake inputs to fix nix build.

Without/before this PR, a `nix build` of the flake in this repo results in a build failure because the Rust version in the used nixpkgs revision is too old, producing a log like this:
```
wgsl-analyzer-deps> Running phase: buildPhase
wgsl-analyzer-deps> ++ command cargo --version
wgsl-analyzer-deps> cargo 1.80.0 (376290515 2024-07-16)
wgsl-analyzer-deps> ++ command cargo check --release -p wgsl-analyzer --all-targets
wgsl-analyzer-deps> error: failed to load manifest for workspace member `/build/source/xtask`
wgsl-analyzer-deps> referenced by workspace at `/build/source/Cargo.toml`
wgsl-analyzer-deps>
wgsl-analyzer-deps> Caused by:
wgsl-analyzer-deps>   failed to parse manifest at `/build/source/xtask/Cargo.toml`
wgsl-analyzer-deps>
wgsl-analyzer-deps> Caused by:
wgsl-analyzer-deps>   feature `edition2024` is required
wgsl-analyzer-deps>
wgsl-analyzer-deps>   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.80.0 (376290515 2024-07-16)).
wgsl-analyzer-deps>   Consider adding `cargo-features = ["edition2024"]` to the top of Cargo.toml (above the [package] table) to tell Cargo you are opting in to use this unstable feature.
wgsl-analyzer-deps>   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```

Edit: This also fixes a nix evaluation warning that was caused by an outdated version of [crane](https://github.com/ipetkov/crane).

## Testing

- `nix build` runs successfully
- tested on Linux / NixOS 24.11