### PR TITLE
Migrate to new parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lelwel"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90908b03bb7678cea38b5364db7483b59031be0529f3ff7c72e3cd9ae0dad54"
+dependencies = [
+ "codespan-reporting",
+ "logos 0.15.0",
+]
+
+[[package]]
 name = "lexopt"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,7 +1001,32 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
 dependencies = [
- "logos-derive",
+ "logos-derive 0.12.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6f536c1af4c7cc81edf73da1f8029896e7e1e16a219ef09b184e76a296f3db"
+dependencies = [
+ "logos-derive 0.15.0",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189bbfd0b61330abea797e5e9276408f2edbe4f822d7ad08685d67419aafb34e"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.5",
+ "rustc_version",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1006,6 +1041,15 @@ dependencies = [
  "quote",
  "regex-syntax 0.6.29",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebfe8e1a19049ddbfccbd14ac834b215e11b85b90bab0c2dba7c7b92fb5d5cba"
+dependencies = [
+ "logos-codegen",
 ]
 
 [[package]]
@@ -1328,7 +1372,8 @@ dependencies = [
  "drop_bomb",
  "edition",
  "expect-test",
- "logos",
+ "lelwel",
+ "logos 0.12.1",
  "rowan",
 ]
 
@@ -1666,6 +1711,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -21,5 +21,8 @@ edition.workspace = true
 [dev-dependencies]
 expect-test.workspace = true
 
+[build-dependencies]
+lelwel = "0.9.1"
+
 [lints]
 workspace = true

--- a/crates/parser/build.rs
+++ b/crates/parser/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    lelwel::build("src/wesl.llw");
+}

--- a/crates/parser/src/grammar.rs
+++ b/crates/parser/src/grammar.rs
@@ -456,7 +456,7 @@ pub(crate) fn type_declaration(parser: &mut Parser<'_, '_>) -> Option<CompletedM
             _ = marker.complete(parser, SyntaxKind::FieldExpression);
         }
 
-        Some(marker_ty.complete(parser, SyntaxKind::PathType))
+        Some(marker_ty.complete(parser, SyntaxKind::TypeExpression))
     } else {
         // TODO remove this branch
         parser.error();

--- a/crates/parser/src/lexer2.rs
+++ b/crates/parser/src/lexer2.rs
@@ -1,0 +1,275 @@
+use super::parser2::{Diagnostic, Span};
+use logos::{Lexer, Logos};
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(logos::Logos, Debug, Copy, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[repr(u16)]
+pub enum Token {
+    EOF,
+    #[token("enable")]
+    Enable,
+    #[token("requires")]
+    Requires,
+    #[token("fn")]
+    Fn,
+    #[token("alias")]
+    Alias,
+    #[token("struct")]
+    Struct,
+    #[token("var")]
+    Var,
+    #[token("const_assert")]
+    ConstAssert,
+    #[token("if")]
+    If,
+    #[token("for")]
+    For,
+    #[token("else")]
+    Else,
+    #[token("loop")]
+    Loop,
+    #[token("break")]
+    Break,
+    #[token("while")]
+    While,
+    #[token("return")]
+    Return,
+    #[token("switch")]
+    Switch,
+    #[token("discard")]
+    Discard,
+    #[token("continuing")]
+    Continuing,
+    #[token("const")]
+    Const,
+    #[token("case")]
+    Case,
+    #[token("default")]
+    Default,
+    #[token("override")]
+    Override,
+    #[token("continue")]
+    Continue,
+    #[token("let")]
+    Let,
+    #[token("true")]
+    True,
+    #[token("false")]
+    False,
+    #[token("diagnostic")]
+    Diagnostic,
+    #[token(";")]
+    Semi,
+    #[token("(")]
+    LPar,
+    #[token(")")]
+    RPar,
+    #[token(",")]
+    Comma,
+    #[token("=")]
+    Eq,
+    #[token(":")]
+    Colon,
+    #[token("{")]
+    LBrace,
+    #[token("}")]
+    RBrace,
+    #[token("->")]
+    MinusGt,
+    #[token("<")]
+    Lt,
+    #[token(">")]
+    Gt,
+    #[token(".")]
+    Dot,
+    #[token("@")]
+    At,
+    #[token("[")]
+    LBrak,
+    #[token("]")]
+    RBrak,
+    #[token("&")]
+    And,
+    #[token("!")]
+    Excl,
+    #[token("*")]
+    Star,
+    #[token("-")]
+    Minus,
+    #[token("~")]
+    Tilde,
+    #[token("+")]
+    Plus,
+    #[token("==")]
+    Eq2,
+    #[token("|")]
+    Pipe,
+    #[token("&&")]
+    And2,
+    #[token("/")]
+    Slash,
+    #[token("^")]
+    Caret,
+    #[token("||")]
+    Pipe2,
+    #[token("!=")]
+    ExclEq,
+    #[token("%")]
+    Percent,
+    #[token("_")]
+    Underscore,
+    #[token("&=")]
+    AndEq,
+    #[token("*=")]
+    StarEq,
+    #[token("+=")]
+    PlusEq,
+    #[token("|=")]
+    PipeEq,
+    #[token("-=")]
+    MinusEq,
+    #[token("/=")]
+    SlashEq,
+    #[token("^=")]
+    CaretEq,
+    #[token("%=")]
+    PercentEq,
+    #[token("++")]
+    Plus2,
+    #[token("--")]
+    Minus2,
+    #[regex(r"([_\p{XID_Start}][\p{XID_Continue}]+)|[\p{XID_Start}]")]
+    Ident,
+    #[regex(r"0[fh]")]
+    #[regex(r"[1-9][0-9]*[fh]")]
+    #[regex(r"[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?[fh]?", priority = 5)]
+    #[regex(r"[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?[fh]?")]
+    #[regex(r"[0-9]+[eE][+-]?[0-9]+[fh]?")]
+    #[regex(
+        r"0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP][+-]?[0-9]+[fh]?)?",
+        priority = 9
+    )]
+    #[regex(r"0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP][+-]?[0-9]+[fh]?)?")]
+    #[regex(r"0[xX][0-9a-fA-F]+[pP][+-]?[0-9]+[fh]?")]
+    FloatLiteral,
+    #[regex(r"0[iu]?")]
+    #[regex(r"[1-9][0-9]*[iu]?")]
+    #[regex(r"0[xX][0-9a-fA-F]+[iu]?")]
+    IntLiteral,
+    #[regex("[\x20\x09\x0A-\x0D\u{0085}\u{200E}\u{200F}\u{2028}\u{2029}]+")]
+    Whitespace,
+    #[token("//", lex_line_ending_comment)]
+    #[token("/*", lex_block_comment)]
+    Comment,
+
+    #[error]
+    Error,
+}
+
+/// A line-ending comment is a kind of comment consisting of the two code points `//` (U+002F followed by U+002F)
+/// and the code points that follow, up until but not including:
+/// - the next line break, or
+/// - the end of the program.
+fn lex_line_ending_comment(lexer: &mut logos::Lexer<'_, Token>) {
+    let remainder = lexer.remainder();
+
+    // see blankspace and line breaks: https://www.w3.org/TR/WGSL/#blankspace-and-line-breaks
+    let line_end = remainder
+        .char_indices()
+        .find(|(_, character)| is_line_ending_comment_end(*character))
+        .map_or(remainder.len(), |(index, _)| index);
+    lexer.bump(line_end);
+}
+
+/// See: <https://www.w3.org/TR/WGSL/#blankspace-and-line-breaks>
+fn is_line_ending_comment_end(character: char) -> bool {
+    [
+        '\u{000A}', // line feed
+        '\u{000B}', // vertical tab
+        '\u{000C}', // form feed
+        '\u{000D}', // carriage return when not also followed by line feed or carriage return followed by line feed
+        '\u{0085}', // next line
+        '\u{2028}', // line separator
+        '\u{2029}', // paragraph separator
+    ]
+    .contains(&character)
+}
+
+fn lex_block_comment(lexer: &mut logos::Lexer<'_, Token>) -> Option<()> {
+    let mut depth = 1;
+    let slice = lexer.remainder();
+    let mut index = 0;
+    let bytes = slice.as_bytes();
+    while index + 1 < bytes.len() {
+        if bytes[index] == b'/' && bytes[index + 1] == b'*' {
+            depth += 1;
+            index += 2;
+        } else if bytes[index] == b'*' && bytes[index + 1] == b'/' {
+            depth -= 1;
+            index += 2;
+            if depth == 0 {
+                lexer.bump(index);
+                return Some(());
+            }
+        } else {
+            index += 1;
+        }
+    }
+    // If we reach here, the comment was unterminated; consume the rest.
+    lexer.bump(index);
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+    use logos::Logos as _;
+
+    use super::Token;
+
+    #[expect(clippy::needless_pass_by_value, reason = "intended API")]
+    fn check_lex(
+        source: &str,
+        expect: expect_test::Expect,
+    ) {
+        let tokens: Vec<_> = Token::lexer(source).collect();
+        expect.assert_eq(&format!("{tokens:?}"));
+    }
+
+    #[test]
+    fn lex_decimal_float() {
+        check_lex("10.0", expect![["[DecimalFloatLiteral]"]]);
+        check_lex("-10.0", expect![["[DecimalFloatLiteral]"]]);
+        check_lex("1e9f", expect![["[DecimalFloatLiteral]"]]);
+        check_lex("-0.0e7", expect![["[DecimalFloatLiteral]"]]);
+        check_lex(".1", expect![["[DecimalFloatLiteral]"]]);
+        check_lex("1.", expect![["[DecimalFloatLiteral]"]]);
+    }
+
+    #[test]
+    fn lex_hex_float() {
+        check_lex("0x0.0", expect![["[HexFloatLiteral]"]]);
+        check_lex("0X1p9", expect![["[HexFloatLiteral]"]]);
+        check_lex("-0x0.0", expect![["[HexFloatLiteral]"]]);
+        check_lex("0xff.13p13", expect![["[HexFloatLiteral]"]]);
+    }
+
+    #[test]
+    fn lex_comment() {
+        check_lex(
+            "// test asdf\nnot_comment",
+            expect!["[LineEndingComment, Blankspace, Identifier]"],
+        );
+    }
+
+    #[test]
+    fn lex_nested_brackets() {
+        // Expect: Identifier (a), [, Identifier (a), [, DecimalIntLiteral (0), ], ]
+        check_lex(
+            "a[a[0]]",
+            expect![[
+                "[Identifier, BracketLeft, Identifier, BracketLeft, DecimalIntLiteral, BracketRight, BracketRight]"
+            ]],
+        );
+    }
+}

