### PR TITLE
add diagnostic for identifiers starting with __

### DIFF
--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -147,6 +147,11 @@ pub enum AnyDiagnostic {
         expression: InFile<AstPointer<ast::Expression>>,
         message: String,
     },
+    InvalidIdentifier {
+        file_id: HirFileId,
+        name: Name,
+        range: TextRange,
+    },
     ExpectedLoweredKind {
         expression: InFile<AstPointer<ast::Expression>>,
         expected: LoweredKind,
@@ -181,7 +186,8 @@ impl AnyDiagnostic {
             Self::InvalidTypeSpecifier { type_specifier, .. } => type_specifier.file_id,
             Self::NagaValidationError { file_id, .. }
             | Self::ParseError { file_id, .. }
-            | Self::CyclicType { file_id, .. } => *file_id,
+            | Self::CyclicType { file_id, .. }
+            | Self::InvalidIdentifier { file_id, .. } => *file_id,
         }
     }
 }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -853,6 +853,8 @@ impl Module {
         config: &DiagnosticsConfig,
         accumulator: &mut Vec<AnyDiagnostic>,
     ) {
+        validate_identifiers(self.file_id, database, accumulator);
+
         for item in self.items(database) {
             match item {
                 ModuleDef::Function(_function) => {},
@@ -867,10 +869,10 @@ impl Module {
                 ModuleDef::GlobalConstant(_constant) => {},
                 ModuleDef::Override(_constant) => {},
                 ModuleDef::GlobalAssertStatement(_global_assert_statement) => {},
-                ModuleDef::Struct(strukt) => {
-                    let file = strukt.id.lookup(database).file_id;
-                    let (_, signature_map) = database.struct_data(strukt.id);
-                    let diagnostics = &database.field_types(strukt.id).1;
+                ModuleDef::Struct(r#struct) => {
+                    let file = r#struct.id.lookup(database).file_id;
+                    let (_, signature_map) = database.struct_data(r#struct.id);
+                    let diagnostics = &database.field_types(r#struct.id).1;
                     for diagnostic in diagnostics {
                         if diagnostic.source != ExpressionStoreSource::Signature {
                             tracing::warn!(
@@ -916,42 +918,105 @@ impl Module {
                     }
                 },
             }
-            if let Some(definition) = item.as_def_with_body_id() {
-                let file = definition.file_id(database);
-                let (_, signature_map) = database.signature_with_source_map(definition);
-                let (_, source_map) = database.body_with_source_map(definition);
-                if config.type_errors {
-                    let infer = database.infer(definition);
-                    for diagnostic in infer.diagnostics() {
-                        match diagnostics::any_diag_from_infer_diagnostic(
-                            &diagnostic.kind,
-                            match diagnostic.source {
-                                ExpressionStoreSource::Body => source_map.expression_source_map(),
-                                ExpressionStoreSource::Signature => &signature_map,
-                            },
-                            file,
-                        ) {
-                            Some(diagnostic) => accumulator.push(diagnostic),
-                            None => {
-                                tracing::warn!("could not create diagnostic from {:?}", diagnostic);
-                            },
-                        }
-                    }
-                }
-
-                diagnostics::precedence::collect(database, definition, |diagnostic| {
-                    match diagnostics::any_diag_from_shift(
-                        &diagnostic,
-                        source_map.expression_source_map(),
-                        file,
-                    ) {
-                        Some(diagnostic) => accumulator.push(diagnostic),
-                        None => {
-                            tracing::warn!("could not create diagnostic from {:?}", diagnostic);
-                        },
-                    }
-                });
+            if config.type_errors {
+                check_type_errors(database, accumulator, &item);
             }
         }
+    }
+}
+
+#[expect(clippy::doc_paragraphs_missing_punctuation, reason = "clippy bug")]
+/// Check for identifiers starting with "__". These are invalid according the WGSL specification.
+///
+/// See: <https://www.w3.org/TR/WGSL/#identifiers>
+fn validate_identifiers(
+    file_id: HirFileId,
+    database: &dyn HirDatabase,
+    accumulator: &mut Vec<AnyDiagnostic>,
+) {
+    let item_tree = database.item_tree(file_id);
+    let ast_id_map = database.ast_id_map(file_id);
+    let root = database.parse_or_resolve(file_id).syntax();
+
+    macro_rules! validate {
+        ($id:expr, $item_tree:expr, $ast_id_map:expr, $root:expr, $accumulator:expr, $file_id:expr) => {{
+            let data = $item_tree.get(*$id);
+            if data.name.as_str().starts_with("__") {
+                let ast_ptr = $ast_id_map.get(data.ast_id);
+                let node = ast_ptr.to_node(&$root);
+                if let Some(name_node) = node.name() {
+                    $accumulator.push(AnyDiagnostic::InvalidIdentifier {
+                        file_id: $file_id,
+                        name: data.name.clone(),
+                        range: name_node.syntax().text_range(),
+                    });
+                }
+            }
+        }};
+    }
+
+    for item in item_tree.items() {
+        match item {
+            ModuleItem::Function(id) => {
+                validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
+            },
+            ModuleItem::GlobalVariable(id) => {
+                validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
+            },
+            ModuleItem::GlobalConstant(id) => {
+                validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
+            },
+            ModuleItem::Override(id) => {
+                validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
+            },
+            ModuleItem::Struct(id) => {
+                validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
+            },
+            ModuleItem::TypeAlias(id) => {
+                validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
+            },
+            ModuleItem::ImportStatement(_) | ModuleItem::GlobalAssertStatement(_) => {},
+        }
+    }
+}
+
+fn check_type_errors(
+    database: &dyn HirDatabase,
+    accumulator: &mut Vec<AnyDiagnostic>,
+    item: &ModuleDef,
+) {
+    if let Some(definition) = item.as_def_with_body_id() {
+        let file = definition.file_id(database);
+        let (_, signature_map) = database.signature_with_source_map(definition);
+        let (_, source_map) = database.body_with_source_map(definition);
+        let infer = database.infer(definition);
+        for diagnostic in infer.diagnostics() {
+            match diagnostics::any_diag_from_infer_diagnostic(
+                &diagnostic.kind,
+                match diagnostic.source {
+                    ExpressionStoreSource::Body => source_map.expression_source_map(),
+                    ExpressionStoreSource::Signature => &signature_map,
+                },
+                file,
+            ) {
+                Some(diagnostic) => accumulator.push(diagnostic),
+                None => {
+                    tracing::warn!("could not create diagnostic from {:?}", diagnostic);
+                },
+            }
+        }
+
+        diagnostics::precedence::collect(database, definition, |diagnostic| {
+            match diagnostics::any_diag_from_shift(
+                &diagnostic,
+                source_map.expression_source_map(),
+                file,
+            ) {
+                Some(diagnostic) => accumulator.push(diagnostic),
+                None => {
+                    tracing::warn!("could not create diagnostic from {:?}", diagnostic);
+                },
+            }
+        });
     }
 }

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -644,6 +644,11 @@ More complex operands must be this with parenthesized `()`"
                         frange.range,
                     )
                 },
+                AnyDiagnostic::InvalidIdentifier { name, range, .. } => Diagnostic::new(
+                    DiagnosticCode("24"),
+                    format!("'{}' is not a valid name for an identifier", name.as_str()),
+                    range,
+                ),
             }
         })
         .collect()
@@ -746,6 +751,31 @@ var<storage> lines: array<LineSegment>;
             expect![[r#"
                 48..59 Error 14: `LineSegment` not found in scope
             "#]],
+        );
+    }
+
+    #[test]
+    fn reserved_identifier_double_underscore() {
+        // https://github.com/wgsl-analyzer/wgsl-analyzer/issues/681
+        // Identifiers starting with "__" are reserved by the WGSL spec.
+        check_diagnostics(
+            "
+fn __my_func() {}
+",
+            expect![[r#"
+                3..12 Error 24: '__my_func' is not a valid name for an identifier
+            "#]],
+        );
+    }
+
+    #[test]
+    fn non_reserved_identifier_single_underscore() {
+        // A single underscore prefix should NOT trigger the reserved identifier diagnostic.
+        check_diagnostics(
+            "
+fn _my_func() {}
+",
+            expect![""],
         );
     }
 


### PR DESCRIPTION


# Objective

Fixes #681 

The WGSL spec describes what is a valid name for an identifier. Identifiers starting with double underscore (__) are not allowed.

## Solution

 This adds a diagnostic that flags user-defined declarations (functions, variables, constants, overrides, structs, type aliases) whose names start with __.

## Testing

Added test
