### PR TITLE
Use local dependencies instead of workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "camino"
@@ -190,15 +190,16 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -238,9 +239,9 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -290,13 +291,13 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -332,7 +333,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.0",
+ "redox_users 0.5.2",
  "windows-sys 0.60.2",
 ]
 
@@ -355,7 +356,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -417,6 +418,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
 
 [[package]]
 name = "flate2"
@@ -485,7 +492,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.3+wasi-0.2.4",
 ]
 
 [[package]]
@@ -930,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
@@ -940,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
 dependencies = [
  "zlib-rs",
 ]
@@ -1154,7 +1161,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "strum",
  "termcolor",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "unicode-xid",
 ]
 
@@ -1260,9 +1267,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "parking_lot"
@@ -1307,7 +1314,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1370,9 +1377,9 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -1427,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1459,7 +1466,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1488,9 +1495,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1555,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.4",
 ]
@@ -1575,13 +1582,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1593,18 +1600,18 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -1615,9 +1622,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rowan"
@@ -1633,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -1651,22 +1658,22 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -1756,7 +1763,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1780,7 +1787,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1874,7 +1881,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1890,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1907,7 +1914,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1923,15 +1930,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1983,11 +1990,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -1998,18 +2005,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2054,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
 dependencies = [
  "deranged",
  "libc",
@@ -2070,15 +2077,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2121,7 +2128,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2304,11 +2311,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2399,11 +2406,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2411,6 +2418,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-sys"
@@ -2445,7 +2458,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2481,10 +2494,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2634,13 +2648,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.4",
-]
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "write-json"
@@ -2727,7 +2738,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -2748,7 +2759,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2768,7 +2779,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -2785,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2802,14 +2813,14 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "zip"
-version = "4.5.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835eb39822904d39cb19465de1159e05d371973f0c6df3a365ad50565ddc8b9"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
@@ -2822,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,133 +40,27 @@ debug = 2
 [workspace.dependencies]
 # local crates
 base-db = { path = "./crates/base_db", version = "0.0.0" }
-cfg = { path = "./crates/cfg", version = "0.0.0", features = ["tt"] }
 hir = { path = "./crates/hir", version = "0.0.0" }
 hir-def = { path = "./crates/hir_def", version = "0.0.0" }
-hir-expand = { path = "./crates/hir-expand", version = "0.0.0" }
 hir-ty = { path = "./crates/hir_ty", version = "0.0.0" }
 ide = { path = "./crates/ide", version = "0.0.0" }
-ide-assists = { path = "./crates/ide-assists", version = "0.0.0" }
 ide-completion = { path = "./crates/ide_completion", version = "0.0.0" }
 ide-db = { path = "./crates/ide-db", version = "0.0.0" }
-# ide-diagnostics = { path = "./crates/ide-diagnostics", version = "0.0.0" }
-ide-ssr = { path = "./crates/ide-ssr", version = "0.0.0" }
-# intern = { path = "./crates/intern", version = "0.0.0" }
-limit = { path = "./crates/limit", version = "0.0.0" }
-load-cargo = { path = "./crates/load-cargo", version = "0.0.0" }
-mbe = { path = "./crates/mbe", version = "0.0.0" }
 parser = { path = "./crates/parser", version = "0.0.0" }
-# paths = { path = "./crates/paths", version = "0.0.0" }
-proc-macro-api = { path = "./crates/proc-macro-api", version = "0.0.0" }
-proc-macro-srv = { path = "./crates/proc-macro-srv", version = "0.0.0" }
-proc-macro-srv-cli = { path = "./crates/proc-macro-srv-cli", version = "0.0.0" }
 profile = { path = "./crates/profile", version = "0.0.0" }
-# project-model = { path = "./crates/project-model", version = "0.0.0" }
-# span = { path = "./crates/span", version = "0.0.0" }
 stdx = { path = "./crates/stdx", version = "0.0.0" }
 syntax = { path = "./crates/syntax", version = "0.0.0" }
-syntax-bridge = { path = "./crates/syntax-bridge", version = "0.0.0" }
-# test-fixture = { path = "./crates/test-fixture", version = "0.0.0" }
 test-utils = { path = "./crates/test-utils", version = "0.0.0" }
-tt = { path = "./crates/tt", version = "0.0.0" }
 wgsl-analyzer = { path = "./crates/wgsl-analyzer", version = "0.0.0" }
 wgsl-formatter = { path = "./crates/wgsl_formatter", version = "0.0.0" }
 wgslfmt = { path = "./crates/wgslfmt", version = "0.0.0" }
 edition = { path = "./crates/edition", version = "0.0.0" }
 
