### PR TITLE
internal: Install cargo-udeps from GitGub Releases instead of building it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,15 +261,15 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      # cargo-udeps requires this toolchain at runtime
       - name: Install nightly Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
 
-      - name: Install udeps
-        run: cargo install --locked cargo-udeps
-
-      - name: Run udeps
+      - name: Install cargo-udeps
+        uses: taiki-e/install-action@cargo-udeps
+      - name: Run cargo-udeps
         run: cargo udeps
 
   typescript:


### PR DESCRIPTION
# Objective

cargo-udeps takes a long time to build and it is unnecessary for this check

## Solution

This install action uses binstall to install a tool from GitHub Releases. I see it used in other projects.

## Testing

Tested in CI

## Showcase

Before
<img width="271" height="56" alt="image" src="https://github.com/user-attachments/assets/b0ec7aa2-dc8b-41f8-81a5-7d2968f3782d" />

After
<img width="224" height="43" alt="image" src="https://github.com/user-attachments/assets/8a717a4d-0720-4564-8555-806b4db744c8" />
