### PR TITLE
introduce DiagnosticDirective syntaxnode

### DIFF
--- a/crates/parser/src/cst_builder.rs
+++ b/crates/parser/src/cst_builder.rs
@@ -84,7 +84,7 @@ impl CstBuilder<'_, '_> {
             Rule::DefaultCaseSelector => self.start_node(SyntaxKind::SwitchDefaultSelector),
             Rule::DiagnosticAttr => self.start_node(SyntaxKind::DiagnosticAttribute),
             Rule::DiagnosticControl => self.start_node(SyntaxKind::DiagnosticControl),
-            Rule::DiagnosticDirective => self.start_node(SyntaxKind::Diagnostic),
+            Rule::DiagnosticDirective => self.start_node(SyntaxKind::DiagnosticDirective),
             Rule::DiagnosticRuleName => self.start_node(SyntaxKind::DiagnosticRuleName),
             Rule::DiscardStatement => self.start_node(SyntaxKind::DiscardStatement),
             Rule::ElseClause => self.start_node(SyntaxKind::ElseClause),

--- a/crates/parser/src/syntax_kind.rs
+++ b/crates/parser/src/syntax_kind.rs
@@ -212,6 +212,7 @@ pub enum SyntaxKind {
     Diagnostic,
     DiagnosticControl,
     DiagnosticAttribute,
+    DiagnosticDirective,
     DiagnosticRuleName,
     SeverityControlName,
     Discard,
@@ -393,6 +394,7 @@ impl SyntaxKind {
             Self::SourceFile
                 | Self::EnableDirective
                 | Self::RequiresDirective
+                | Self::DiagnosticDirective
                 | Self::Attribute
                 | Self::ImportStatement
                 | Self::ImportPath

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(test), allow(unused))]
 
+mod diagnostic;
 mod expression;
 mod imports;
 
@@ -3607,45 +3608,6 @@ fn diagnostic_attribute() {
                       Identifier@26..29 "bla"
                     ParenthesisRight@29..30 ")"
                 Blankspace@30..39 "\n        "
-                Fn@39..41 "fn"
-                Blankspace@41..42 " "
-                Name@42..46
-                  Identifier@42..46 "main"
-                FunctionParameters@46..48
-                  ParenthesisLeft@46..47 "("
-                  ParenthesisRight@47..48 ")"
-                Blankspace@48..49 " "
-                CompoundStatement@49..51
-                  BraceLeft@49..50 "{"
-                  BraceRight@50..51 "}"
-              Blankspace@51..60 "\n        ""#]],
-    );
-}
-
-#[test]
-fn diagnostic_directive() {
-    check(
-        "
-        diagnostic(off, bla);
-        fn main() {}
-        ",
-        expect![[r#"
-            SourceFile@0..60
-              Blankspace@0..9 "\n        "
-              Diagnostic@9..30
-                Diagnostic@9..19 "diagnostic"
-                DiagnosticControl@19..29
-                  ParenthesisLeft@19..20 "("
-                  SeverityControlName@20..23
-                    Identifier@20..23 "off"
-                  Comma@23..24 ","
-                  Blankspace@24..25 " "
-                  DiagnosticRuleName@25..28
-                    Identifier@25..28 "bla"
-                  ParenthesisRight@28..29 ")"
-                Semicolon@29..30 ";"
-              Blankspace@30..39 "\n        "
-              FunctionDeclaration@39..51
                 Fn@39..41 "fn"
                 Blankspace@41..42 " "
                 Name@42..46

--- a/crates/parser/src/tests/diagnostic.rs
+++ b/crates/parser/src/tests/diagnostic.rs
@@ -1,0 +1,67 @@
+use expect_test::expect;
+
+use crate::tests::check;
+
+#[test]
+fn parse_diagnostic_attribute() {
+    check(
+        "
+        @diagnostic(off, bla)
+        fn a() {}
+        ",
+        expect![[r#"
+            SourceFile@0..57
+              Blankspace@0..9 "\n        "
+              FunctionDeclaration@9..48
+                DiagnosticAttribute@9..30
+                  AttributeOperator@9..10 "@"
+                  Diagnostic@10..20 "diagnostic"
+                  DiagnosticControl@20..30
+                    ParenthesisLeft@20..21 "("
+                    SeverityControlName@21..24
+                      Identifier@21..24 "off"
+                    Comma@24..25 ","
+                    Blankspace@25..26 " "
+                    DiagnosticRuleName@26..29
+                      Identifier@26..29 "bla"
+                    ParenthesisRight@29..30 ")"
+                Blankspace@30..39 "\n        "
+                Fn@39..41 "fn"
+                Blankspace@41..42 " "
+                Name@42..43
+                  Identifier@42..43 "a"
+                FunctionParameters@43..45
+                  ParenthesisLeft@43..44 "("
+                  ParenthesisRight@44..45 ")"
+                Blankspace@45..46 " "
+                CompoundStatement@46..48
+                  BraceLeft@46..47 "{"
+                  BraceRight@47..48 "}"
+              Blankspace@48..57 "\n        ""#]],
+    );
+}
+
+#[test]
+fn parse_diagnostic_directive() {
+    check(
+        "
+        diagnostic(off, bla);
+        ",
+        expect![[r#"
+            SourceFile@0..39
+              Blankspace@0..9 "\n        "
+              DiagnosticDirective@9..30
+                Diagnostic@9..19 "diagnostic"
+                DiagnosticControl@19..29
+                  ParenthesisLeft@19..20 "("
+                  SeverityControlName@20..23
+                    Identifier@20..23 "off"
+                  Comma@23..24 ","
+                  Blankspace@24..25 " "
+                  DiagnosticRuleName@25..28
+                    Identifier@25..28 "bla"
+                  ParenthesisRight@28..29 ")"
+                Semicolon@29..30 ";"
+              Blankspace@30..39 "\n        ""#]],
+    );
+}

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -644,7 +644,6 @@ ast_node! {
 ast_node! {
     Diagnostic:
     ident_token: Option<SyntaxToken Identifier>;
-    parameters: Option<Arguments>;
 }
 
 ast_node! {
@@ -654,7 +653,14 @@ ast_node! {
 }
 
 ast_node! {
+    DiagnosticDirective:
+    diagnostic_token: Option<Diagnostic>;
+    parameters: Option<DiagnosticControl>;
+}
+
+ast_node! {
     DiagnosticAttribute:
+    diagnostic_token: Option<Diagnostic>;
     parameters: Option<DiagnosticControl>;
 }
 


### PR DESCRIPTION
# Objective

The `Diagnostic` syntax kind serves double duty for the "diagnostic" token and for the diagnostic directive.

## Solution

introduce DiagnosticDirective syntaxnode

## Testing

See `parser/src/tests/diagnostic.rs`

## Extra Info

Feel free to close this PR or supersede it with the work in #983, i just thought i have already done the work, i might as well throw it your way!