--- a/crates/parser/src/lexer2.rs
+++ b/crates/parser/src/lexer2.rs
@@ -75,7 +75,7 @@ pub enum Token {
     #[token("}")]
     RBrace,
     #[token("->")]
-    MinusGt,
+    Arrow,
     #[token("<")]
     Lt,
     #[token(">")]
@@ -139,28 +139,32 @@ pub enum Token {
     #[token("--")]
     Minus2,
     #[regex(r"([_\p{XID_Start}][\p{XID_Continue}]+)|[\p{XID_Start}]")]
-    IdentPat,
+    Ident,
     #[regex(r"0[fh]")]
     #[regex(r"[1-9][0-9]*[fh]")]
+    // We need priorities so that we avoid the fact that e.g. 1.2 would match both otherwise
     #[regex(r"[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?[fh]?", priority = 5)]
     #[regex(r"[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?[fh]?")]
     #[regex(r"[0-9]+[eE][+-]?[0-9]+[fh]?")]
+    FloatLiteral,
     #[regex(
         r"0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP][+-]?[0-9]+[fh]?)?",
         priority = 9
     )]
     #[regex(r"0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP][+-]?[0-9]+[fh]?)?")]
     #[regex(r"0[xX][0-9a-fA-F]+[pP][+-]?[0-9]+[fh]?")]
-    FloatLiteral,
+    HexFloatLiteral,
     #[regex(r"0[iu]?")]
     #[regex(r"[1-9][0-9]*[iu]?")]
-    #[regex(r"0[xX][0-9a-fA-F]+[iu]?")]
     IntLiteral,
+    #[regex(r"0[xX][0-9a-fA-F]+[iu]?")]
+    HexIntLiteral,
     #[regex("[\x20\x09\x0A-\x0D\u{0085}\u{200E}\u{200F}\u{2028}\u{2029}]+")]
     Whitespace,
     #[token("//", lex_line_ending_comment)]
+    LineEndingComment,
     #[token("/*", lex_block_comment)]
-    Comment,
+    BlockComment,
 
     #[error]
     Error,

--- a/crates/parser/src/lexer2.rs
+++ b/crates/parser/src/lexer2.rs
@@ -139,7 +139,7 @@ pub enum Token {
     #[token("--")]
     Minus2,
     #[regex(r"([_\p{XID_Start}][\p{XID_Continue}]+)|[\p{XID_Start}]")]
-    Ident,
+    IdentPat,
     #[regex(r"0[fh]")]
     #[regex(r"[1-9][0-9]*[fh]")]
     #[regex(r"[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?[fh]?", priority = 5)]

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -128,7 +128,7 @@ pub enum ParseEntryPoint {
     Expression,
     Statement,
     Type,
-    AttributeList,
+    Attribute,
     FunctionParameterList,
 }
 
@@ -143,7 +143,7 @@ pub fn parse_entrypoint(
         ParseEntryPoint::Type => parse::<_>(input, |parser| {
             grammar::type_declaration(parser);
         }),
-        ParseEntryPoint::AttributeList => parse::<_>(input, grammar::attribute_list),
+        ParseEntryPoint::Attribute => parse::<_>(input, grammar::attribute_list),
         ParseEntryPoint::FunctionParameterList => parse::<_>(input, grammar::inner_parameter_list),
     }
 }
@@ -159,7 +159,7 @@ fn check_entrypoint(
     entry_point: ParseEntryPoint,
     expected_tree: &expect_test::Expect,
 ) {
-    let parse = crate::parse_entrypoint(input, entry_point);
+    let parse = crate::parser2::parse_entrypoint(input, entry_point);
     expected_tree.assert_eq(&parse.debug_tree());
 }
 

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -3,7 +3,9 @@
 mod event;
 mod grammar;
 mod lexer;
+mod lexer2;
 mod parser;
+mod parser2;
 mod sink;
 mod source;
 mod syntax_kind;

--- a/crates/parser/src/parser2.rs
+++ b/crates/parser/src/parser2.rs
@@ -1,17 +1,27 @@
 #![allow(elided_lifetimes_in_paths)]
 use logos::Logos;
 use rowan::{GreenNode, GreenNodeBuilder};
+use std::fmt::{self, Write as _};
 
-use crate::ParseEntryPoint;
+use crate::{ParseEntryPoint, SyntaxKind};
 
 use super::lexer2::Token;
 use std::collections::HashSet;
 
-#[derive(Default)]
 pub struct Context<'a> {
     template_start: HashSet<usize>,
     template_end: HashSet<usize>,
     marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> Default for Context<'a> {
