### PR TITLE
internal: Speed up toml CI check using Docker image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,21 +180,17 @@ jobs:
           globs: '**/*.md'
 
   toml:
+    name: Check TOML formatting
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v5
 
-      - name: Install stable Rust toolchain
-        uses: dtolnay/rust-toolchain@1.90.0
-
-      - name: Install taplo
-        run: cargo install taplo-cli --locked
-
-      - name: Run Taplo
-        id: taplo
-        run: taplo fmt --check --diff
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check formatting with with Taplo
+        uses: docker://docker.io/tamasfe/taplo:latest
+        with:
+          args: fmt --check --diff
 
       - name: Taplo info
         if: failure()


### PR DESCRIPTION
# Objective

CI is fast and doesn't waste resources.

## Solution

Copy CI from the taplo repository itself.

## Testing

Should bring this step down from a few minutes down to a few seconds.

## Showcase

Before
<img width="230" height="42" alt="image" src="https://github.com/user-attachments/assets/c54d0a14-00fb-4754-84ad-3c678d8e0398" />

After
<img width="241" height="32" alt="image" src="https://github.com/user-attachments/assets/dff5614e-92cd-4714-a018-34c365561701" />

