### PR TITLE
add diagnostics back to frontend

### DIFF
--- a/crates/wgsl-analyzer/src/dispatch.rs
+++ b/crates/wgsl-analyzer/src/dispatch.rs
@@ -132,7 +132,7 @@ impl<'global_state> RequestDispatcher<'global_state> {
     /// ready this will return a `default` constructed [`R::Result`].
     pub(crate) fn on_with_vfs_default<R>(
         &mut self,
-        f: fn(GlobalStateSnapshot, R::Params) -> anyhow::Result<R::Result>,
+        function: fn(GlobalStateSnapshot, R::Params) -> anyhow::Result<R::Result>,
         default: impl FnOnce() -> R::Result,
         on_cancelled: fn() -> ResponseError,
     ) -> &mut Self
@@ -151,7 +151,7 @@ impl<'global_state> RequestDispatcher<'global_state> {
             }
             return self;
         }
-        self.on_with_thread_intent::<false, false, R>(ThreadIntent::Worker, f, on_cancelled)
+        self.on_with_thread_intent::<false, false, R>(ThreadIntent::Worker, function, on_cancelled)
     }
 
     /// Formatting requests should never block on waiting a for task thread to open up, editors will wait

--- a/crates/wgsl-analyzer/src/dispatch.rs
+++ b/crates/wgsl-analyzer/src/dispatch.rs
@@ -128,6 +128,32 @@ impl<'global_state> RequestDispatcher<'global_state> {
         )
     }
 
+    /// Dispatches a non-latency-sensitive request onto the thread pool. When the VFS is marked not
+    /// ready this will return a `default` constructed [`R::Result`].
+    pub(crate) fn on_with_vfs_default<R>(
+        &mut self,
+        f: fn(GlobalStateSnapshot, R::Params) -> anyhow::Result<R::Result>,
+        default: impl FnOnce() -> R::Result,
+        on_cancelled: fn() -> ResponseError,
+    ) -> &mut Self
+    where
+        R: lsp_types::request::Request<
+                Params: DeserializeOwned + panic::UnwindSafe + Send + fmt::Debug,
+                Result: Serialize,
+            > + 'static,
+    {
+        if !self.global_state.vfs_done {
+            if let Some(lsp_server::Request { id, .. }) =
+                self.request.take_if(|it| it.method == R::METHOD)
+            {
+                self.global_state
+                    .respond(lsp_server::Response::new_ok(id, default()));
+            }
+            return self;
+        }
+        self.on_with_thread_intent::<false, false, R>(ThreadIntent::Worker, f, on_cancelled)
+    }
+
     /// Formatting requests should never block on waiting a for task thread to open up, editors will wait
     /// on the response and a late formatting update might mess with the document and user.
     /// We can't run this on the main thread though as we invoke rustfmt which may take arbitrary time to complete!

