### PR TITLE
Toml fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,29 +13,6 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/wgsl-analyzer/wgsl-analyzer"
 
-[profile.dev]
-debug = 1
-
-[profile.dev.package]
-# These speed up local tests.
-rowan.opt-level = 3
-rustc-hash.opt-level = 3
-smol_str.opt-level = 3
-text-size.opt-level = 3
-serde.opt-level = 3
-salsa.opt-level = 3
-# This speeds up `cargo xtask dist`.
-# miniz_oxide.opt-level = 3
-
-[profile.release]
-incremental = true
-# Set this to 1 or 2 to get more useful backtraces in debugger.
-debug = 0
-
-[profile.dev-rel]
-inherits = "release"
-debug = 2
-
 [workspace.dependencies]
 # local crates
 base-db = { path = "./crates/base_db", version = "0.0.0" }
@@ -171,3 +148,26 @@ missing_inline_in_public_items = "allow"
 
 # prefer get().expect() so that the reason is documented
 indexing_slicing = "allow"
+
+[profile.dev]
+debug = 1
+
+[profile.dev.package]
+# These speed up local tests.
+rowan.opt-level = 3
+rustc-hash.opt-level = 3
+smol_str.opt-level = 3
+text-size.opt-level = 3
+serde.opt-level = 3
+salsa.opt-level = 3
+# This speeds up `cargo xtask dist`.
+# miniz_oxide.opt-level = 3
+
+[profile.release]
+incremental = true
+# Set this to 1 or 2 to get more useful backtraces in debugger.
+debug = 0
+
+[profile.dev-rel]
+inherits = "release"
+debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ resolver = "2"
 rust-version = "1.90"
 edition = "2024"
 license = "MIT OR Apache-2.0"
-authors = ["wgsl-analyzer team"]
 repository = "https://github.com/wgsl-analyzer/wgsl-analyzer"
 
 [profile.dev]

--- a/crates/base_db/Cargo.toml
+++ b/crates/base_db/Cargo.toml
@@ -3,8 +3,6 @@ name = "base-db"
 version = "0.0.0"
 repository.workspace = true
 description = "Basic database traits for wgsl-analyzer. The concrete DB is defined by `ide` (aka `wa_ap_ide`)."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/edition/Cargo.toml
+++ b/crates/edition/Cargo.toml
@@ -5,7 +5,6 @@ description = "Shader language edition support crate for wgsl-analyzer."
 rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
-authors.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -3,8 +3,6 @@ name = "hir"
 version = "0.0.0"
 repository.workspace = true
 description = "A high-level object-oriented access to code for wgsl-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -3,8 +3,6 @@ name = "hir-def"
 version = "0.0.0"
 repository.workspace = true
 description = "RPC Api for the `proc-macro-srv` crate of wgsl-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -3,8 +3,6 @@ name = "hir-ty"
 version = "0.0.0"
 repository.workspace = true
 description = "The type system for wgsl-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -3,8 +3,6 @@ name = "ide-db"
 version = "0.0.0"
 repository.workspace = true
 description = "IDE Database of wgsl-analyzer"
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -3,8 +3,6 @@ name = "ide"
 version = "0.0.0"
 repository.workspace = true
 description = "Core data structure representing IDE state for wgsl-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/ide_completion/Cargo.toml
+++ b/crates/ide_completion/Cargo.toml
@@ -3,8 +3,6 @@ name = "ide-completion"
 version = "0.0.0"
 repository.workspace = true
 description = "Utilities for generating completions of user input for wgsl-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -3,8 +3,6 @@ name = "parser"
 version = "0.0.0"
 repository.workspace = true
 description = "The parser for wgsl-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -3,8 +3,6 @@ name = "profile"
 version = "0.0.0"
 repository.workspace = true
 description = "A collection of tools for profiling wgsl-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -3,9 +3,7 @@ name = "stdx"
 version = "0.0.0"
 repository.workspace = true
 description = "Missing batteries for standard libraries for wgsl-analyzer."
-
 publish = false
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -3,8 +3,6 @@ name = "syntax"
 version = "0.0.0"
 repository.workspace = true
 description = "Concrete syntax tree definitions for wgsl-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -3,8 +3,6 @@ name = "test-utils"
 version = "0.0.0"
 repository.workspace = true
 description = "Assorted testing utilities for wgsl-analyzer"
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -3,8 +3,6 @@ name = "toolchain"
 version = "0.0.0"
 repository.workspace = true
 description = "Discovery of `cargo` & `rustc` executables for rust-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -3,8 +3,6 @@ name = "vfs-notify"
 version = "0.0.0"
 repository.workspace = true
 description = "Implementation of `loader::Handle` for wgsl-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/wgsl-analyzer/Cargo.toml
+++ b/crates/wgsl-analyzer/Cargo.toml
@@ -6,8 +6,6 @@ repository.workspace = true
 description = "A language server for WGSL and WESL code"
 # documentation = "https://wgsl-analyzer.github.io/manual.html"
 autobins = false
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/wgsl_formatter/Cargo.toml
+++ b/crates/wgsl_formatter/Cargo.toml
@@ -3,8 +3,6 @@ name = "wgsl-formatter"
 version = "0.0.0"
 repository.workspace = true
 description = "RPC Api for the `proc-macro-srv` crate of wgsl-analyzer."
-
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
# Objective

Tombi keeps shouting at me because it doesn't like our `Cargo.toml` files. Turns out that they have a point.

The authors field is deprecated. https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field

And the order in which we defined tables is discouraged by the toml specification.

> Defining tables out-of-order is discouraged.
> https://toml.io/en/v1.0.0#table

## Solution

I removed the authors field, and moved the offending table further down.

## Testing

- Dear CI, please be green

## Showcase

<img width="504" height="265" alt="image" src="https://github.com/user-attachments/assets/9dd60f4c-8730-4f3a-a0c0-afcaffc6989c" />

Zero warnings, even with tombi installed :)