+    fn default() -> Self {
+        Self {
+            template_start: Default::default(),
+            template_end: Default::default(),
+            marker: Default::default(),
+        }
+    }
 }
 
 pub struct Diagnostic {
@@ -19,11 +29,96 @@ pub struct Diagnostic {
     pub range: rowan::TextRange,
 }
 
+impl fmt::Debug for Diagnostic {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        f.debug_struct("Diagnostic")
+            .field("message", &self.message)
+            .field("range", &self.range)
+            .finish()
+    }
+}
+
+impl fmt::Display for Diagnostic {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(
+            f,
+            "error at {}..{}: {}",
+            u32::from(self.range.start()),
+            u32::from(self.range.end()),
+            self.message
+        )
+    }
+}
+
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
 pub struct Parse2 {
     green_node: GreenNode,
-    diags: Vec<Diagnostic>,
+    errors: Vec<Diagnostic>,
+}
+impl fmt::Debug for Parse2 {
+    fn fmt(
+        &self,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        formatter
+            .debug_struct("Parse")
+            .field("green_node", &self.green_node)
+            .field("errors", &self.errors)
+            .finish()
+    }
+}
+
+impl PartialEq for Parse2 {
+    fn eq(
+        &self,
+        other: &Self,
+    ) -> bool {
+        self.green_node == other.green_node
+    }
+}
+
+impl Eq for Parse2 {}
+
+impl Parse2 {
+    #[must_use]
+    pub fn debug_tree(&self) -> String {
+        let mut buffer = String::new();
+
+        let tree = format!("{:#?}", self.syntax());
+
+        // We cut off the last byte because formatting the SyntaxNode adds on a newline at the end.
+        buffer.push_str(&tree[0..tree.len() - 1]);
+
+        if !self.errors.is_empty() {
+            buffer.push('\n');
+        }
+        for diagnostic in &self.errors {
+            write!(buffer, "\n{diagnostic}");
+        }
+        buffer
+    }
+
+    #[must_use]
+    pub fn syntax(&self) -> rowan::SyntaxNode<crate::syntax_kind::WeslLanguage> {
+        rowan::SyntaxNode::new_root(self.green_node.clone())
+    }
+
+    #[must_use]
+    pub fn errors(&self) -> &[Diagnostic] {
+        &self.errors
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (GreenNode, Vec<Diagnostic>) {
+        (self.green_node, self.errors)
+    }
 }
 
 pub fn parse_entrypoint(
@@ -32,9 +127,7 @@ pub fn parse_entrypoint(
 ) -> Parse2 {
     let mut diags = Vec::new();
     let parsed = match entrypoint {
-        ParseEntryPoint::File => {
-            Parser::parse_generic(input, &mut diags, Parser::rule_translation_unit)
-        },
+        ParseEntryPoint::File => Parser::parse(input, &mut diags),
         ParseEntryPoint::Expression => {
             Parser::parse_generic(input, &mut diags, Parser::rule_expression)
         },
@@ -42,108 +135,267 @@ pub fn parse_entrypoint(
             Parser::parse_generic(input, &mut diags, Parser::rule_statement)
         },
         ParseEntryPoint::Type => {
-            Parser::parse_generic(input, &mut diags, Parser::rule_type_specifier)
+            Parser::parse_generic(input, &mut diags, Parser::rule_type_expression)
         },
-        ParseEntryPoint::AttributeList => {
-            todo!(
-                "Not supported. I think we can get rid of this, or replace it with a single attribute parser"
-            )
+        ParseEntryPoint::Attribute => {
+            Parser::parse_generic(input, &mut diags, Parser::rule_attribute)
         },
         ParseEntryPoint::FunctionParameterList => {
-            todo!("Ask Benjamin what this is for")
+            todo!("Remove this")
         },
     };
-    let mut builder = GreenNodeBuilder::new();
-    build_cst(&mut builder, parsed, NodeRef::ROOT);
+    let green_node = CstBuilder {
+        builder: GreenNodeBuilder::new(),
+        cst: parsed,
+    }
+    .build();
     Parse2 {
-        green_node: builder.finish(),
-        diags,
+        green_node,
+        errors: diags,
     }
 }
 
-fn build_cst(
-    builder: &mut GreenNodeBuilder,
-    cst: Cst<'_>,
-    node_ref: NodeRef,
-) {
-    // TODO: Make the SyntaxKind closely follow the wgsl spec
-    match cst.get(node_ref) {
-        Node::Rule(rule, end_offset) => {},
-        Node::Token(token, index) => match token {
-            Token::EOF => todo!(),
-            Token::Enable => todo!(),
+struct CstBuilder<'a, 'cache> {
+    builder: GreenNodeBuilder<'cache>,
+    cst: Cst<'a>,
+}
+impl<'a, 'cache> CstBuilder<'a, 'cache> {
+    /// Turn a lelwel syntax tree into a rowan syntax tree
+    fn build(mut self) -> GreenNode {
+        let mut rule_ends = vec![];
+        for offset in 0..self.cst.nodes.len() {
+            let node_ref = NodeRef(offset);
+            let node = self.cst.get(node_ref);
+            match node {
+                Node::Rule(rule, end_offset) => {
+                    self.start_rule(rule);
+                    let end_offset = usize::from(end_offset);
+                    if end_offset > 0 {
+                        rule_ends.push((node_ref, rule, offset + end_offset));
+                    } else {
+                        self.end_rule(node_ref, rule);
+                    }
+                },
+                Node::Token(token, index) => self.token(token, index),
+            }
+
+            while let Some((node_ref, rule, _)) = rule_ends.pop_if(|(_, _, end)| offset >= *end) {
+                self.end_rule(node_ref, rule);
+            }
+        }
+        assert_eq!(rule_ends.len(), 0, "All rules should have been consumed");
+
+        self.builder.finish()
+    }
+
+    fn start_rule(
+        &mut self,
+        rule: Rule,
+    ) {
+        match rule {
+            Rule::Arguments => self.start_node(SyntaxKind::Arguments),
+            Rule::ArgumentExpressionList => panic!("should be a Arguments instead"),
+            Rule::ArgumentExpressionListExpr => {
+                panic!("should be a Arguments instead")
+            },
+            Rule::AssertStatement => todo!(),
+            Rule::Attribute => self.start_node(SyntaxKind::Attribute),
+            Rule::BinaryExpression => todo!(),
+            Rule::Literal => self.start_node(SyntaxKind::Literal),
+            Rule::BreakIfStatement => todo!(),
+            Rule::BreakStatement => todo!(),
+            Rule::CaseClause => todo!(),
+            Rule::CaseSelector => todo!(),
+            Rule::CaseSelectors => todo!(),
+            Rule::CompoundAssignmentOperator => todo!(),
+            Rule::CompoundAssignmentStatement => todo!(),
+            Rule::CompoundStatement => todo!(),
+            Rule::ConstDeclaration => todo!(),
+            Rule::ContinueStatement => todo!(),
+            Rule::ContinuingStatement => todo!(),
+            Rule::DecrementStatement => todo!(),
+            Rule::DefaultAloneClause => todo!(),
+            Rule::DiagnosticAttr => todo!(),
+            Rule::DiagnosticControl => todo!(),
+            Rule::DiagnosticDirective => todo!(),
+            Rule::DiagnosticRuleName => todo!(),
+            Rule::DiscardStatement => todo!(),
+            Rule::ElseClause => todo!(),
+            Rule::ElseIfClause => todo!(),
+            Rule::EmptyStatement => todo!(),
+            Rule::EnableDirective => todo!(),
+            Rule::Error => todo!(),
+            Rule::ExprTemplateList => todo!(),
+            Rule::Expression => panic!("expressions should always be a more specific node"),
+            Rule::FieldExpression => todo!(),
+            Rule::ForInit => todo!(),
+            Rule::ForStatement => todo!(),
+            Rule::ForUpdate => todo!(),
+            Rule::FunctionCall => self.start_node(SyntaxKind::FunctionCall),
+            Rule::FunctionCallStatement => self.start_node(SyntaxKind::FunctionCallStatement),
+            Rule::FunctionDeclaration => todo!(),
+            Rule::FunctionHeader => todo!(),
+            Rule::GlobalAssert => todo!(),
+            Rule::GlobalDeclaration => todo!(),
+            Rule::GlobalDirective => todo!(),
+            Rule::GlobalItem => todo!(),
+            Rule::GlobalValueDeclaration => todo!(),
+            Rule::GlobalVariableDeclaration => todo!(),
+            // TODO: Do we keep the Name node, or does it not add anything of value?
+            // (Defer this decision until we've added the wesl::qualified::idents)
+            Rule::FullIdent => self.start_node(SyntaxKind::Name),
+            Rule::IfClause => todo!(),
+            Rule::IfStatement => todo!(),
+            Rule::IncrementStatement => todo!(),
+            Rule::IndexingExpression => todo!(),
+            Rule::LetDeclaration => todo!(),
+            Rule::LhsExpression => todo!(),
+            Rule::LoopStatement => todo!(),
+            Rule::MemberIdent => todo!(),
+            Rule::OverrideDeclaration => todo!(),
+            Rule::Parameter => self.start_node(SyntaxKind::Parameter),
+            Rule::Parameters => todo!(),
+            Rule::ParenExpression => todo!(),
+            Rule::PhonyAssignmentStatement => todo!(),
+            Rule::RequiresDirective => todo!(),
+            Rule::ReturnStatement => todo!(),
+            Rule::ReturnType => todo!(),
+            Rule::SeverityControlName => todo!(),
+            Rule::SimpleAssignmentStatement => todo!(),
+            Rule::Statement => todo!(),
+            Rule::StructBody => self.start_node(SyntaxKind::StructDeclBody),
+            Rule::StructDeclaration => self.start_node(SyntaxKind::StructDeclaration),
+            Rule::StructMember => self.start_node(SyntaxKind::StructDeclarationField),
+            Rule::SwitchClause => todo!(),
+            Rule::SwitchStatement => todo!(),
+            Rule::TemplateArgs => todo!(),
+            Rule::TemplateList => todo!(),
+            Rule::TranslationUnit => todo!(),
+            Rule::TypeAliasDeclaration => self.start_node(SyntaxKind::TypeAliasDeclaration),
+            Rule::TypeExpression => self.start_node(SyntaxKind::TypeExpression),
+            Rule::TypedIdent => todo!(),
+            Rule::UnaryExpression => todo!(),
+            Rule::VariableDeclaration => todo!(),
+            Rule::VariableOrValue => todo!(),
+            Rule::VariableOrValueStatement => todo!(),
+            Rule::VariableUpdating => todo!(),
+            Rule::WhileStatement => todo!(),
+        }
+    }
+
+    fn start_node(
+        &mut self,
+        node: SyntaxKind,
+    ) {
+        self.builder.start_node(rowan::SyntaxKind::from(node));
+    }
+
+    fn end_rule(
+        &mut self,
+        _node_ref: NodeRef,
+        _rule: Rule,
+    ) {
+        self.builder.finish_node();
+    }
+
+    fn token(
+        &mut self,
+        token: Token,
+        index: CstIndex,
+    ) {
+        if token == Token::EOF {
+            return; // Ignore
+        }
+        let text = &self.cst.source[self.cst.spans[usize::from(index)].clone()];
+        let syntax_kind = SyntaxKind::try_from(token)
+            .unwrap_or_else(|()| panic!("token {token:?} should be convertible to a SyntaxKind"));
+        self.builder.token(syntax_kind.into(), text);
+    }
+}
+
+impl TryFrom<Token> for SyntaxKind {
+    type Error = ();
+
+    fn try_from(value: Token) -> Result<Self, ()> {
+        let output = match value {
+            Token::EOF => return Err(()),
+            Token::Enable => SyntaxKind::Enable,
             Token::Requires => todo!(),
-            Token::Fn => todo!(),
-            Token::Alias => todo!(),
-            Token::Struct => todo!(),
-            Token::Var => todo!(),
+            Token::Fn => SyntaxKind::Fn,
+            Token::Alias => SyntaxKind::Alias,
+            Token::Struct => SyntaxKind::Struct,
+            Token::Var => SyntaxKind::Var,
             Token::ConstAssert => todo!(),
-            Token::If => todo!(),
-            Token::For => todo!(),
-            Token::Else => todo!(),
-            Token::Loop => todo!(),
-            Token::Break => todo!(),
-            Token::While => todo!(),
-            Token::Return => todo!(),
-            Token::Switch => todo!(),
-            Token::Discard => todo!(),
-            Token::Continuing => todo!(),
-            Token::Const => todo!(),
-            Token::Case => todo!(),
-            Token::Default => todo!(),
-            Token::Override => todo!(),
-            Token::Continue => todo!(),
-            Token::Let => todo!(),
-            Token::True => todo!(),
-            Token::False => todo!(),
+            Token::If => SyntaxKind::If,
+            Token::For => SyntaxKind::For,
+            Token::Else => SyntaxKind::Else,
+            Token::Loop => SyntaxKind::Loop,
+            Token::Break => SyntaxKind::Break,
+            Token::While => SyntaxKind::While,
+            Token::Return => SyntaxKind::Return,
+            Token::Switch => SyntaxKind::Switch,
+            Token::Discard => SyntaxKind::Discard,
+            Token::Continuing => SyntaxKind::Continuing,
+            Token::Const => SyntaxKind::Constant,
+            Token::Case => SyntaxKind::Case,
+            Token::Default => SyntaxKind::Default,
+            Token::Override => SyntaxKind::Override,
+            Token::Continue => SyntaxKind::Continue,
+            Token::Let => SyntaxKind::Let,
+            Token::True => SyntaxKind::True,
+            Token::False => SyntaxKind::False,
             Token::Diagnostic => todo!(),
-            Token::Semi => todo!(),
-            Token::LPar => todo!(),
-            Token::RPar => todo!(),
-            Token::Comma => todo!(),
-            Token::Eq => todo!(),
-            Token::Colon => todo!(),
-            Token::LBrace => todo!(),
-            Token::RBrace => todo!(),
-            Token::MinusGt => todo!(),
-            Token::Lt => todo!(),
-            Token::Gt => todo!(),
-            Token::Dot => todo!(),
-            Token::At => todo!(),
-            Token::LBrak => todo!(),
-            Token::RBrak => todo!(),
-            Token::And => todo!(),
-            Token::Excl => todo!(),
-            Token::Star => todo!(),
-            Token::Minus => todo!(),
-            Token::Tilde => todo!(),
-            Token::Plus => todo!(),
-            Token::Eq2 => todo!(),
-            Token::Pipe => todo!(),
-            Token::And2 => todo!(),
-            Token::Slash => todo!(),
-            Token::Caret => todo!(),
-            Token::Pipe2 => todo!(),
-            Token::ExclEq => todo!(),
-            Token::Percent => todo!(),
+            Token::Semi => SyntaxKind::Semicolon,
+            Token::LPar => SyntaxKind::ParenthesisLeft,
+            Token::RPar => SyntaxKind::ParenthesisRight,
+            Token::Comma => SyntaxKind::Comma,
+            Token::Eq => SyntaxKind::Equal,
+            Token::Colon => SyntaxKind::Colon,
+            Token::LBrace => SyntaxKind::BraceLeft,
+            Token::RBrace => SyntaxKind::BraceRight,
+            Token::Arrow => SyntaxKind::Arrow,
+            Token::Lt => SyntaxKind::LessThan,
+            Token::Gt => SyntaxKind::GreaterThan,
+            Token::Dot => SyntaxKind::Period,
+            Token::At => SyntaxKind::AttributeOperator,
+            Token::LBrak => SyntaxKind::BracketLeft,
+            Token::RBrak => SyntaxKind::BracketRight,
+            Token::And => SyntaxKind::And,
+            Token::Excl => SyntaxKind::Bang,
+            Token::Star => SyntaxKind::Star,
+            Token::Minus => SyntaxKind::Minus,
+            Token::Tilde => SyntaxKind::Tilde,
+            Token::Plus => SyntaxKind::Plus,
+            Token::Eq2 => SyntaxKind::EqualEqual,
+            Token::Pipe => SyntaxKind::Or,
+            Token::And2 => SyntaxKind::AndAnd,
+            Token::Slash => SyntaxKind::ForwardSlash,
+            Token::Caret => SyntaxKind::Xor,
+            Token::Pipe2 => SyntaxKind::OrOr,
+            Token::ExclEq => SyntaxKind::NotEqual,
+            Token::Percent => SyntaxKind::Modulo,
             Token::Underscore => todo!(),
-            Token::AndEq => todo!(),
-            Token::StarEq => todo!(),
-            Token::PlusEq => todo!(),
-            Token::PipeEq => todo!(),
-            Token::MinusEq => todo!(),
-            Token::SlashEq => todo!(),
-            Token::CaretEq => todo!(),
-            Token::PercentEq => todo!(),
-            Token::Plus2 => todo!(),
-            Token::Minus2 => todo!(),
-            Token::IdentPat => todo!(),
-            Token::FloatLiteral => todo!(),
-            Token::IntLiteral => todo!(),
-            Token::Whitespace => todo!(),
-            Token::Comment => todo!(),
-            Token::Error => todo!(),
-        },
+            Token::AndEq => SyntaxKind::AndEqual,
+            Token::StarEq => SyntaxKind::TimesEqual,
+            Token::PlusEq => SyntaxKind::PlusEqual,
+            Token::PipeEq => SyntaxKind::OrEqual,
+            Token::MinusEq => SyntaxKind::MinusEqual,
+            Token::SlashEq => SyntaxKind::DivisionEqual,
+            Token::CaretEq => SyntaxKind::XorEqual,
+            Token::PercentEq => SyntaxKind::ModuloEqual,
+            Token::Plus2 => SyntaxKind::PlusPlus,
+            Token::Minus2 => SyntaxKind::MinusMinus,
+            Token::Ident => SyntaxKind::Identifier,
+            Token::FloatLiteral => SyntaxKind::DecimalFloatLiteral,
+            Token::HexFloatLiteral => SyntaxKind::HexFloatLiteral,
+            Token::IntLiteral => SyntaxKind::DecimalIntLiteral,
+            Token::HexIntLiteral => SyntaxKind::HexIntLiteral,
+            Token::Whitespace => SyntaxKind::Blankspace,
+            Token::LineEndingComment => SyntaxKind::LineEndingComment,
+            Token::BlockComment => SyntaxKind::BlockComment,
+            Token::Error => SyntaxKind::Error,
+        };
+        Ok(output)
     }
 }
 
@@ -170,6 +422,7 @@ impl<'a> Parser<'a> {
             error_cooldown: false,
             in_ordered_choice: false,
         };
+        parser.init_skip();
         start_rule(&mut parser, diags);
         parser.cst
     }
@@ -283,8 +536,8 @@ impl<'a> ParserCallbacks for Parser<'a> {
         source: &str,
         _diags: &mut Vec<Diagnostic>,
     ) -> (Vec<Token>, Vec<Span>) {
-        let tokens: Vec<_> = Token::lexer(source).collect();
-        (tokens, vec![])
+        let (tokens, spans): (Vec<_>, Vec<_>) = Token::lexer(source).spanned().collect();
+        (tokens, spans)
     }
     fn create_diagnostic(
         &self,
@@ -309,9 +562,6 @@ impl<'a> ParserCallbacks for Parser<'a> {
     }
     fn predicate_struct_body_1(&self) -> bool {
         self.peek(1) != Token::RBrace
-    }
-    fn predicate_attribute_1(&self) -> bool {
-        self.peek(1) != Token::RPar
     }
     fn action_template_list_1(
         &mut self,

--- a/crates/parser/src/parser2.rs
+++ b/crates/parser/src/parser2.rs
@@ -231,6 +231,7 @@ impl<'a, 'cache> CstBuilder<'a, 'cache> {
             Rule::ForInit => todo!(),
             Rule::ForStatement => todo!(),
             Rule::ForUpdate => todo!(),
+            Rule::FullIdent => panic!("full idents should be flattened"),
             Rule::FunctionCall => self.start_node(SyntaxKind::FunctionCall),
             Rule::FunctionCallStatement => self.start_node(SyntaxKind::FunctionCallStatement),
             Rule::FunctionDeclaration => todo!(),
@@ -241,9 +242,7 @@ impl<'a, 'cache> CstBuilder<'a, 'cache> {
             Rule::GlobalItem => todo!(),
             Rule::GlobalValueDeclaration => todo!(),
             Rule::GlobalVariableDeclaration => todo!(),
-            // TODO: Do we keep the Name node, or does it not add anything of value?
-            // (Defer this decision until we've added the wesl::qualified::idents)
-            Rule::FullIdent => self.start_node(SyntaxKind::Name),
+            Rule::IdentExpression => todo!(),
             Rule::IfClause => todo!(),
             Rule::IfStatement => todo!(),
             Rule::IncrementStatement => todo!(),
@@ -269,7 +268,7 @@ impl<'a, 'cache> CstBuilder<'a, 'cache> {
             Rule::SwitchClause => todo!(),
             Rule::SwitchStatement => todo!(),
             Rule::TemplateArgs => todo!(),
-            Rule::TemplateList => todo!(),
+            Rule::TemplateList => self.start_node(SyntaxKind::GenericArgumentList),
             Rule::TranslationUnit => todo!(),
             Rule::TypeAliasDeclaration => self.start_node(SyntaxKind::TypeAliasDeclaration),
             Rule::TypeExpression => self.start_node(SyntaxKind::TypeExpression),

--- a/crates/parser/src/parser2.rs
+++ b/crates/parser/src/parser2.rs
@@ -1,0 +1,293 @@
+#![allow(elided_lifetimes_in_paths)]
+use logos::Logos;
+use rowan::GreenNode;
+
+use crate::ParseEntryPoint;
+
+use super::lexer2::Token;
+use std::collections::HashSet;
+
+#[derive(Default)]
+pub struct Context<'a> {
+    template_start: HashSet<usize>,
+    template_end: HashSet<usize>,
+    marker: std::marker::PhantomData<&'a ()>,
+}
+
+pub struct Diagnostic {
+    pub message: String,
+    pub range: rowan::TextRange,
+}
+
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+pub struct Parse2 {
+    green_node: GreenNode,
+    diags: Vec<Diagnostic>,
+}
+
+pub fn parse_entrypoint(
+    input: &str,
+    entrypoint: ParseEntryPoint,
+) -> Parse2 {
+    let mut diags = Vec::new();
+    let parsed = match entrypoint {
+        ParseEntryPoint::File => {
+            Parser::parse_generic(input, &mut diags, Parser::rule_translation_unit)
+        },
+        ParseEntryPoint::Expression => {
+            Parser::parse_generic(input, &mut diags, Parser::rule_expression)
+        },
+        ParseEntryPoint::Statement => {
+            Parser::parse_generic(input, &mut diags, Parser::rule_statement)
+        },
+        ParseEntryPoint::Type => {
+            Parser::parse_generic(input, &mut diags, Parser::rule_type_specifier)
+        },
+        ParseEntryPoint::AttributeList => {
+            todo!(
+                "Not supported. I think we can get rid of this, or replace it with a single attribute parser"
+            )
+        },
+        ParseEntryPoint::FunctionParameterList => {
+            todo!("Ask Benjamin what this is for")
+        },
+    };
+
+    Parse2 {
+        green_node: todo!(),
+        diags,
+    }
+}
+
+impl<'a> Parser<'a> {
+    /// Returns the CST for a parse with the given `source` file and writes diagnostics to `diags`.
+    ///
+    /// The context can be explicitly defined for the parse.
+    pub fn parse_with_context_generic<Function: Fn(&mut Parser<'a>, &mut Vec<Diagnostic>)>(
+        source: &'a str,
+        diags: &mut Vec<Diagnostic>,
+        context: Context<'a>,
+        start_rule: Function,
+    ) -> Cst<'a> {
+        let (tokens, spans) = Self::create_tokens(source, diags);
+        let max_offset = source.len();
+        let mut parser = Self {
+            current: Token::EOF,
+            cst: Cst::new(source, spans),
+            tokens,
+            pos: 0,
+            last_error_span: Span::default(),
+            max_offset,
+            context,
+            error_cooldown: false,
+            in_ordered_choice: false,
+        };
+        start_rule(&mut parser, diags);
+        parser.cst
+    }
+    /// Returns the CST for a parse with the given `source` file and writes diagnostics to `diags`.
+    ///
+    /// The context will be default initialized for the parse.
+    pub fn parse_generic<Function: Fn(&mut Parser<'a>, &mut Vec<Diagnostic>)>(
+        source: &'a str,
+        diags: &mut Vec<Diagnostic>,
+        start_rule: Function,
+    ) -> Cst<'a> {
+        Self::parse_with_context_generic(source, diags, Context::default(), start_rule)
+    }
+
+    fn is_swizzle_name(&self) -> bool {
+        let name = self.cst.source[self.span()].as_bytes();
+        matches!(
+            name,
+            [b'r' | b'g' | b'b' | b'a']
+                | [b'r' | b'g' | b'b' | b'a', b'r' | b'g' | b'b' | b'a']
+                | [
+                    b'r' | b'g' | b'b' | b'a',
+                    b'r' | b'g' | b'b' | b'a',
+                    b'r' | b'g' | b'b' | b'a'
+                ]
+                | [
+                    b'r' | b'g' | b'b' | b'a',
+                    b'r' | b'g' | b'b' | b'a',
+                    b'r' | b'g' | b'b' | b'a',
+                    b'r' | b'g' | b'b' | b'a'
+                ]
+                | [b'x' | b'y' | b'z' | b'w']
+                | [b'x' | b'y' | b'z' | b'w', b'x' | b'y' | b'z' | b'w']
+                | [
+                    b'x' | b'y' | b'z' | b'w',
+                    b'x' | b'y' | b'z' | b'w',
+                    b'x' | b'y' | b'z' | b'w'
+                ]
+                | [
+                    b'x' | b'y' | b'z' | b'w',
+                    b'x' | b'y' | b'z' | b'w',
+                    b'x' | b'y' | b'z' | b'w',
+                    b'x' | b'y' | b'z' | b'w'
+                ]
+        )
+    }
+    fn find_template_list(&mut self) {
+        if self.context.template_start.contains(&self.pos) {
+            return;
+        }
+        let mut nesting_depth = 0usize;
+        let mut pending = vec![];
+        let mut last_lt_offset = 0;
+        for (offset, tok) in self.tokens[self.pos..].iter().enumerate() {
+            match tok {
+                Token::LPar | Token::LBrak => nesting_depth += 1,
+                Token::RPar | Token::RBrak => {
+                    while let Some((_, pending_nesting_depth)) = pending.last().copied() {
+                        if pending_nesting_depth < nesting_depth {
+                            break;
+                        } else {
+                            pending.pop();
+                        }
+                    }
+                    nesting_depth = nesting_depth.saturating_sub(1);
+                },
+                Token::Semi | Token::LBrace | Token::Colon => break,
+                Token::And2 | Token::Pipe2 => {
+                    while let Some((_, pending_nesting_depth)) = pending.last().copied() {
+                        if pending_nesting_depth < nesting_depth {
+                            break;
+                        } else {
+                            pending.pop();
+                        }
+                    }
+                },
+                Token::Lt | Token::Eq if offset == last_lt_offset + 1 => {
+                    pending.pop();
+                },
+                Token::Lt => {
+                    last_lt_offset = offset;
+                    pending.push((self.pos + offset, nesting_depth));
+                },
+                Token::Gt => {
+                    if let Some((pending_pos, pending_nesting_depth)) = pending.last().copied() {
+                        if pending_nesting_depth == nesting_depth {
+                            pending.pop();
+                            self.context.template_start.insert(pending_pos);
+                            self.context.template_end.insert(self.pos + offset);
+                        }
+                    }
+                },
+                _ => {},
+            }
+            if pending.is_empty() {
+                break;
+            }
+        }
+    }
+    fn is_func_call(&self) -> bool {
+        matches!(self.peek(1), Token::LPar | Token::Lt) && self.peek(2) != Token::Lt
+    }
+    fn is_diagnostic(&self) -> bool {
+        &self.cst.source[self.span()] == "diagnostic"
+    }
+}
+
+impl<'a> ParserCallbacks for Parser<'a> {
+    fn create_tokens(
+        source: &str,
+        _diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
+        let tokens: Vec<_> = Token::lexer(source).collect();
+        (tokens, vec![])
+    }
+    fn create_diagnostic(
+        &self,
+        span: Span,
+        message: String,
+    ) -> Diagnostic {
+        let range = {
+            let std::ops::Range { start, end } = span;
+            let start = rowan::TextSize::try_from(start).unwrap();
+            let end = rowan::TextSize::try_from(end).unwrap();
+
+            rowan::TextRange::new(start, end)
+        };
+
+        Diagnostic { message, range }
+    }
+    fn predicate_global_directive_1(&self) -> bool {
+        self.peek(1) != Token::Semi
+    }
+    fn predicate_parameters_1(&self) -> bool {
+        self.peek(1) != Token::RPar
+    }
+    fn predicate_struct_body_1(&self) -> bool {
+        self.peek(1) != Token::RBrace
+    }
+    fn predicate_attribute_1(&self) -> bool {
+        self.peek(1) != Token::RPar
+    }
+    fn action_template_list_1(
+        &mut self,
+        _diags: &mut Vec<Diagnostic>,
+    ) {
+        self.find_template_list();
+    }
+    fn action_expr_template_list_1(
+        &mut self,
+        _diags: &mut Vec<Diagnostic>,
+    ) {
+        if self.current == Token::Lt {
+            self.find_template_list();
+        }
+    }
+    fn predicate_expr_template_list_1(&self) -> bool {
+        self.context.template_start.contains(&self.pos)
+    }
+    fn predicate_template_args_1(&self) -> bool {
+        self.peek(1) != Token::Gt
+    }
+    fn predicate_expression_1(&self) -> bool {
+        self.is_swizzle_name()
+    }
+    fn predicate_expression_2(&self) -> bool {
+        if self.current == Token::Gt && self.context.template_end.contains(&self.pos) {
+            return false;
+        }
+        self.tokens[self.pos + 1] == self.current
+    }
+    fn predicate_expression_3(&self) -> bool {
+        self.current != Token::Gt || !self.context.template_end.contains(&self.pos)
+    }
+    fn predicate_expression_4(&self) -> bool {
+        self.tokens[self.pos + 1] != Token::Eq
+    }
+    fn predicate_argument_expression_list_1(&self) -> bool {
+        self.peek(1) != Token::RPar
+    }
+    fn predicate_argument_expression_list_expr_1(&self) -> bool {
+        self.peek(1) != Token::RPar
+    }
+    fn predicate_statement_1(&self) -> bool {
+        self.peek(1) == Token::If
+    }
+    fn predicate_statement_2(&self) -> bool {
+        self.is_func_call()
+    }
+    fn predicate_continuing_statement_1(&self) -> bool {
+        self.peek(1) != Token::If
+    }
+    fn predicate_for_init_1(&self) -> bool {
+        self.is_func_call()
+    }
+    fn predicate_for_update_1(&self) -> bool {
+        self.is_func_call()
+    }
+    fn predicate_case_selectors_1(&self) -> bool {
+        !matches!(self.peek(1), Token::At | Token::Colon | Token::LBrace)
+    }
+    fn predicate_compound_assignment_operator_1(&self) -> bool {
+        self.tokens[self.pos + 1] == self.current && self.tokens[self.pos + 2] == Token::Eq
+    }
+    fn predicate_lhs_expression_1(&self) -> bool {
+        self.is_swizzle_name()
+    }
+}

--- a/crates/parser/src/parser2.rs
+++ b/crates/parser/src/parser2.rs
@@ -1,6 +1,6 @@
 #![allow(elided_lifetimes_in_paths)]
 use logos::Logos;
-use rowan::GreenNode;
+use rowan::{GreenNode, GreenNodeBuilder};
 
 use crate::ParseEntryPoint;
 
@@ -53,10 +53,97 @@ pub fn parse_entrypoint(
             todo!("Ask Benjamin what this is for")
         },
     };
-
+    let mut builder = GreenNodeBuilder::new();
+    build_cst(&mut builder, parsed, NodeRef::ROOT);
     Parse2 {
-        green_node: todo!(),
+        green_node: builder.finish(),
         diags,
+    }
+}
+
+fn build_cst(
+    builder: &mut GreenNodeBuilder,
+    cst: Cst<'_>,
+    node_ref: NodeRef,
+) {
+    // TODO: Make the SyntaxKind closely follow the wgsl spec
+    match cst.get(node_ref) {
+        Node::Rule(rule, end_offset) => {},
+        Node::Token(token, index) => match token {
+            Token::EOF => todo!(),
+            Token::Enable => todo!(),
+            Token::Requires => todo!(),
+            Token::Fn => todo!(),
+            Token::Alias => todo!(),
+            Token::Struct => todo!(),
+            Token::Var => todo!(),
+            Token::ConstAssert => todo!(),
+            Token::If => todo!(),
+            Token::For => todo!(),
+            Token::Else => todo!(),
+            Token::Loop => todo!(),
+            Token::Break => todo!(),
+            Token::While => todo!(),
+            Token::Return => todo!(),
+            Token::Switch => todo!(),
+            Token::Discard => todo!(),
+            Token::Continuing => todo!(),
+            Token::Const => todo!(),
+            Token::Case => todo!(),
+            Token::Default => todo!(),
+            Token::Override => todo!(),
+            Token::Continue => todo!(),
+            Token::Let => todo!(),
+            Token::True => todo!(),
+            Token::False => todo!(),
+            Token::Diagnostic => todo!(),
+            Token::Semi => todo!(),
+            Token::LPar => todo!(),
+            Token::RPar => todo!(),
+            Token::Comma => todo!(),
+            Token::Eq => todo!(),
+            Token::Colon => todo!(),
+            Token::LBrace => todo!(),
+            Token::RBrace => todo!(),
+            Token::MinusGt => todo!(),
+            Token::Lt => todo!(),
+            Token::Gt => todo!(),
+            Token::Dot => todo!(),
+            Token::At => todo!(),
+            Token::LBrak => todo!(),
+            Token::RBrak => todo!(),
+            Token::And => todo!(),
+            Token::Excl => todo!(),
+            Token::Star => todo!(),
+            Token::Minus => todo!(),
+            Token::Tilde => todo!(),
+            Token::Plus => todo!(),
+            Token::Eq2 => todo!(),
+            Token::Pipe => todo!(),
+            Token::And2 => todo!(),
+            Token::Slash => todo!(),
+            Token::Caret => todo!(),
+            Token::Pipe2 => todo!(),
+            Token::ExclEq => todo!(),
+            Token::Percent => todo!(),
+            Token::Underscore => todo!(),
+            Token::AndEq => todo!(),
+            Token::StarEq => todo!(),
+            Token::PlusEq => todo!(),
+            Token::PipeEq => todo!(),
+            Token::MinusEq => todo!(),
+            Token::SlashEq => todo!(),
+            Token::CaretEq => todo!(),
+            Token::PercentEq => todo!(),
+            Token::Plus2 => todo!(),
+            Token::Minus2 => todo!(),
+            Token::IdentPat => todo!(),
+            Token::FloatLiteral => todo!(),
+            Token::IntLiteral => todo!(),
+            Token::Whitespace => todo!(),
+            Token::Comment => todo!(),
+            Token::Error => todo!(),
+        },
     }
 }
 
@@ -129,6 +216,7 @@ impl<'a> Parser<'a> {
                 ]
         )
     }
+    /// Implements the template disambiguation algorithm and remembers the results in a hash set
     fn find_template_list(&mut self) {
         if self.context.template_start.contains(&self.pos) {
             return;
@@ -245,9 +333,6 @@ impl<'a> ParserCallbacks for Parser<'a> {
     fn predicate_template_args_1(&self) -> bool {
         self.peek(1) != Token::Gt
     }
-    fn predicate_expression_1(&self) -> bool {
-        self.is_swizzle_name()
-    }
     fn predicate_expression_2(&self) -> bool {
         if self.current == Token::Gt && self.context.template_end.contains(&self.pos) {
             return false;
@@ -286,8 +371,5 @@ impl<'a> ParserCallbacks for Parser<'a> {
     }
     fn predicate_compound_assignment_operator_1(&self) -> bool {
         self.tokens[self.pos + 1] == self.current && self.tokens[self.pos + 2] == Token::Eq
-    }
-    fn predicate_lhs_expression_1(&self) -> bool {
-        self.is_swizzle_name()
     }
 }

--- a/crates/parser/src/syntax_kind.rs
+++ b/crates/parser/src/syntax_kind.rs
@@ -4,6 +4,8 @@ use std::mem;
 #[repr(u16)]
 pub enum SyntaxKind {
     SourceFile,
+    /// Arguments in an attribute or in a function call
+    Arguments,
     /// Emergent nodes
     Name,
     /// a function
@@ -108,8 +110,8 @@ pub enum SyntaxKind {
     ParenthesisExpression,
     /// an expression of the form `bitcast< <type> >(expression)`
     BitcastExpression,
-    /// a non-builtin type
-    PathType,
+    /// a type with an optional template `foo<bar>`
+    TypeExpression,
     /// `a += b`
     CompoundAssignmentStatement,
     /// `[[location(0), interpolate(flat)]]`

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -29,11 +29,11 @@ fn check_statement(
 }
 
 #[expect(clippy::needless_pass_by_value, reason = "intended API")]
-fn check_attribute_list(
+fn check_attribute(
     statement: &str,
     expected_tree: Expect,
 ) {
-    crate::check_entrypoint(statement, ParseEntryPoint::AttributeList, &expected_tree);
+    crate::check_entrypoint(statement, ParseEntryPoint::Attribute, &expected_tree);
 }
 
 #[test]
@@ -1498,46 +1498,55 @@ fn parse_var_with_initializer() {
 
 #[test]
 fn attribute_list_modern() {
-    check_attribute_list(
-        "@location(0) @interpolate(flat) @attr(1, 2, 0.0, ident)",
+    check_attribute(
+        "@location(0)",
         expect![[r#"
-            AttributeList@0..55
+            Attribute@0..12
               AttributeOperator@0..1 "@"
-              Attribute@1..13
-                Identifier@1..9 "location"
-                AttributeParameters@9..13
-                  ParenthesisLeft@9..10 "("
-                  Literal@10..11
-                    DecimalIntLiteral@10..11 "0"
-                  ParenthesisRight@11..12 ")"
-                  Blankspace@12..13 " "
-              AttributeOperator@13..14 "@"
-              Attribute@14..32
-                Identifier@14..25 "interpolate"
-                AttributeParameters@25..32
-                  ParenthesisLeft@25..26 "("
-                  Identifier@26..30 "flat"
-                  ParenthesisRight@30..31 ")"
-                  Blankspace@31..32 " "
-              AttributeOperator@32..33 "@"
-              Attribute@33..55
-                Identifier@33..37 "attr"
-                AttributeParameters@37..55
-                  ParenthesisLeft@37..38 "("
-                  Literal@38..39
-                    DecimalIntLiteral@38..39 "1"
-                  Comma@39..40 ","
-                  Blankspace@40..41 " "
-                  Literal@41..42
-                    DecimalIntLiteral@41..42 "2"
-                  Comma@42..43 ","
-                  Blankspace@43..44 " "
-                  Literal@44..47
-                    DecimalFloatLiteral@44..47 "0.0"
-                  Comma@47..48 ","
-                  Blankspace@48..49 " "
-                  Identifier@49..54 "ident"
-                  ParenthesisRight@54..55 ")""#]],
+              Identifier@1..9 "location"
+              Arguments@9..12
+                ParenthesisLeft@9..10 "("
+                Literal@10..11
+                  DecimalIntLiteral@10..11 "0"
+                ParenthesisRight@11..12 ")""#]],
+    );
+    check_attribute(
+        "@interpolate(flat)",
+        expect![[r#"
+            Attribute@0..18
+              AttributeOperator@0..1 "@"
+              Identifier@1..12 "interpolate"
+              Arguments@12..18
+                ParenthesisLeft@12..13 "("
+                TypeExpression@13..17
+                  Name@13..17
+                    Identifier@13..17 "flat"
+                ParenthesisRight@17..18 ")""#]],
+    );
+    check_attribute(
+        "@attr(1, 2, 0.0, ident)",
+        expect![[r#"
+            Attribute@0..23
+              AttributeOperator@0..1 "@"
+              Identifier@1..5 "attr"
+              Arguments@5..23
+                ParenthesisLeft@5..6 "("
+                Literal@6..7
+                  DecimalIntLiteral@6..7 "1"
+                Comma@7..8 ","
+                Blankspace@8..9 " "
+                Literal@9..10
+                  DecimalIntLiteral@9..10 "2"
+                Comma@10..11 ","
+                Blankspace@11..12 " "
+                Literal@12..15
+                  DecimalFloatLiteral@12..15 "0.0"
+                Comma@15..16 ","
+                Blankspace@16..17 " "
+                TypeExpression@17..22
+                  Name@17..22
+                    Identifier@17..22 "ident"
+                ParenthesisRight@22..23 ")""#]],
     );
 }
 

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -503,24 +503,24 @@ fn fn_recover_2() {
 #[test]
 fn parse_type_primitive() {
     check_type(
-        "f32",
+        "f32;",
         expect![[r#"
-            Float32@0..3
-              Float32@0..3 "f32""#]],
+            TypeExpression@0..3
+              Identifier@0..3 "f32""#]],
     );
 }
 
 #[test]
 fn parse_type_generic() {
     check_type(
-        "vec3<f32>",
+        "vec3<f32>;",
         expect![[r#"
-            Vec3@0..9
-              Vec3@0..4 "vec3"
+            TypeExpression@0..9
+              Identifier@0..4 "vec3"
               GenericArgumentList@4..9
                 LessThan@4..5 "<"
-                Float32@5..8
-                  Float32@5..8 "f32"
+                TypeExpression@5..8
+                  Identifier@5..8 "f32"
                 GreaterThan@8..9 ">""#]],
     );
 }
@@ -530,16 +530,16 @@ fn parse_type_generic_shift_ambiguity() {
     check_type(
         "array<vec3<f32, 2>>",
         expect![[r#"
-            Array@0..19
-              Array@0..5 "array"
+            TypeExpression@0..19
+              Identifier@0..5 "array"
               GenericArgumentList@5..19
                 LessThan@5..6 "<"
-                Vec3@6..18
-                  Vec3@6..10 "vec3"
+                TypeExpression@6..18
+                  Identifier@6..10 "vec3"
                   GenericArgumentList@10..18
                     LessThan@10..11 "<"
-                    Float32@11..14
-                      Float32@11..14 "f32"
+                    TypeExpression@11..14
+                      Identifier@11..14 "f32"
                     Comma@14..15 ","
                     Blankspace@15..16 " "
                     Literal@16..17
@@ -1519,8 +1519,7 @@ fn attribute_list_modern() {
               Arguments@12..18
                 ParenthesisLeft@12..13 "("
                 TypeExpression@13..17
-                  Name@13..17
-                    Identifier@13..17 "flat"
+                  Identifier@13..17 "flat"
                 ParenthesisRight@17..18 ")""#]],
     );
     check_attribute(
@@ -1544,8 +1543,7 @@ fn attribute_list_modern() {
                 Comma@15..16 ","
                 Blankspace@16..17 " "
                 TypeExpression@17..22
-                  Name@17..22
-                    Identifier@17..22 "ident"
+                  Identifier@17..22 "ident"
                 ParenthesisRight@22..23 ")""#]],
     );
 }

--- a/crates/parser/src/wesl.llw
+++ b/crates/parser/src/wesl.llw
@@ -1,0 +1,168 @@
+// Based on https://www.w3.org/TR/WGSL with some modifications.
+
+token Enable='enable' Requires='requires' Fn='fn' Alias='alias' Struct='struct' Var='var'
+      ConstAssert='const_assert' If='if' For='for' Else='else' Loop='loop' Break='break'
+      While='while' Return='return' Switch='switch' Discard='discard' Continuing='continuing'
+      Const='const' Case='case' Default='default' Override='override' Continue='continue'
+      Let='let' True='true' False='false' Diagnostic='diagnostic';
+token Semi=';' LPar='(' RPar=')' Comma=',' Eq='=' Colon=':' LBrace='{' RBrace='}' MinusGt='->'
+      Lt='<' Gt='>' Dot='.' At='@' LBrak='[' RBrak=']' And='&' Excl='!' Star='*' Minus='-'
+      Tilde='~' Plus='+' Eq2='==' Pipe='|' And2='&&' Slash='/' Caret='^' Pipe2='||' ExclEq='!='
+      Percent='%' Underscore='_' AndEq='&=' StarEq='*=' PlusEq='+=' PipeEq='|=' MinusEq='-='
+      SlashEq='/=' CaretEq='^=' PercentEq='%=' Plus2='++' Minus2='--';
+token Ident='<identifier>' FloatLiteral='<floating point literal>' IntLiteral='<integer literal>';
+token Whitespace Comment;
+
+skip Whitespace Comment;
+
+start translation_unit;
+
+// later validate that directives come before declarations to improve error messages
+translation_unit: (global_item | ';')*;
+global_item^: global_directive | global_decl | global_assert;
+
+global_assert: 'const_assert' expression ';'; // §10
+global_directive:
+  'diagnostic' diagnostic_control ';' @diagnostic_directive // §4.2
+| 'enable' Ident (?1 ',' Ident)* [','] ';' @enable_directive // §4.1.1
+| 'requires' Ident (?1 ',' Ident)* [','] ';' @requires_directive // §4.1.2
+;
+diagnostic_control: '(' severity_control_name ',' diagnostic_rule_name [','] ')';
+severity_control_name: Ident;
+diagnostic_rule_name: Ident ['.' Ident];
+
+global_decl:
+  attribute* (
+    function_header compound_statement @function_decl
+  | variable_decl ';' @global_variable_decl
+  | override_decl ';' @global_value_decl
+  )
+| const_decl ';' @global_value_decl
+| 'alias' Ident '=' Ident template_list ';' @type_alias_decl
+| 'struct' Ident struct_body @struct_decl
+;
+function_header: 'fn' Ident '(' parameters ')' return_type;
+parameters: [param (?1 ',' param)* [',']];
+param: attribute* Ident ':' type_specifier;
+return_type: ['->' attribute* Ident template_list];
+struct_body: '{' struct_member (?1 ',' struct_member)* [','] '}';
+struct_member: attribute* Ident ':' type_specifier;
+
+attribute:
+  '@' (
+    'diagnostic' diagnostic_control @diagnostic_attr
+  | Ident ['(' [expression (?1 ',' expression)* [',']] ')']
+  )
+;
+typed_ident: Ident [':' type_specifier];
+
+type_specifier: Ident template_list;
+template_list^: [#1 template_args >];
+expr_template_list^: #1 [?1 template_args >template_list];
+template_args^: '<' expression (?1 ',' expression)* [','] '>';
+
+expression:
+  expression '[' expression ']' @indexing_expression // §8.5
+| expression '.' (?1 Ident @swizzle_expression | Ident @named_component_expression) // §8.5
+| ('-' | '!' | '~' | '*' | '&') expression @unary_expression // §8.6, §8.7, §8.9, §8.13, §8.14
+| expression ('*' | '/' | '%') expression @binary_expression // §8.7
+| expression ('+' | '-') expression @binary_expression // §8.7
+| ?2 expression ('<' '<' | '>' '>') expression @binary_expression // §8.9
+| ?3 expression (?4 '<' | ?4 '>' | '<' '=' | '>' '=' | '==' | '!=') expression @binary_expression // §8.8
+| expression '&' expression @binary_expression // §8.9
+| expression '^' expression @binary_expression // §8.9
+| expression '|' expression @binary_expression // §8.9
+| expression '&&' expression @binary_expression // §8.6
+| expression '||' expression @binary_expression // §8.6
+| Ident expr_template_list @ident_expression [argument_expression_list_expr @call_expression] // §8.10, §8.11
+| '(' expression ')' @paren_expression // §8.4
+| IntLiteral @int_expression // §8.3
+| FloatLiteral @float_expression // §8.3
+| 'true' @bool_expression // §8.3
+| 'false' @bool_expression // §8.3
+;
+argument_expression_list: '(' [expression (?1 ',' expression)* [',']] ')';
+// extra rule for better error handling
+argument_expression_list_expr: '(' [expression (?1 ',' expression)* [',']] ')' @argument_expression_list;
+
+statement:
+  attribute* (
+    if_clause (?1 else_if_clause)* [else_clause] @if_statement // §9.4.1
+  | 'switch' expression attribute* '{' switch_clause * '}' @switch_statement // §9.4.2
+  | 'loop' attribute* '{' statement* [continuing_statement] '}' @loop_statement // §9.4.3
+  | 'for' '(' [for_init] ';' [expression] ';' [for_update] ')' compound_statement @for_statement // §9.4.4
+  | 'while' expression compound_statement @while_statement // §9.4.5
+  | '{' statement* '}' @compound_statement // §9.1
+  )
+| ?2 func_call ';' @func_call_statement // §9.5
+| variable_or_value ';' @variable_or_value_statement
+| lhs_expression (
+    '=' expression @simple_assignment_statement // §9.2.1
+  | compound_assignment_operator expression @compound_assignment_statement // §9.2.3
+  | '++' @increment_statement // §9.3
+  | '--' @decrement_statement // §9.3
+  ) ';'
+| '_' '=' expression ';' @phony_assignment_statement // §9.2.2
+| 'const_assert' expression ';' @assert_statement // §10.1
+| 'break' ';' @break_statement // §9.4.6
+| 'continue' ';' @continue_statement // §9.4.8
+| ';' @empty_statement
+| 'discard' ';' @discard_statement // §9.4.11
+| 'return' [expression] ';' @return_statement // §9.4.10
+;
+continuing_statement: 'continuing' attribute* '{' (?1 statement)* [break_if_statement] '}'; // §9.4.9
+break_if_statement: 'break' 'if' expression ';'; // §9.4.7
+for_init:
+  ?1 func_call
+| variable_or_value
+| variable_updating
+;
+for_update: ?1 func_call | variable_updating;
+if_clause: 'if' expression compound_statement;
+else_if_clause: 'else' 'if' expression compound_statement;
+else_clause: 'else' compound_statement;
+switch_clause^: case_clause | default_alone_clause;
+case_clause: 'case' case_selectors [':'] compound_statement;
+case_selectors: case_selector (?1 ',' case_selector)* [','];
+case_selector: 'default' | expression;
+default_alone_clause: 'default' [':'] compound_statement;
+compound_statement: attribute* '{' & statement* '}'; // §9.1
+
+func_call: Ident template_list argument_expression_list;
+
+variable_or_value^: variable_decl | let_decl | const_decl;
+variable_decl: 'var' template_list typed_ident ['=' expression];
+let_decl: 'let' typed_ident '=' expression;
+const_decl: 'const' typed_ident '=' expression;
+override_decl: 'override' typed_ident ['=' expression];
+
+// duplicated so it can be used in `for` statement without semicolon
+variable_updating:
+  lhs_expression (
+    '=' expression @simple_assignment_statement // §9.2.1
+  | compound_assignment_operator expression @compound_assignment_statement // §9.2.3
+  | '++' @increment_statement // §9.3
+  | '--' @decrement_statement // §9.3
+  )
+| '_' '=' expression @phony_assignment_statement // §9.2.2
+;
+compound_assignment_operator^:
+  ?1 '<' '<' '='
+| ?1 '>' '>' '='
+| '%='
+| '&='
+| '*='
+| '+='
+| '-='
+| '/='
+| '^='
+| '|='
+;
+lhs_expression:
+  lhs_expression '[' expression ']' @indexing_expression // §8.5
+| lhs_expression '.' (?1 Ident @swizzle_expression | Ident @named_component_expression) // §8.5
+| '*' lhs_expression @unary_expression // §8.14
+| '&' lhs_expression @unary_expression // §8.13
+| '(' lhs_expression ')' @paren_expression // §8.4
+| Ident @ident_expression // §8.11
+;

--- a/crates/parser/src/wesl.llw
+++ b/crates/parser/src/wesl.llw
@@ -10,7 +10,7 @@ token Semi=';' LPar='(' RPar=')' Comma=',' Eq='=' Colon=':' LBrace='{' RBrace='}
       Tilde='~' Plus='+' Eq2='==' Pipe='|' And2='&&' Slash='/' Caret='^' Pipe2='||' ExclEq='!='
       Percent='%' Underscore='_' AndEq='&=' StarEq='*=' PlusEq='+=' PipeEq='|=' MinusEq='-='
       SlashEq='/=' CaretEq='^=' PercentEq='%=' Plus2='++' Minus2='--';
-token Ident='<identifier>' FloatLiteral='<floating point literal>' IntLiteral='<integer literal>';
+token IdentPat='<identifier>' FloatLiteral='<floating point literal>' IntLiteral='<integer literal>';
 token Whitespace Comment;
 
 skip Whitespace Comment;
@@ -24,12 +24,12 @@ global_item^: global_directive | global_decl | global_assert;
 global_assert: 'const_assert' expression ';'; // §10
 global_directive:
   'diagnostic' diagnostic_control ';' @diagnostic_directive // §4.2
-| 'enable' Ident (?1 ',' Ident)* [','] ';' @enable_directive // §4.1.1
-| 'requires' Ident (?1 ',' Ident)* [','] ';' @requires_directive // §4.1.2
+| 'enable' IdentPat (?1 ',' IdentPat)* [','] ';' @enable_directive // §4.1.1
+| 'requires' IdentPat (?1 ',' IdentPat)* [','] ';' @requires_directive // §4.1.2
 ;
 diagnostic_control: '(' severity_control_name ',' diagnostic_rule_name [','] ')';
-severity_control_name: Ident;
-diagnostic_rule_name: Ident ['.' Ident];
+severity_control_name: IdentPat;
+diagnostic_rule_name: IdentPat ['.' IdentPat];
 
 global_decl:
   attribute* (
@@ -38,32 +38,40 @@ global_decl:
   | override_decl ';' @global_value_decl
   )
 | const_decl ';' @global_value_decl
-| 'alias' Ident '=' Ident template_list ';' @type_alias_decl
-| 'struct' Ident struct_body @struct_decl
+| 'alias' ident '=' ident template_list ';' @type_alias_decl
+| 'struct' ident struct_body @struct_decl
 ;
-function_header: 'fn' Ident '(' parameters ')' return_type;
+function_header: 'fn' ident '(' parameters ')' return_type;
 parameters: [param (?1 ',' param)* [',']];
-param: attribute* Ident ':' type_specifier;
-return_type: ['->' attribute* Ident template_list];
+param: attribute* ident ':' type_specifier;
+return_type: ['->' attribute* ident template_list];
 struct_body: '{' struct_member (?1 ',' struct_member)* [','] '}';
-struct_member: attribute* Ident ':' type_specifier;
+struct_member: attribute* member_ident ':' type_specifier;
+member_ident: IdentPat;
 
 attribute:
   '@' (
     'diagnostic' diagnostic_control @diagnostic_attr
-  | Ident ['(' [expression (?1 ',' expression)* [',']] ')']
+  | IdentPat ['(' [expression (?1 ',' expression)* [',']] ')']
+    // TODO:
+    // interpolate is special
+    // builtin is special
   )
 ;
-typed_ident: Ident [':' type_specifier];
+typed_ident: ident [':' type_specifier];
+ident: IdentPat;
 
-type_specifier: Ident template_list;
+type_specifier: ident template_list;
 template_list^: [#1 template_args >];
 expr_template_list^: #1 [?1 template_args >template_list];
 template_args^: '<' expression (?1 ',' expression)* [','] '>';
 
+// This is pratt parser, with higher elements having a higher binding power
+// Source: https://github.com/0x2a-42/lelwel/tree/main?tab=readme-ov-file#direct-left-recursion
+// later check for invalid expressions, like a < b < c
 expression:
   expression '[' expression ']' @indexing_expression // §8.5
-| expression '.' (?1 Ident @swizzle_expression | Ident @named_component_expression) // §8.5
+| expression '.' (ident @field_expression) // §8.5, but cannot distinguish swizzles and fields from syntax
 | ('-' | '!' | '~' | '*' | '&') expression @unary_expression // §8.6, §8.7, §8.9, §8.13, §8.14
 | expression ('*' | '/' | '%') expression @binary_expression // §8.7
 | expression ('+' | '-') expression @binary_expression // §8.7
@@ -74,7 +82,7 @@ expression:
 | expression '|' expression @binary_expression // §8.9
 | expression '&&' expression @binary_expression // §8.6
 | expression '||' expression @binary_expression // §8.6
-| Ident expr_template_list @ident_expression [argument_expression_list_expr @call_expression] // §8.10, §8.11
+| ident expr_template_list @ident_expression [argument_expression_list_expr @call_expression] // §8.10, §8.11
 | '(' expression ')' @paren_expression // §8.4
 | IntLiteral @int_expression // §8.3
 | FloatLiteral @float_expression // §8.3
@@ -92,6 +100,7 @@ statement:
   | 'loop' attribute* '{' statement* [continuing_statement] '}' @loop_statement // §9.4.3
   | 'for' '(' [for_init] ';' [expression] ';' [for_update] ')' compound_statement @for_statement // §9.4.4
   | 'while' expression compound_statement @while_statement // §9.4.5
+  // TODO: check if using & here makes it recover better https://github.com/0x2a-42/lelwel/issues/34
   | '{' statement* '}' @compound_statement // §9.1
   )
 | ?2 func_call ';' @func_call_statement // §9.5
@@ -128,7 +137,7 @@ case_selector: 'default' | expression;
 default_alone_clause: 'default' [':'] compound_statement;
 compound_statement: attribute* '{' & statement* '}'; // §9.1
 
-func_call: Ident template_list argument_expression_list;
+func_call: ident template_list argument_expression_list;
 
 variable_or_value^: variable_decl | let_decl | const_decl;
 variable_decl: 'var' template_list typed_ident ['=' expression];
@@ -160,9 +169,9 @@ compound_assignment_operator^:
 ;
 lhs_expression:
   lhs_expression '[' expression ']' @indexing_expression // §8.5
-| lhs_expression '.' (?1 Ident @swizzle_expression | Ident @named_component_expression) // §8.5
+| lhs_expression '.' (ident @field_expression) // §8.5
 | '*' lhs_expression @unary_expression // §8.14
 | '&' lhs_expression @unary_expression // §8.13
 | '(' lhs_expression ')' @paren_expression // §8.4
-| Ident @ident_expression // §8.11
+| ident @ident_expression // §8.11
 ;

--- a/crates/parser/src/wesl.llw
+++ b/crates/parser/src/wesl.llw
@@ -59,7 +59,7 @@ attribute:
   )
 ;
 typed_ident: Ident [':' type_expression];
-full_ident: Ident; // wesl ident
+full_ident^: Ident; // wesl ident
 
 // Corresponds to type_specifier, but used in more places
 type_expression: full_ident template_list;
@@ -180,5 +180,5 @@ lhs_expression:
 | '*' lhs_expression @unary_expression // §8.14
 | '&' lhs_expression @unary_expression // §8.13
 | '(' lhs_expression ')' @paren_expression // §8.4
-| full_ident
+| full_ident @ident_expression
 ;

--- a/crates/parser/src/wesl.llw
+++ b/crates/parser/src/wesl.llw
@@ -5,63 +5,64 @@ token Enable='enable' Requires='requires' Fn='fn' Alias='alias' Struct='struct' 
       While='while' Return='return' Switch='switch' Discard='discard' Continuing='continuing'
       Const='const' Case='case' Default='default' Override='override' Continue='continue'
       Let='let' True='true' False='false' Diagnostic='diagnostic';
-token Semi=';' LPar='(' RPar=')' Comma=',' Eq='=' Colon=':' LBrace='{' RBrace='}' MinusGt='->'
+token Semi=';' LPar='(' RPar=')' Comma=',' Eq='=' Colon=':' LBrace='{' RBrace='}' Arrow='->'
       Lt='<' Gt='>' Dot='.' At='@' LBrak='[' RBrak=']' And='&' Excl='!' Star='*' Minus='-'
       Tilde='~' Plus='+' Eq2='==' Pipe='|' And2='&&' Slash='/' Caret='^' Pipe2='||' ExclEq='!='
       Percent='%' Underscore='_' AndEq='&=' StarEq='*=' PlusEq='+=' PipeEq='|=' MinusEq='-='
       SlashEq='/=' CaretEq='^=' PercentEq='%=' Plus2='++' Minus2='--';
-token IdentPat='<identifier>' FloatLiteral='<floating point literal>' IntLiteral='<integer literal>';
-token Whitespace Comment;
+token Ident='<identifier>' FloatLiteral='<floating point literal>' IntLiteral='<integer literal>' 
+      HexFloatLiteral='<hex floating point literal>' HexIntLiteral='<hex integer literal>';
+token Whitespace LineEndingComment BlockComment;
 
-skip Whitespace Comment;
+skip Whitespace LineEndingComment BlockComment;
 
 start translation_unit;
 
 // later validate that directives come before declarations to improve error messages
 translation_unit: (global_item | ';')*;
-global_item^: global_directive | global_decl | global_assert;
+global_item^: global_directive | global_declaration | global_assert;
 
 global_assert: 'const_assert' expression ';'; // §10
 global_directive:
   'diagnostic' diagnostic_control ';' @diagnostic_directive // §4.2
-| 'enable' IdentPat (?1 ',' IdentPat)* [','] ';' @enable_directive // §4.1.1
-| 'requires' IdentPat (?1 ',' IdentPat)* [','] ';' @requires_directive // §4.1.2
+| 'enable' Ident (?1 ',' Ident)* [','] ';' @enable_directive // §4.1.1
+| 'requires' Ident (?1 ',' Ident)* [','] ';' @requires_directive // §4.1.2
 ;
 diagnostic_control: '(' severity_control_name ',' diagnostic_rule_name [','] ')';
-severity_control_name: IdentPat;
-diagnostic_rule_name: IdentPat ['.' IdentPat];
+severity_control_name: Ident;
+diagnostic_rule_name: Ident ['.' Ident];
 
-global_decl:
+global_declaration:
   attribute* (
-    function_header compound_statement @function_decl
-  | variable_decl ';' @global_variable_decl
-  | override_decl ';' @global_value_decl
+    function_header compound_statement @function_declaration
+  | variable_declaration ';' @global_variable_declaration
+  | override_declaration ';' @global_value_declaration
   )
-| const_decl ';' @global_value_decl
-| 'alias' ident '=' ident template_list ';' @type_alias_decl
-| 'struct' ident struct_body @struct_decl
+| const_declaration ';' @global_value_declaration
+| 'alias' Ident '=' type_expression ';' @type_alias_declaration
+| 'struct' Ident struct_body @struct_declaration
 ;
-function_header: 'fn' ident '(' parameters ')' return_type;
-parameters: [param (?1 ',' param)* [',']];
-param: attribute* ident ':' type_specifier;
-return_type: ['->' attribute* ident template_list];
+function_header: 'fn' Ident '(' parameters ')' return_type;
+parameters: [parameter (?1 ',' parameter)* [',']];
+parameter: attribute* Ident ':' type_expression;
+return_type: ['->' attribute* type_expression];
 struct_body: '{' struct_member (?1 ',' struct_member)* [','] '}';
-struct_member: attribute* member_ident ':' type_specifier;
-member_ident: IdentPat;
+struct_member: attribute* member_ident ':' type_expression;
+member_ident: Ident;
 
 attribute:
   '@' (
     'diagnostic' diagnostic_control @diagnostic_attr
-  | IdentPat ['(' [expression (?1 ',' expression)* [',']] ')']
-    // TODO:
+  | Ident [argument_expression_list]
     // interpolate is special
     // builtin is special
   )
 ;
-typed_ident: ident [':' type_specifier];
-ident: IdentPat;
+typed_ident: Ident [':' type_expression];
+full_ident: Ident; // wesl ident
 
-type_specifier: ident template_list;
+// Corresponds to type_specifier, but used in more places
+type_expression: full_ident template_list;
 template_list^: [#1 template_args >];
 expr_template_list^: #1 [?1 template_args >template_list];
 template_args^: '<' expression (?1 ',' expression)* [','] '>';
@@ -71,7 +72,7 @@ template_args^: '<' expression (?1 ',' expression)* [','] '>';
 // later check for invalid expressions, like a < b < c
 expression:
   expression '[' expression ']' @indexing_expression // §8.5
-| expression '.' (ident @field_expression) // §8.5, but cannot distinguish swizzles and fields from syntax
+| expression '.' (Ident @field_expression) // §8.5, but cannot distinguish swizzles and fields from syntax
 | ('-' | '!' | '~' | '*' | '&') expression @unary_expression // §8.6, §8.7, §8.9, §8.13, §8.14
 | expression ('*' | '/' | '%') expression @binary_expression // §8.7
 | expression ('+' | '-') expression @binary_expression // §8.7
@@ -82,16 +83,22 @@ expression:
 | expression '|' expression @binary_expression // §8.9
 | expression '&&' expression @binary_expression // §8.6
 | expression '||' expression @binary_expression // §8.6
-| ident expr_template_list @ident_expression [argument_expression_list_expr @call_expression] // §8.10, §8.11
+| full_ident expr_template_list @type_expression [argument_expression_list_expr @function_call] // §8.10, §8.11
 | '(' expression ')' @paren_expression // §8.4
-| IntLiteral @int_expression // §8.3
-| FloatLiteral @float_expression // §8.3
-| 'true' @bool_expression // §8.3
-| 'false' @bool_expression // §8.3
+| literal @literal
 ;
-argument_expression_list: '(' [expression (?1 ',' expression)* [',']] ')';
+// §8.3
+literal^:
+  IntLiteral
+| HexIntLiteral
+| FloatLiteral
+| HexFloatLiteral
+| 'true'
+| 'false'
+;
+argument_expression_list: '(' [expression (?1 ',' expression)* [',']] ')' @arguments;
 // extra rule for better error handling
-argument_expression_list_expr: '(' [expression (?1 ',' expression)* [',']] ')' @argument_expression_list;
+argument_expression_list_expr: '(' [expression (?1 ',' expression)* [',']] ')' @arguments;
 
 statement:
   attribute* (
@@ -103,7 +110,7 @@ statement:
   // TODO: check if using & here makes it recover better https://github.com/0x2a-42/lelwel/issues/34
   | '{' statement* '}' @compound_statement // §9.1
   )
-| ?2 func_call ';' @func_call_statement // §9.5
+| ?2 function_call ';' @function_call_statement // §9.5
 | variable_or_value ';' @variable_or_value_statement
 | lhs_expression (
     '=' expression @simple_assignment_statement // §9.2.1
@@ -122,11 +129,11 @@ statement:
 continuing_statement: 'continuing' attribute* '{' (?1 statement)* [break_if_statement] '}'; // §9.4.9
 break_if_statement: 'break' 'if' expression ';'; // §9.4.7
 for_init:
-  ?1 func_call
+  ?1 function_call
 | variable_or_value
 | variable_updating
 ;
-for_update: ?1 func_call | variable_updating;
+for_update: ?1 function_call | variable_updating;
 if_clause: 'if' expression compound_statement;
 else_if_clause: 'else' 'if' expression compound_statement;
 else_clause: 'else' compound_statement;
@@ -137,13 +144,13 @@ case_selector: 'default' | expression;
 default_alone_clause: 'default' [':'] compound_statement;
 compound_statement: attribute* '{' & statement* '}'; // §9.1
 
-func_call: ident template_list argument_expression_list;
+function_call: type_expression argument_expression_list;
 
-variable_or_value^: variable_decl | let_decl | const_decl;
-variable_decl: 'var' template_list typed_ident ['=' expression];
-let_decl: 'let' typed_ident '=' expression;
-const_decl: 'const' typed_ident '=' expression;
-override_decl: 'override' typed_ident ['=' expression];
+variable_or_value^: variable_declaration | let_declaration | const_declaration;
+variable_declaration: 'var' template_list typed_ident ['=' expression];
+let_declaration: 'let' typed_ident '=' expression;
+const_declaration: 'const' typed_ident '=' expression;
+override_declaration: 'override' typed_ident ['=' expression];
 
 // duplicated so it can be used in `for` statement without semicolon
 variable_updating:
@@ -169,9 +176,9 @@ compound_assignment_operator^:
 ;
 lhs_expression:
   lhs_expression '[' expression ']' @indexing_expression // §8.5
-| lhs_expression '.' (ident @field_expression) // §8.5
+| lhs_expression '.' (Ident @field_expression) // §8.5
 | '*' lhs_expression @unary_expression // §8.14
 | '&' lhs_expression @unary_expression // §8.13
 | '(' lhs_expression ')' @paren_expression // §8.4
-| ident @ident_expression // §8.11
+| full_ident
 ;

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -998,7 +998,7 @@ ast_enum_raw! {
 }
 
 ast_node! {
-    PathType:
+    TypeExpression:
     name: Option<NameReference>;
 }
 


### PR DESCRIPTION
# Objective

We want a maintainable, lossless parser with good error recovery.

Fixes #402

## Solution

 This PR migrates wgsl-analyzer to use the [excellent lelwel library](https://github.com/0x2a-42/lelwel) for parsing.

Stuff below will be filled out in the future, when this PR is getting closer to completion vvv

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you cannot test?

## Showcase

This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

```rust
println!("My super cool code.");
```
