### PR TITLE
Switch to cheaper Linux runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
 
       # https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/rust.json
       - name: Install Rust Problem Matcher
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'ubuntu-latest'
         run: echo "::add-matcher::.github/rust.json"
 
       # - name: Cache Dependencies
@@ -98,8 +98,8 @@ jobs:
         run: cargo nextest run --no-fail-fast --hide-progress-bar --status-level fail
 
       - name: Clippy
-        # Because macos runners are the fastest
-        if: matrix.os == 'macos-latest'
+        # Because Linux runners are the fastest
+        if: matrix.os == 'ubuntu-latest'
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   rustfmt:


### PR DESCRIPTION
# Objective

I saw the comment about the macos runners being faster. And I'm skeptical.


## Solution

Try out the Linux runners. Let's see what the CI times actually say.


## Testing

The Linux run took 2m 31s 
https://github.com/wgsl-analyzer/wgsl-analyzer/actions/runs/23483979850/job/68334632101?pr=947
That Linux run took 2m 38s
https://github.com/wgsl-analyzer/wgsl-analyzer/actions/runs/23483979850/job/68335536243?pr=947

Which is on par with some of our previous MacOS runs
- 2m 52s for https://github.com/wgsl-analyzer/wgsl-analyzer/actions/runs/23434443477/job/68168829484
- 2m 12s for https://github.com/wgsl-analyzer/wgsl-analyzer/actions/runs/23434424250/job/68168763413
- 2m 41s for https://github.com/wgsl-analyzer/wgsl-analyzer/actions/runs/23374595378/job/68004404150
- 2m 33s for https://github.com/wgsl-analyzer/wgsl-analyzer/actions/runs/23339716444/job/67890121243

## Conclusion

We probably would benefit from more points of data.
On the other hand, considering that the Linux runners are 10x cheaper while not introducing any obvious performance regressions, it seems reasonable to switch to them. https://docs.github.com/en/billing/concepts/product-billing/github-actions#baseline-minute-costs