--- a/crates/wgsl-analyzer/src/handlers/request.rs
+++ b/crates/wgsl-analyzer/src/handlers/request.rs
@@ -200,13 +200,17 @@ pub(crate) fn handle_document_diagnostics(
     let source_root = snap.analysis.source_root_id(file_id).ok();
     let config = snap.config.data().diagnostics(source_root);
 
-   let items = publish_diagnostics(&snap, &config, file_id).unwrap();
+    let items = publish_diagnostics(&snap, &config, file_id).unwrap();
 
     Ok(lsp_types::DocumentDiagnosticReportResult::Report(
         lsp_types::DocumentDiagnosticReport::Full(lsp_types::RelatedFullDocumentDiagnosticReport {
             related_documents: None,
             full_document_diagnostic_report: lsp_types::FullDocumentDiagnosticReport {
-                result_id: Some(params.previous_result_id.unwrap_or_else(|| "wgsl-analyzer".to_owned())),
+                result_id: Some(
+                    params
+                        .previous_result_id
+                        .unwrap_or_else(|| "wgsl-analyzer".to_owned()),
+                ),
                 items,
             },
         }),

--- a/crates/wgsl-analyzer/src/handlers/request.rs
+++ b/crates/wgsl-analyzer/src/handlers/request.rs
@@ -193,9 +193,9 @@ pub(crate) fn empty_diagnostic_report() -> lsp_types::DocumentDiagnosticReportRe
 
 pub(crate) fn handle_document_diagnostics(
     snap: GlobalStateSnapshot,
-    params: lsp_types::DocumentDiagnosticParams,
+    parameters: lsp_types::DocumentDiagnosticParams,
 ) -> anyhow::Result<lsp_types::DocumentDiagnosticReportResult> {
-    let file_id = from_proto::file_id(&snap, &params.text_document.uri)?;
+    let file_id = from_proto::file_id(&snap, &parameters.text_document.uri)?;
 
     let source_root = snap.analysis.source_root_id(file_id).ok();
     let config = snap.config.data().diagnostics(source_root);
@@ -211,7 +211,7 @@ pub(crate) fn handle_document_diagnostics(
             related_documents: None,
             full_document_diagnostic_report: lsp_types::FullDocumentDiagnosticReport {
                 result_id: Some(
-                    params
+                    parameters
                         .previous_result_id
                         .unwrap_or_else(|| "wgsl-analyzer".to_owned()),
                 ),

--- a/crates/wgsl-analyzer/src/handlers/request.rs
+++ b/crates/wgsl-analyzer/src/handlers/request.rs
@@ -200,6 +200,10 @@ pub(crate) fn handle_document_diagnostics(
     let source_root = snap.analysis.source_root_id(file_id).ok();
     let config = snap.config.data().diagnostics(source_root);
 
+    if !config.enabled {
+        return Ok(empty_diagnostic_report());
+    }
+
     let items = publish_diagnostics(&snap, &config, file_id).unwrap();
 
     Ok(lsp_types::DocumentDiagnosticReportResult::Report(

--- a/crates/wgsl-analyzer/src/handlers/request.rs
+++ b/crates/wgsl-analyzer/src/handlers/request.rs
@@ -177,6 +177,42 @@ pub(crate) fn debug_command(
     Ok(())
 }
 
+// This is the “empty” fallback if the VFS lookup fails.
+// It returns an “Unchanged” report with the same `previousResultId` the client sent.
+pub(crate) fn empty_diagnostic_report() -> lsp_types::DocumentDiagnosticReportResult {
+    lsp_types::DocumentDiagnosticReportResult::Report(lsp_types::DocumentDiagnosticReport::Full(
+        lsp_types::RelatedFullDocumentDiagnosticReport {
+            related_documents: None,
+            full_document_diagnostic_report: lsp_types::FullDocumentDiagnosticReport {
+                result_id: Some("wgsl-analyzer".to_owned()),
+                items: vec![],
+            },
+        },
+    ))
+}
+
+pub(crate) fn handle_document_diagnostics(
+    snap: GlobalStateSnapshot,
+    params: lsp_types::DocumentDiagnosticParams,
+) -> anyhow::Result<lsp_types::DocumentDiagnosticReportResult> {
+    let file_id = from_proto::file_id(&snap, &params.text_document.uri)?;
+
+    let source_root = snap.analysis.source_root_id(file_id).ok();
+    let config = snap.config.data().diagnostics(source_root);
+
+   let items = publish_diagnostics(&snap, &config, file_id).unwrap();
+
+    Ok(lsp_types::DocumentDiagnosticReportResult::Report(
+        lsp_types::DocumentDiagnosticReport::Full(lsp_types::RelatedFullDocumentDiagnosticReport {
+            related_documents: None,
+            full_document_diagnostic_report: lsp_types::FullDocumentDiagnosticReport {
+                result_id: Some(params.previous_result_id.unwrap_or_else(|| "wgsl-analyzer".to_owned())),
+                items,
+            },
+        }),
+    ))
+}
+
 pub(crate) fn handle_inlay_hints(
     snap: GlobalStateSnapshot,
     parameters: lsp_types::InlayHintParams,

--- a/crates/wgsl-analyzer/src/lsp/capabilities.rs
+++ b/crates/wgsl-analyzer/src/lsp/capabilities.rs
@@ -51,7 +51,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
                 inter_file_dependencies: false,
                 workspace_diagnostics: false,
                 work_done_progress_options: WorkDoneProgressOptions {
-                    work_done_progress: None,
+                    work_done_progress: Some(false),
                 },
             },
         )),

--- a/crates/wgsl-analyzer/src/lsp/capabilities.rs
+++ b/crates/wgsl-analyzer/src/lsp/capabilities.rs
@@ -3,7 +3,7 @@ use line_index::WideEncoding;
 use lsp_types::{
     CallHierarchyServerCapability, CodeActionKind, CodeActionOptions, CodeActionProviderCapability,
     CodeLensOptions, CompletionOptions, CompletionOptionsCompletionItem, DeclarationCapability,
-    DocumentOnTypeFormattingOptions, FileOperationFilter, FileOperationPattern,
+    DiagnosticOptions, DocumentOnTypeFormattingOptions, FileOperationFilter, FileOperationPattern,
     FileOperationPatternKind, FileOperationRegistrationOptions, FoldingRangeProviderCapability,
     HoverProviderCapability, ImplementationProviderCapability, InlayHintOptions,
     InlayHintServerCapabilities, OneOf, PositionEncodingKind, RenameOptions, SaveOptions,
@@ -45,6 +45,16 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
         // definition_provider: Some(OneOf::Left(true)),
         inlay_hint_provider: Some(OneOf::Left(true)),
         experimental: Some(json!({ "inlayHints": true })),
+        diagnostic_provider: Some(lsp_types::DiagnosticServerCapabilities::Options(
+            DiagnosticOptions {
+                identifier: None,
+                inter_file_dependencies: false,
+                workspace_diagnostics: false,
+                work_done_progress_options: WorkDoneProgressOptions {
+                    work_done_progress: None,
+                },
+            },
+        )),
         ..Default::default()
     }
 }

--- a/crates/wgsl-analyzer/src/main_loop.rs
+++ b/crates/wgsl-analyzer/src/main_loop.rs
@@ -373,7 +373,6 @@ impl GlobalState {
     }
 
     #[expect(clippy::cognitive_complexity, reason = "")]
-    #[expect(clippy::too_many_lines, reason = "")]
     fn handle_event(
         &mut self,
         event: Event,

--- a/crates/wgsl-analyzer/src/main_loop.rs
+++ b/crates/wgsl-analyzer/src/main_loop.rs
@@ -744,7 +744,7 @@ impl GlobalState {
             // FIXME: Some of these NO_RETRY could be retries if the file they are interested didn't change.
             // All other request handlers
             .on_with_vfs_default::<lsp_types::request::DocumentDiagnosticRequest>(handlers::request::handle_document_diagnostics, handlers::request::empty_diagnostic_report, || lsp_server::ResponseError {
-                code: lsp_server::ErrorCode::ServerCancelled as i32,
+                code: i32::try_from(lsp_types::error_codes::SERVER_CANCELLED).expect("LSP error code must fit in i32"),
                 message: "server cancelled the request".to_owned(),
                 data: serde_json::to_value(lsp_types::DiagnosticServerCancellationData {
                     retrigger_request: true


### PR DESCRIPTION
# Objective

Fixes #260 

## Solution

- Added diagnostics to server capabilities
- added request handler

## Testing

Opened a wgsl file and added syntax errors, e.g. this error successfully appears:
```wgsl
fn f() {
    let x: = 92;
}
```

There are some errors it doesn't catch like missing semicolons but not sure if that's due to the backend? I can't remember if it caught those types of errors.
