### PR TITLE
Ast fixes attribte fields

### DIFF
--- a/crates/hir_def/src/attributes.rs
+++ b/crates/hir_def/src/attributes.rs
@@ -93,56 +93,47 @@ fn get_attribute_parameters(
             .map_or_else(|| Either::Left(iter::empty()), Either::Right)
             .collect(),
         ast::Attribute::AlignAttribute(inner) => inner
-            .parameters()
-            .map(|p| p.arguments().map(|e| collector.collect_expression(e)))
-            .map_or_else(|| Either::Left(iter::empty()), Either::Right)
+            .parameter()
+            .into_iter()
+            .map(|e| collector.collect_expression(e))
             .collect(),
         ast::Attribute::BindingAttribute(inner) => inner
-            .parameters()
-            .map(|p| p.arguments().map(|e| collector.collect_expression(e)))
-            .map_or_else(|| Either::Left(iter::empty()), Either::Right)
+            .parameter()
+            .into_iter()
+            .map(|e| collector.collect_expression(e))
             .collect(),
         ast::Attribute::BlendSrcAttribute(inner) => inner
-            .parameters()
-            .map(|p| p.arguments().map(|e| collector.collect_expression(e)))
-            .map_or_else(|| Either::Left(iter::empty()), Either::Right)
+            .parameter()
+            .into_iter()
+            .map(|e| collector.collect_expression(e))
             .collect(),
-        ast::Attribute::BuiltinAttribute(inner) => inner
-            .parameters()
-            .map(|p| p.arguments().map(|e| collector.collect_expression(e)))
-            .map_or_else(|| Either::Left(iter::empty()), Either::Right)
-            .collect(),
+        ast::Attribute::BuiltinAttribute(inner) => Vec::new(), // these arguments are not expressions
         ast::Attribute::GroupAttribute(inner) => inner
-            .parameters()
-            .map(|p| p.arguments().map(|e| collector.collect_expression(e)))
-            .map_or_else(|| Either::Left(iter::empty()), Either::Right)
+            .parameter()
+            .into_iter()
+            .map(|e| collector.collect_expression(e))
             .collect(),
         ast::Attribute::IdAttribute(inner) => inner
-            .parameters()
-            .map(|p| p.arguments().map(|e| collector.collect_expression(e)))
-            .map_or_else(|| Either::Left(iter::empty()), Either::Right)
+            .parameter()
+            .into_iter()
+            .map(|e| collector.collect_expression(e))
             .collect(),
         ast::Attribute::InterpolateAttribute(inner) => Vec::new(), // these arguments are not expressions
-        ast::Attribute::InvariantAttribute(inner) => inner
-            .parameters()
-            .map(|p| p.arguments().map(|e| collector.collect_expression(e)))
-            .map_or_else(|| Either::Left(iter::empty()), Either::Right)
-            .collect(),
+        ast::Attribute::InvariantAttribute(inner) => Vec::new(),   // has no arguments
         ast::Attribute::LocationAttribute(inner) => inner
-            .parameters()
-            .map(|p| p.arguments().map(|e| collector.collect_expression(e)))
-            .map_or_else(|| Either::Left(iter::empty()), Either::Right)
+            .parameter()
+            .into_iter()
+            .map(|e| collector.collect_expression(e))
             .collect(),
         ast::Attribute::MustUseAttribute(inner) => Vec::new(),
         ast::Attribute::SizeAttribute(inner) => inner
-            .parameters()
-            .map(|p| p.arguments().map(|e| collector.collect_expression(e)))
-            .map_or_else(|| Either::Left(iter::empty()), Either::Right)
+            .parameter()
+            .into_iter()
+            .map(|e| collector.collect_expression(e))
             .collect(),
         ast::Attribute::WorkgroupSizeAttribute(inner) => inner
             .parameters()
-            .map(|p| p.arguments().map(|e| collector.collect_expression(e)))
-            .map_or_else(|| Either::Left(iter::empty()), Either::Right)
+            .map(|e| collector.collect_expression(e))
             .collect(),
         ast::Attribute::VertexAttribute(inner) => Vec::new(),
         ast::Attribute::FragmentAttribute(inner) => Vec::new(),

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -693,25 +693,29 @@ ast_node! {
 ast_node! {
     AlignAttribute:
     name: Option<SyntaxToken Align>;
-    parameters: Option<Arguments>;
+    parameter: Option<Expression>;
 }
 
 ast_node! {
     BindingAttribute:
     name: Option<SyntaxToken Binding>;
-    parameters: Option<Arguments>;
+    parameter: Option<Expression>;
 }
 
 ast_node! {
     BlendSrcAttribute:
     name: Option<SyntaxToken BlendSrc>;
-    parameters: Option<Arguments>;
+    parameter: Option<Expression>;
 }
 
 ast_node! {
     BuiltinAttribute:
     name: Option<SyntaxToken Builtin>;
-    parameters: Option<Arguments>;
+    value_name: Option<BuiltinValueName>;
+}
+
+ast_node! {
+    BuiltinValueName
 }
 
 ast_node! {
@@ -728,13 +732,13 @@ ast_node! {
 ast_node! {
     GroupAttribute:
     name: Option<SyntaxToken Group>;
-    parameters: Option<Arguments>;
+    parameter: Option<Expression>;
 }
 
 ast_node! {
     IdAttribute:
     name: Option<SyntaxToken Id>;
-    parameters: Option<Arguments>;
+    parameter: Option<Expression>;
 }
 
 ast_node! {
@@ -755,13 +759,12 @@ ast_node! {
 ast_node! {
     InvariantAttribute:
     name: Option<SyntaxToken Group>;
-    parameters: Option<Arguments>;
 }
 
 ast_node! {
     LocationAttribute:
     name: Option<SyntaxToken Group>;
-    parameters: Option<Arguments>;
+    parameter: Option<Expression>;
 }
 
 ast_node! {
@@ -772,13 +775,13 @@ ast_node! {
 ast_node! {
     SizeAttribute:
     name: Option<SyntaxToken Group>;
-    parameters: Option<Arguments>;
+    parameter: Option<Expression>;
 }
 
 ast_node! {
     WorkgroupSizeAttribute:
     name: Option<SyntaxToken WorkgroupSize>;
-    parameters: Option<Arguments>;
+    parameters: AstChildren<Expression>;
 }
 
 ast_node! {


### PR DESCRIPTION
# Objective

There are currently a lot of attribute `ast_node!`s that have a `parameters` child of type `Arguments` however after the changes to the lelwel grammar, the parameters of the attributes are no longer wrapped within an `Arguments` node.

This PR fixes that.

## Solution

I replaced the 
```
ast_node! {
...
    parameters: Option<Arguments>;
}
```
with
```
ast_node! {
...
    parameter: Option<Expression>;
// OR
    parameters: AstChildren<Expression>;
}
```

## Testing

I have tested that the `parameters()` / `parameter()` accessors now actually yield the parameter, instead of `None`.

I am not aware of any existing tests for that infrastructure and I am unsure how that would look like. 
These changes are basically untested, and as I am not well versed with what parts of w-a these changes
impact I do not know how to manually test them - so please help me with that before merging!
