### PR TITLE
Fix Nix Build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib stdenv;
         craneLib = crane.mkLib pkgs;
-        weslFilter = path: _type: builtins.match ".*\.(wgsl|wesl|llw|wgsl.txt|.json)$" path != null;
+        weslFilter = path: _type: builtins.match ".*\.(wgsl|wesl|llw|wgsl.txt|.json|.md)$" path != null;
         weslOrCargo = path: type:
         (weslFilter path type) || (craneLib.filterCargoSources path type);
 


### PR DESCRIPTION
# Objective

I didn't find a relevant open issue, but the nix flake build was failing due to some file types being filtered out.

## Solution

I added the necessary file extensions to the filter list to get the build to succeed.

## Testing

The build now succeeds on my machine (Linux 6.18.18 x86_64 GNU/Linux).