### PR TITLE
Switch launch configuration order to be easier for new contributors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,26 +8,6 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			// Used for testing the extension with the installed LSP server.
-			"name": "Run Installed Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": [
-				// "--user-data-dir=${workspaceFolder}/target/code",
-				"--disable-extensions",
-				"--extensionDevelopmentPath=${workspaceFolder}/editors/code",
-				"--log wgsl-analyzer.wgsl-analyzer:debug"
-			],
-			"outFiles": [
-				"${workspaceFolder}/editors/code/out/**/*.js"
-			],
-			"preLaunchTask": "Build Extension",
-			"skipFiles": [
-				"<node_internals>/**/*.js"
-			]
-		},
-		{
 			// Used for testing the extension with a local build of the LSP server (in `target/debug`).
 			"name": "Run Extension (Debug Build)",
 			"type": "extensionHost",
@@ -71,6 +51,26 @@
 			"env": {
 				"__WA_LSP_SERVER_DEBUG": "${workspaceFolder}/target/release/wgsl-analyzer"
 			}
+		},
+		{
+			// Used for testing the extension with the installed LSP server.
+			"name": "Run Installed Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				// "--user-data-dir=${workspaceFolder}/target/code",
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}/editors/code",
+				"--log wgsl-analyzer.wgsl-analyzer:debug"
+			],
+			"outFiles": [
+				"${workspaceFolder}/editors/code/out/**/*.js"
+			],
+			"preLaunchTask": "Build Extension",
+			"skipFiles": [
+				"<node_internals>/**/*.js"
+			]
 		},
 		{
 			// Used for testing the extension with a local build of the LSP server (in `target/release`)


### PR DESCRIPTION
F5 now works by default

# Objective

I cloned wgsl-analyzer on my new laptop, hit F5 and was frustrated because the extension seemingly did not work

## Solution

Turns out that the default/topmost task is "run installed extension".
I swapped the order, it now is "Run Extension (Debug Build)" which is what I pretty much always want.