### PR TITLE
Fix parsing error on hover

### DIFF
--- a/crates/wgsl-analyzer/src/main_loop.rs
+++ b/crates/wgsl-analyzer/src/main_loop.rs
@@ -752,7 +752,7 @@ impl GlobalState {
             )
             .on::<RETRY, lsp_types::request::Completion>(handlers::request::handle_completion)
             .on_fmt_thread::<lsp_types::request::Formatting>(handlers::request::handle_formatting)
-            .on::<NO_RETRY, lsp_types::request::HoverRequest>(handlers::request::handle_hover)
+            .on::<NO_RETRY, lsp::extensions::HoverRequest>(handlers::request::handle_hover)
             .on::<NO_RETRY, lsp_types::request::Shutdown>(handlers::request::handle_shutdown)
             .on::<NO_RETRY, lsp_types::request::InlayHintRequest>(
                 handlers::request::handle_inlay_hints,


### PR DESCRIPTION
# Objective

Fixes #272 

## Solution

When hovering over selected text, the language server would send a PositionOrRange, but the handle_hover implementation was still building an lsp_types::Hover directly. Because lsp_types::Hover expects only a single Position (with fields line and character) and not a Range, the deserialization would fail with a “missing field line” error. Refactored handle_hover to accept PositionOrRange and to produce extensions::Hover. This prevents the parse‐error when text is selected.

## Testing

1. Open a .wgsl file
2. Select some text and hover over it