### PR TITLE
Suggest using tombi VSCode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,11 +5,11 @@
 	"recommendations": [
 		"vadimcn.vscode-lldb",
 		"editorconfig.editorconfig",
-		"tamasfe.even-better-toml",
 		"github.vscode-github-actions",
 		"davidanson.vscode-markdownlint",
 		"redcmd.tmlanguage-syntax-highlighter",
-		"biomejs.biome"
+		"biomejs.biome",
+		"tombi-toml.tombi"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []


### PR DESCRIPTION
# Objective

I forgot to update the VSCode extension recommendations in the #725 PR. 

## Solution

Now we're recommending the correct ones. 