+# rust-analyzer crates
 vfs-notify = { git = "https://github.com/rust-lang/rust-analyzer", rev = "a31e10a2fdc585e9d7ea0857cacfd322dd478070", version = "0.0.0" }
 vfs = { git = "https://github.com/rust-lang/rust-analyzer", rev = "a31e10a2fdc585e9d7ea0857cacfd322dd478070", version = "0.0.0" }
 paths = { git = "https://github.com/rust-lang/rust-analyzer", rev = "a31e10a2fdc585e9d7ea0857cacfd322dd478070", version = "0.0.0" }
 query-group = { package = "query-group-macro", git = "https://github.com/rust-lang/rust-analyzer", rev = "a31e10a2fdc585e9d7ea0857cacfd322dd478070", version = "0.0.0" }
-
-# crates from rust-analyzer that are published separately
-line-index = "0.1.2"
-la-arena = "0.3.1"
-lsp-server = "0.7.9"
-
-# non-local crates
-anyhow = "1.0.99"
-arrayvec = "0.7.6"
-base64 = "0.22"
-bitflags = "2.9.4"
-cargo_metadata = "0.19.1"
-camino = "1.1.12"
-dirs = "5.0.1"
-scip = "0.5.2"
-chalk-solve = { version = "0.99.0", default-features = false }
-chalk-ir = "0.99.0"
-chalk-recursive = { version = "0.99.0", default-features = false }
-chalk-derive = "0.99.0"
-cov-mark = "2.0.0"
-crossbeam-channel = "0.5.15"
-dissimilar = "1.0.9"
-dot = "0.1.4"
-either = "1.15.0"
-expect-test = "1.5.1"
-fst = { version = "0.4.7", default-features = false }
-fxhash = "0.2.1"
-hashbrown = { version = "0.15.5", features = [
-  "inline-more",
-], default-features = false }
-indexmap = "2.11.0"
-itertools = "0.14.0"
-jod-thread = "1.0.0"
-libc = "0.2.175"
-libloading = "0.8.6"
-memchr = "2.7.5"
-logos = "0.12.1"
-walkdir = "2.3.2"
-toml = "0.8.8"
-tenthash = "1.0.0"
-num_cpus = "1.17.0"
-memmap2 = "0.9.5"
-nohash-hasher = "0.2.0"
-oorandom = "11.1.5"
-object = { version = "0.36.7", default-features = false, features = [
-  "std",
-  "read_core",
-  "elf",
-  "macho",
-  "pe",
-] }
-parking_lot = "0.12.4"
-xflags = "0.3.0"
-threadpool = "1.8.1"
-process-wrap = { version = "8.2.0", features = ["std"] }
-pulldown-cmark-to-cmark = "21.0.0"
-pulldown-cmark = { version = "0.13.0", default-features = false }
-rayon = "1.11.0"
-rowan = "0.16.1"
-rustc-hash = "2.1.1"
-salsa = "0.17.0-pre.2"
-salsa-macros = "0.22.0"
-semver = "1.0.25"
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.143"
-smallvec = { version = "1.15.1", features = [
-  "const_new",
-  "union",
-  "const_generics",
-] }
-smol_str = "0.3.2"
-text-size = "1.1.1"
-tracing = "0.1.40"
-tracing-tree = "0.3.0"
-tracing-subscriber = { version = "0.3.20", default-features = false, features = [
-  "registry",
-  "fmt",
-  "local-time",
-  "std",
-  "time",
-  "tracing-log",
-] }
-triomphe = { version = "0.1.14", default-features = false, features = ["std"] }
-url = "2.5.7"
-xshell = "0.2.7"
-lexopt = "0.3.0"
-prettydiff = "0.8.1"
-notify = "8.2.0"
-proptest = "1.7.0"
 
 # We need to freeze the version of the crate because the raw-api feature is considered unstable
 dashmap = { version = "6.1.0", features = ["raw-api"] }

--- a/crates/base_db/Cargo.toml
+++ b/crates/base_db/Cargo.toml
@@ -13,16 +13,16 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-salsa.workspace = true
-rowan.workspace = true
-rustc-hash.workspace = true
+salsa = "0.17.0-pre.2"
+rowan = "0.16.1"
+rustc-hash = "2.1.1"
 syntax.workspace = true
 regex = { version = "1.11.2", default-features = false, features = [
   "std",
   "unicode",
 ] }
