### PR TITLE
docs: fix edit page URL

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -9,8 +9,8 @@ title = "wgsl-analyzer"
 edition = "2024"
 
 [output.html]
-edit-url-template = "https://github.com/wgsl-analyzer/wgsl-analyzer/edit/master/docs/book/{path}"
-git-repository-url = "https://github.com/wgsl-analyzer/wgsl-analyzer/tree/master/docs/book"
+edit-url-template = "https://github.com/wgsl-analyzer/wgsl-analyzer/edit/main/docs/book/{path}"
+git-repository-url = "https://github.com/wgsl-analyzer/wgsl-analyzer/tree/main/docs/book"
 mathjax-support = true
 site-url = "/book/"
 


### PR DESCRIPTION
# Objective

"Suggest an Edit" button on any page on the docs currently points to a 404 page.

## Solution

Update the edit-url-template to point to the current path

## Testing

- Did you test these changes? If so, how?
Ran mdbook serve locally and observed
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
`mdbook serve`
