### PR TITLE
fix workgroup size attr parsing

### DIFF
--- a/crates/parser/src/tests/attributes.rs
+++ b/crates/parser/src/tests/attributes.rs
@@ -1650,14 +1650,13 @@ fn parse_all_attributes() {
                   AttributeOperator@709..710 "@"
                   Compute@710..717 "compute"
                 Blankspace@717..726 "\n        "
-                Attribute@726..744
+                WorkgroupSizeAttribute@726..744
                   AttributeOperator@726..727 "@"
-                  WorkgroupSizeAttribute@727..744
-                    WorkgroupSize@727..741 "workgroup_size"
-                    ParenthesisLeft@741..742 "("
-                    Literal@742..743
-                      IntLiteral@742..743 "1"
-                    ParenthesisRight@743..744 ")"
+                  WorkgroupSize@727..741 "workgroup_size"
+                  ParenthesisLeft@741..742 "("
+                  Literal@742..743
+                    IntLiteral@742..743 "1"
+                  ParenthesisRight@743..744 ")"
                 Blankspace@744..753 "\n        "
                 Fn@753..755 "fn"
                 Blankspace@755..756 " "

--- a/crates/parser/src/wesl.llw
+++ b/crates/parser/src/wesl.llw
@@ -201,7 +201,7 @@ attribute:
 			| 'location' '(' expression [','] ')' @location_attr
 			| 'must_use' @must_use_attr
 			| 'size' '(' expression [','] ')'@size_attr
-			| workgroup_size_attr
+			| workgroup_size_attr @workgroup_size_attr
 			| 'vertex' @vertex_attr
 			| 'fragment' @fragment_attr
 			| 'compute' @compute_attr
@@ -225,7 +225,7 @@ interpolate_sampling_name:
 	| 'either'
 ;
 
-workgroup_size_attr:
+workgroup_size_attr^:
 	'workgroup_size' '(' expression
 		[ ',' expression
 			[ ',' expression


### PR DESCRIPTION
# Objective

Fix `@workgroup_size` attr parsing to be inline with all the other attributes.

Before:
```
              FunctionDeclaration@9..50
                Attribute@9..31
                  AttributeOperator@9..10 "@"
                  WorkgroupSizeAttribute@10..31
                    WorkgroupSize@10..24 "workgroup_size"
                    ParenthesisLeft@24..25 "("
                    Literal@25..26
                      IntLiteral@25..26 "1"
                    Comma@26..27 ","
                    Literal@27..28
                      IntLiteral@27..28 "1"
                    Comma@28..29 ","
                    Literal@29..30
                      IntLiteral@29..30 "1"
                    ParenthesisRight@30..31 ")"
```

After:
```
              FunctionDeclaration@9..50
                WorkgroupSizeAttribute@9..31
                  AttributeOperator@9..10 "@"
                  WorkgroupSize@10..24 "workgroup_size"
                  ParenthesisLeft@24..25 "("
                  Literal@25..26
                    IntLiteral@25..26 "1"
                  Comma@26..27 ","
                  Literal@27..28
                    IntLiteral@27..28 "1"
                  Comma@28..29 ","
                  Literal@29..30
                    IntLiteral@29..30 "1"
                  ParenthesisRight@30..31 ")"
```

# Notes:
I have changed the lelwel grammar so that the `workgroup_size_attr` is being elided, and instead the `attribute` node is renamed to the `workgroup_size_attr`. This might not be the cleanest solution, but my reasoning was, that for the other attributes the `@` token is contained within the node. If we instead elide the `attribute` node and keep the `workgroup_size_attr` node then the `@` token would be outside the node and that is not inline with the others.