-triomphe.workspace = true
-line-index.workspace = true
+triomphe = { version = "0.1.14", default-features = false, features = ["std"] }
+line-index = "0.1.2"
 vfs.workspace = true
 
 [dev-dependencies]

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -14,15 +14,19 @@ doctest = false
 
 [dependencies]
 base-db.workspace = true
-either.workspace = true
+either = "1.15.0"
 hir-def.workspace = true
 hir-ty.workspace = true
 syntax.workspace = true
-tracing.workspace = true
-la-arena.workspace = true
-smallvec.workspace = true
+tracing = "0.1.41"
+la-arena = "0.3.1"
+smallvec = { version = "1.15.1", features = [
+	"const_new",
+	"union",
+	"const_generics",
+] }
 vfs.workspace = true
-serde.workspace = true
+serde = { version = "1.0.219", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -21,9 +21,9 @@ syntax.workspace = true
 tracing = "0.1.41"
 la-arena = "0.3.1"
 smallvec = { version = "1.15.1", features = [
-	"const_new",
-	"union",
-	"const_generics",
+  "const_new",
+  "union",
+  "const_generics",
 ] }
 vfs.workspace = true
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -13,17 +13,21 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-la-arena.workspace = true
+la-arena = "0.3.1"
 vfs.workspace = true
-salsa.workspace = true
+salsa = "0.17.0-pre.2"
 syntax.workspace = true
 base-db.workspace = true
-smol_str.workspace = true
-rustc-hash.workspace = true
-either.workspace = true
-smallvec.workspace = true
-rowan.workspace = true
-tracing.workspace = true
+smol_str = "0.3.2"
+rustc-hash = "2.1.1"
+either = "1.15.0"
+smallvec = { version = "1.15.1", features = [
+	"const_new",
+	"union",
+	"const_generics",
+] }
+rowan = "0.16.1"
+tracing = "0.1.41"
 
 [lints]
 workspace = true

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -22,9 +22,9 @@ smol_str = "0.3.2"
 rustc-hash = "2.1.1"
 either = "1.15.0"
 smallvec = { version = "1.15.1", features = [
-	"const_new",
-	"union",
-	"const_generics",
+  "const_new",
+  "union",
+  "const_generics",
 ] }
 rowan = "0.16.1"
 tracing = "0.1.41"

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -22,9 +22,9 @@ either = "1.15.0"
 rustc-hash = "2.1.1"
 itertools = "0.14.0"
 smallvec = { version = "1.15.1", features = [
-	"const_new",
-	"union",
-	"const_generics",
+  "const_new",
+  "union",
+  "const_generics",
 ] }
 
 [lints]

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -16,12 +16,16 @@ doctest = false
 base-db.workspace = true
 hir-def.workspace = true
 
-salsa.workspace = true
-la-arena.workspace = true
-either.workspace = true
-rustc-hash.workspace = true
-itertools.workspace = true
-smallvec.workspace = true
+salsa = "0.17.0-pre.2"
+la-arena = "0.3.1"
+either = "1.15.0"
+rustc-hash = "2.1.1"
+itertools = "0.14.0"
+smallvec = { version = "1.15.1", features = [
+	"const_new",
+	"union",
+	"const_generics",
+] }
 
 [lints]
 workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -26,9 +26,9 @@ triomphe = { version = "0.1.14", default-features = false, features = ["std"] }
 nohash-hasher = "0.2.0"
 smol_str = "0.3.2"
 smallvec = { version = "1.15.1", features = [
-	"const_new",
-	"union",
-	"const_generics",
+  "const_new",
+  "union",
+  "const_generics",
 ] }
 
 base-db.workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -13,27 +13,31 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-crossbeam-channel.workspace = true
-tracing.workspace = true
-fst.workspace = true
-rustc-hash.workspace = true
-either.workspace = true
-itertools.workspace = true
-indexmap.workspace = true
-memchr.workspace = true
-salsa.workspace = true
-triomphe.workspace = true
-nohash-hasher.workspace = true
-smol_str.workspace = true
-smallvec.workspace = true
+crossbeam-channel = "0.5.15"
+tracing = "0.1.41"
+fst = { version = "0.4.7", default-features = false }
+rustc-hash = "2.1.1"
+either = "1.15.0"
+itertools = "0.14.0"
+indexmap = "2.11.0"
+memchr = "2.7.5"
+salsa = "0.17.0-pre.2"
+triomphe = { version = "0.1.14", default-features = false, features = ["std"] }
+nohash-hasher = "0.2.0"
+smol_str = "0.3.2"
+smallvec = { version = "1.15.1", features = [
+	"const_new",
+	"union",
+	"const_generics",
+] }
 
 base-db.workspace = true
 hir-def.workspace = true
 hir-ty.workspace = true
 syntax.workspace = true
-rowan.workspace = true
+rowan = "0.16.1"
 vfs.workspace = true
-line-index.workspace = true
+line-index = "0.1.2"
 
 [dev-dependencies]
 expect-test = "1.5.1"

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -12,28 +12,32 @@ rust-version.workspace = true
 [lib]
 
 [dependencies]
-crossbeam-channel.workspace = true
-tracing.workspace = true
+crossbeam-channel = "0.5.15"
+tracing = "0.1.41"
 fst = { version = "0.4.7", default-features = false }
-rustc-hash.workspace = true
-either.workspace = true
-itertools.workspace = true
-arrayvec.workspace = true
-indexmap.workspace = true
-memchr.workspace = true
-salsa.workspace = true
-triomphe.workspace = true
-nohash-hasher.workspace = true
-bitflags.workspace = true
-smol_str.workspace = true
-smallvec.workspace = true
+rustc-hash = "2.1.1"
+either = "1.15.0"
+itertools = "0.14.0"
+arrayvec = "0.7.6"
+indexmap = "2.11.0"
+memchr = "2.7.5"
+salsa = "0.17.0-pre.2"
+triomphe = { version = "0.1.14", default-features = false, features = ["std"] }
+nohash-hasher = "0.2.0"
+bitflags = "2.9.4"
+smol_str = "0.3.2"
+smallvec = { version = "1.15.1", features = [
+  "const_new",
+  "union",
+  "const_generics",
+] }
 
 # local deps
 base-db.workspace = true
 ide-completion.workspace = true
 syntax.workspace = true
 wgsl-formatter.workspace = true
-rowan.workspace = true
+rowan = "0.16.1"
 parser.workspace = true
 ide-db.workspace = true
 stdx.workspace = true
@@ -45,7 +49,7 @@ hir.workspace = true
 hir-def.workspace = true # todo
 hir-ty.workspace = true  # todo
 
-line-index.workspace = true
+line-index = "0.1.2"
 
 naga14 = { package = "naga", version = "0.14", features = [
   "wgsl-in",

--- a/crates/ide_completion/Cargo.toml
+++ b/crates/ide_completion/Cargo.toml
@@ -28,9 +28,9 @@ rowan = "0.16.1"
 rustc-hash = "2.1.1"
 smol_str = "0.3.2"
 smallvec = { version = "1.15.1", features = [
-	"const_new",
-	"union",
-	"const_generics",
+  "const_new",
+  "union",
+  "const_generics",
 ] }
 
 [dev-dependencies]

--- a/crates/ide_completion/Cargo.toml
+++ b/crates/ide_completion/Cargo.toml
@@ -18,19 +18,23 @@ hir.workspace = true
 hir-ty.workspace = true
 hir-def.workspace = true
 syntax.workspace = true
-tracing.workspace = true
+tracing = "0.1.41"
 stdx.workspace = true
 ide-db.workspace = true
 
-itertools.workspace = true
-either.workspace = true
-rowan.workspace = true
-rustc-hash.workspace = true
-smol_str.workspace = true
-smallvec.workspace = true
+itertools = "0.14.0"
+either = "1.15.0"
+rowan = "0.16.1"
+rustc-hash = "2.1.1"
+smol_str = "0.3.2"
+smallvec = { version = "1.15.1", features = [
+	"const_new",
+	"union",
+	"const_generics",
+] }
 
 [dev-dependencies]
-proptest.workspace = true
+proptest = "1.7.0"
 
 [lints]
 workspace = true

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -14,12 +14,12 @@ doctest = false
 
 [dependencies]
 drop_bomb = "0.1.5"
-logos.workspace = true
-rowan.workspace = true
+logos = "0.12.1"
+rowan = "0.16.1"
 edition.workspace = true
 
 [dev-dependencies]
-expect-test.workspace = true
+expect-test = "1.5.1"
 
 [lints]
 workspace = true

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -21,7 +21,7 @@ jemalloc-ctl = { version = "0.6.0", package = "tikv-jemalloc-ctl", optional = tr
 perf-event = "=0.4.8"
 
 [target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
-libc.workspace = true
+libc = "0.2.175"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.60", features = [

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -15,14 +15,14 @@ doctest = false
 
 [dependencies]
 backtrace = { version = "0.3.75", optional = true }
-jod-thread.workspace = true
-crossbeam-channel.workspace = true
-itertools.workspace = true
-tracing.workspace = true
+jod-thread = "1.0.0"
+crossbeam-channel = "0.5.15"
+itertools = "0.14.0"
+tracing = "0.1.41"
 # Think twice before adding anything here
 
 [target.'cfg(unix)'.dependencies]
-libc.workspace = true
+libc = "0.2.175"
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.6.0"

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -13,11 +13,11 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-either.workspace = true
-itertools.workspace = true
-rowan.workspace = true
+either = "1.15.0"
+itertools = "0.14.0"
+rowan = "0.16.1"
 parser.workspace = true
-smol_str.workspace = true
+smol_str = "0.3.2"
 
 [lints]
 workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -14,9 +14,9 @@ doctest = false
 
 [dependencies]
 # Avoid adding deps here, this crate is widely used in tests it should compile fast!
-dissimilar.workspace = true
-text-size.workspace = true
-rustc-hash.workspace = true
+dissimilar = "1.0.10"
+text-size = "1.1.1"
+rustc-hash = "2.1.1"
 
 paths.workspace = true
 stdx.workspace = true

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 home = "0.5.11"
-camino.workspace = true
+camino = "1.1.12"
 
 [lints]
 workspace = true

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -12,17 +12,17 @@ rust-version.workspace = true
 [lib]
 
 [dependencies]
-tracing.workspace = true
-walkdir.workspace = true
-crossbeam-channel.workspace = true
-notify.workspace = true
-rayon.workspace = true
-camino.workspace = true
+tracing = "0.1.41"
+walkdir = "2.5.0"
+crossbeam-channel = "0.5.15"
+notify = "8.2.0"
+rayon = "1.11.0"
+camino = "1.1.12"
 
 stdx.workspace = true
 vfs.workspace = true
 paths.workspace = true
-rustc-hash.workspace = true
+rustc-hash = "2.1.1"
 
 [lints]
 workspace = true

--- a/crates/wgsl-analyzer/Cargo.toml
+++ b/crates/wgsl-analyzer/Cargo.toml
@@ -19,39 +19,46 @@ name = "wgsl-analyzer"
 path = "src/bin/main.rs"
 
 [dependencies]
-anyhow.workspace = true
-# base64.workspace = true
-crossbeam-channel.workspace = true
-# dirs.workspace = true
-dissimilar.workspace = true
+anyhow = "1.0.99"
+# base64 = "0.22"
+crossbeam-channel = "0.5.15"
+# dirs = "5.0.1"
+dissimilar = "1.0.10"
 ide-completion.workspace = true
-itertools.workspace = true
-# scip.workspace = true
+itertools = "0.14.0"
+# scip = "0.5.2"
 lsp-types = { version = "=0.95.0", features = ["proposed"] }
-parking_lot.workspace = true
-xflags.workspace = true
-# threadpool.workspace = true
-salsa.workspace = true
-oorandom.workspace = true
-rayon.workspace = true
-rustc-hash.workspace = true
-serde_json = { workspace = true, features = ["preserve_order"] }
-serde.workspace = true
-# tenthash.workspace = true
-num_cpus.workspace = true
+parking_lot = "0.12.4"
+xflags = "0.3.2"
+# threadpool = "1.8.1"
+salsa = "0.17.0-pre.2"
+oorandom = "11.1.5"
+rayon = "1.11.0"
+rustc-hash = "2.1.1"
+serde_json = { version = "1.0.143", features = ["preserve_order"] }
+serde = { version = "1.0.219", features = ["derive"] }
+# tenthash = "1.0.0"
+num_cpus = "1.17.0"
 mimalloc = { version = "0.1.48", default-features = false, optional = true }
-lsp-server.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
-tracing-tree.workspace = true
-triomphe.workspace = true
-# toml.workspace = true
-nohash-hasher.workspace = true
-walkdir.workspace = true
-semver.workspace = true
-memchr.workspace = true
-cargo_metadata.workspace = true
-# process-wrap.workspace = true
+lsp-server = "0.7.9"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", default-features = false, features = [
+  "registry",
+  "fmt",
+  "local-time",
+  "std",
+  "time",
+  "tracing-log",
+] }
+tracing-tree = "0.3.1"
+triomphe = { version = "0.1.14", default-features = false, features = ["std"] }
+# toml = "0.8.8"
+nohash-hasher = "0.2.0"
+walkdir = "2.5.0"
+semver = "1.0.26"
+memchr = "2.7.5"
+cargo_metadata = "0.19.2"
+# process-wrap = { version = "8.2.0", features = ["std"] }
 # cfg.workspace = true
 hir-def.workspace = true
 hir-ty.workspace = true
@@ -61,7 +68,7 @@ ide-db.workspace = true
 # This should only be used in CLI
 # ide-ssr.workspace = true
 ide.workspace = true
-# load-cargo.workspace = true
+# load-wesl.workspace = true
 # profile.workspace = true
 # project-model.workspace = true
 stdx.workspace = true
@@ -73,7 +80,7 @@ vfs.workspace = true
 paths.workspace = true
 camino = "1.1.12"
 base-db.workspace = true
-line-index.workspace = true
+line-index = "0.1.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.60", features = [
@@ -85,8 +92,8 @@ windows-sys = { version = "0.60", features = [
 jemallocator = { version = "0.6.0", package = "tikv-jemallocator", optional = true }
 
 [dev-dependencies]
-# expect-test.workspace = true
-# xshell.workspace = true
+# expect-test = "1.5.1"
+# xshell = "0.2.7"
 
 test-utils.workspace = true
 # test-fixture.workspace = true

--- a/crates/wgsl-analyzer/src/bin/main.rs
+++ b/crates/wgsl-analyzer/src/bin/main.rs
@@ -330,7 +330,6 @@ fn setup_logging(log_file_flag: Option<PathBuf>) -> anyhow::Result<()> {
         filter: env::var("WA_LOG")
             .ok()
             .unwrap_or_else(|| "error".to_owned()),
-        chalk_filter: env::var("CHALK_DEBUG").ok(),
         profile_filter: env::var("WA_PROFILE").ok(),
         json_profile_filter: std::env::var("WA_PROFILE_JSON").ok(),
     }

--- a/crates/wgsl_formatter/Cargo.toml
+++ b/crates/wgsl_formatter/Cargo.toml
@@ -12,12 +12,12 @@ rust-version.workspace = true
 [dependencies]
 syntax.workspace = true
 parser.workspace = true
-rowan.workspace = true
+rowan = "0.16.1"
 
 [dev-dependencies]
-# anyhow.workspace = true
-expect-test.workspace = true
-dissimilar.workspace = true
+# anyhow = "1.0.99"
+expect-test = "1.5.1"
+dissimilar = "1.0.10"
 
 [lints]
 workspace = true

--- a/crates/wgslfmt/Cargo.toml
+++ b/crates/wgslfmt/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2024"
 
 [dependencies]
 wgsl-formatter.workspace = true
-anyhow.workspace = true
-lexopt.workspace = true
-prettydiff.workspace = true
+anyhow = "1.0.99"
+lexopt = "0.3.1"
+prettydiff = "0.8.1"
 
 [lints]
 workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2024"
 rust-version.workspace = true
 
 [dependencies]
-anyhow.workspace = true
+anyhow = "1.0.99"
 directories = "6.0.0"
 flate2 = "1.1.2"
 write-json = "0.1.4"
-xshell.workspace = true
+xshell = "0.2.7"
 xflags = "0.3.2"
-time = { version = "0.3.42", default-features = false }
-zip = { version = "4.5.0", default-features = false, features = [
+time = { version = "0.3.43", default-features = false }
+zip = { version = "4.6.1", default-features = false, features = [
   "deflate",
   "time",
 ] }
@@ -22,8 +22,8 @@ stdx.workspace = true
 # proc-macro2 = "1.0.93"
 # quote = "1.0.38"
 # ungrammar = "1.16.1"
-either.workspace = true
-itertools.workspace = true
+either = "1.15.0"
+itertools = "0.14.0"
 # Avoid adding more dependencies to this crate
 
 [lints]


### PR DESCRIPTION
# Objective

Dependabot cannot keep workspace dependencies up to date, and we want Dependabot to keep our dependencies up to date.

https://github.com/dependabot/dependabot-core/issues/7896

## Solution

This PR works around that by not using workspace dependencies in most cases. The versions will naturally be in sync because we have `cargo deny` for denying multiple versions of the same dependency in the tree and Dependabot will update all files at once.

Note that this can be undone using https://mainmatter.com/blog/2024/03/18/cargo-autoinherit/ in the future when the Dependabot bug is fixed.

