### PR TITLE
Remove `wgsl-analyzer.syntaxTree`

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -89,11 +89,6 @@
 	"contributes": {
 		"commands": [
 			{
-				"command": "wgsl-analyzer.syntaxTree",
-				"title": "Show Syntax Tree",
-				"category": "wgsl-analyzer"
-			},
-			{
 				"command": "wgsl-analyzer.debugCommand",
 				"title": "Debug command",
 				"category": "wgsl-analyzer"


### PR DESCRIPTION
# Objective

Fixes #446

## Solution

Remove non-existent command.

The syntax tree views and command can be ported from r-a in a follow-up.

## Testing

Tested locally