### PR TITLE
Add WESL syntax highlighting

### DIFF
--- a/editors/code/syntaxes/wesl.tmLanguage.json
+++ b/editors/code/syntaxes/wesl.tmLanguage.json
@@ -23,7 +23,7 @@
 				},
 				{
 					"comment": "double colon",
-					"name": "keyword.operator.module.wgsl",
+					"name": "keyword.operator.module.wesl",
 					"match": "::"
 				}
 			]

--- a/editors/code/syntaxes/wesl.tmLanguage.json
+++ b/editors/code/syntaxes/wesl.tmLanguage.json
@@ -2,9 +2,31 @@
 	"name": "WESL",
 	"scopeName": "source.wesl",
 	"patterns": [
+		{ "include": "#keywords" },
 		{
 			"comment": "WESL is a superset of WGSL.",
 			"include": "source.wgsl"
 		}
-	]
+	],
+	"repository": {
+		"keywords": {
+			"comment": "WESL specific keywords",
+			"patterns": [
+				{
+					"name": "keyword.control.import.wesl",
+					"match": "\\b(import)\\b"
+				},
+				{
+					"comment": "keywords used in import statements",
+					"name": "keyword.control.wesl",
+					"match": "\\b(package|super|as)\\b"
+				},
+				{
+					"comment": "double colon",
+					"name": "keyword.operator.module.wgsl",
+					"match": "::"
+				}
+			]
+		}
+	}
 }


### PR DESCRIPTION
# Objective

Add syntax highlighting for the WESL import statement.

## Solution

Describe the solution used to achieve the objective above.

I originally thought that I'd have to do more complex stuff like in https://github.com/Geri-Borbas/VSCode.Extension.eppz_Code/blob/master/syntaxes/source.cs.extensions.json , but it turned out to be really straightforward.

## Testing

I manually tested it with strings like `import self::foo::{bar as baz, nya};`, and with the "inspect scopes" command.

## Showcase

Ignore the squiggly red line.
![image](https://github.com/user-attachments/assets/7bebd546-31b2-45ea-bb2d-7662670b07e1)

