### PR TITLE
Update dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -38,24 +38,7 @@ updates:
       - C-Dependencies
       - D-Trivial
       - S-Ready-to-Review
-    ignore:
-      - dependency-name: vscode
     groups:
       ts-eslint:
         patterns:
           - '@typescript-eslint/*'
-
-  - package-ecosystem: npm
-    directory: /editors/code
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 1
-    commit-message:
-      prefix: internal
-    labels:
-      - A-Editor
-      - C-Dependencies
-      - D-Trivial
-      - S-Ready-to-Review
-    allow:
-      - dependency-name: vscode


### PR DESCRIPTION
fix invalid config: Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'npm' has overlapping directories.