### PR TITLE
feature: Add WESL syntax highlighting in strings and markdown files

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1732,6 +1732,34 @@
 					"punctuation.definition.tag.range.wgsl",
 					"keyword.other.array-item.wgsl"
 				]
+			},
+			{
+				"injectTo": [
+					"source.js",
+					"source.ts",
+					"source.rust"
+				],
+				"scopeName": "source.comment-string.wesl",
+				"path": "./syntaxes/inline-wesl.tmLanguage.json",
+				"embeddedLanguages": {
+					"meta.embedded.block.wesl": "wesl"
+				}
+			},
+			{
+				"scopeName": "markdown.wesl.codeblock",
+				"path": "./syntaxes/inline-wesl.markdown.tmLanguage.json",
+				"injectTo": [
+					"text.html.markdown"
+				],
+				"embeddedLanguages": {
+					"meta.embedded.block.wesl": "wesl"
+				},
+				"unbalancedBracketScopes": [
+					"punctuation.definition.tag.begin.wgsl",
+					"punctuation.definition.tag.end.wgsl",
+					"punctuation.definition.tag.range.wgsl",
+					"keyword.other.array-item.wgsl"
+				]
 			}
 		],
 		"semanticTokenTypes": [

--- a/editors/code/syntaxes/inline-wesl.markdown.tmLanguage.json
+++ b/editors/code/syntaxes/inline-wesl.markdown.tmLanguage.json
@@ -1,0 +1,27 @@
+{
+	"scopeName": "markdown.wesl.codeblock",
+	"fileTypes": ["md"],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [{ "include": "#fenced_code_block_wesl" }],
+	"repository": {
+		"fenced_code_block_wesl": {
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(wesl)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": { "name": "punctuation.definition.markdown" },
+				"4": { "name": "fenced_code.block.language" },
+				"5": { "name": "fenced_code.block.language.attributes" }
+			},
+			"endCaptures": { "3": { "name": "punctuation.definition.markdown" } },
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.wesl",
+					"patterns": [{ "include": "source.wesl" }]
+				}
+			]
+		}
+	}
+}

--- a/editors/code/syntaxes/inline-wesl.tmLanguage.json
+++ b/editors/code/syntaxes/inline-wesl.tmLanguage.json
@@ -1,0 +1,46 @@
+{
+	"scopeName": "source.comment-string.wesl",
+	"fileTypes": ["js", "ts", "rs"],
+	"injectionSelector": "L:source -comment -string",
+	"patterns": [
+		{
+			"comment": "JavaScript multi-line strings",
+			"begin": "(\\s?/\\*\\s?(?i:wesl)\\s?\\*/\\s*)(`)",
+			"beginCaptures": {
+				"1": { "name": "entity.name.function.tagged-template.ts" },
+				"2": { "name": "string.template.ts, punctuation.definition.string.template.begin.ts" }
+			},
+			"end": "(`)",
+			"endCaptures": {
+				"0": { "name": "string.template.ts, punctuation.definition.string.template.end.ts" }
+			},
+			"patterns": [
+				{ "include": "source.ts#template-substitution-element" },
+				{ "include": "source.wesl" }
+			]
+		},
+		{
+			"comment": "Rust multi-line raw/byte strings",
+			"begin": "(\\s?/\\*\\s?(?i:wesl)\\s?\\*/\\s*)(b?r?)(#*)(\")",
+			"beginCaptures": {
+				"1": { "name": "entity.name.function.rust" },
+				"2": { "name": "string.quoted.byte.raw.rust" },
+				"3": { "name": "string.raw.rust" },
+				"4": { "name": "string.rust" }
+			},
+			"end": "(\")(\\3)",
+			"endCaptures": {
+				"1": { "name": "string.rust" },
+				"2": { "name": "string.raw.rust" }
+			},
+			"patterns": [{ "include": "source.wesl" }]
+		},
+		{
+			"comment": "Standard strings",
+			"begin": "(\\s?/\\*\\s?(?i:wesl)\\s?\\*/\\s*)(\")",
+			"beginCaptures": { "1": { "name": "entity.name.function" } },
+			"end": "(\")",
+			"patterns": [{ "include": "source.wesl" }]
+		}
+	]
+}


### PR DESCRIPTION
# Objective

Fixes #635 

Support syntax highlighting for WESL the same way it already has for WGSL.


## Solution

Copy the same method as the WGSL support.

## Testing

Tested locally

## Showcase

<img width="1524" height="384" alt="image" src="https://github.com/user-attachments/assets/50182518-5ba7-47d5-9797-3b2c04c5dc0e" />
