### PR TITLE
Early return on publish_diagnostics error

### DIFF
--- a/crates/wgsl-analyzer/src/handlers/request.rs
+++ b/crates/wgsl-analyzer/src/handlers/request.rs
@@ -242,7 +242,7 @@ pub(crate) fn handle_document_diagnostics(
         return Ok(empty_diagnostic_report());
     }
 
-    let items = publish_diagnostics(&snap, &config, file_id).unwrap();
+    let items = publish_diagnostics(&snap, &config, file_id)?;
 
     Ok(lsp_types::DocumentDiagnosticReportResult::Report(
         lsp_types::DocumentDiagnosticReport::Full(lsp_types::RelatedFullDocumentDiagnosticReport {


### PR DESCRIPTION
# Objective

Fixes https://github.com/wgsl-analyzer/wgsl-analyzer/issues/951

## Solution

Instead of using `.unwrap()`, use `?` so the error is caught and reported to devs.

## Testing

- Did you test these changes? If so, how?

Sort of. I'm not really sure how to reliably reproduce the error, so I just poked around in my wesl files for a while. I didn't see the error popup again.