### PR TITLE
Remove RootQueryDb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,12 +55,12 @@ dependencies = [
  "edition",
  "expect-test",
  "la-arena",
- "query-group-macro",
  "rowan",
  "rustc-hash 2.1.2",
  "salsa",
  "salsa-macros",
  "syntax",
+ "tracing",
  "triomphe",
  "vfs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ rustc-hash = "2.1.2"
 salsa = { version = "0.25.2", default-features = true, features = [
 	"macros",
 	"rayon",
-	"salsa_unstable"
+	"salsa_unstable",
 ] }
 salsa-macros = "0.25.2"
 semver = "1.0.27"
@@ -89,9 +89,7 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 	"tracing-log",
 ] }
 triomphe = { version = "0.1.15", default-features = false, features = ["std"] }
-wgsl-types = { version = "0.3.2", features = [
-	"naga-ext",
-] }
+wgsl-types = { version = "0.3.2", features = ["naga-ext"] }
 indexmap = { version = "2.13.0" }
 
 # tombi: format.rules.table-keys-order.disabled = true

--- a/crates/base_db/Cargo.toml
+++ b/crates/base_db/Cargo.toml
@@ -14,12 +14,12 @@ doctest = false
 dashmap.workspace = true
 edition.workspace = true
 la-arena.workspace = true
-query-group.workspace = true
 rowan.workspace = true
 rustc-hash.workspace = true
 salsa.workspace = true
 salsa-macros.workspace = true
 syntax.workspace = true
+tracing.workspace = true
 # remove this when refactoring to PackageCraphBuilder
 triomphe.workspace = true
 vfs.workspace = true

--- a/crates/base_db/src/change.rs
+++ b/crates/base_db/src/change.rs
@@ -10,7 +10,7 @@ use triomphe::Arc;
 use vfs::FileId;
 
 use crate::{
-    Package, PackageDisplayName, RootQueryDb, all_packages,
+    Package, PackageDisplayName, SourceDatabase, all_packages,
     input::{Dependency, PackageData, PackageId, PackageOrigin, SourceRoot, SourceRootId},
     set_all_packages_with_durability,
 };
@@ -83,7 +83,7 @@ impl Change {
     /// Panics if the number of source roots exceeds `u32::MAX`, as `SourceRootId` holds a `u32`.
     pub fn apply(
         self,
-        database: &mut dyn RootQueryDb,
+        database: &mut dyn SourceDatabase,
     ) {
         if let Some(roots) = self.roots {
             for (root, root_id) in roots.into_iter().zip(0_u32..) {
@@ -117,7 +117,7 @@ impl Change {
 }
 
 fn apply_package_graph(
-    database: &mut dyn RootQueryDb,
+    database: &mut dyn SourceDatabase,
     mut package_graph: PackageGraph,
     sorted_packages: Vec<PackageId>,
 ) {
@@ -197,7 +197,7 @@ struct PackageGraph {
 }
 
 impl PackageGraph {
-    pub fn new(database: &dyn RootQueryDb) -> Self {
+    pub fn new(database: &dyn SourceDatabase) -> Self {
         let (ids, packages): (Vec<_>, FxHashMap<_, _>) = all_packages(database)
             .iter()
             .map(|package| {

--- a/crates/base_db/src/change.rs
+++ b/crates/base_db/src/change.rs
@@ -10,8 +10,9 @@ use triomphe::Arc;
 use vfs::FileId;
 
 use crate::{
-    Package, PackageDisplayName, RootQueryDb,
+    Package, PackageDisplayName, RootQueryDb, all_packages,
     input::{Dependency, PackageData, PackageId, PackageOrigin, SourceRoot, SourceRootId},
+    set_all_packages_with_durability,
 };
 
 /// Encapsulate a bunch of raw `.set` calls on the database.
@@ -120,8 +121,7 @@ fn apply_package_graph(
     mut package_graph: PackageGraph,
     sorted_packages: Vec<PackageId>,
 ) {
-    let mut old_packages: FxHashMap<PackageId, Package> = database
-        .all_packages()
+    let mut old_packages: FxHashMap<PackageId, Package> = all_packages(database)
         .iter()
         .map(|package| (package.package_id(database), *package))
         .collect();
@@ -160,8 +160,7 @@ fn apply_package_graph(
         // Salsa does not have a removal API yet, see: https://github.com/salsa-rs/salsa/issues/37
         remaining_package.set_data(database).to(dummy_package);
     }
-
-    database.set_all_packages(Arc::new(all_packages.into_boxed_slice()));
+    set_all_packages_with_durability(database, all_packages, Durability::MEDIUM);
 }
 
 #[must_use]
@@ -199,8 +198,7 @@ struct PackageGraph {
 
 impl PackageGraph {
     pub fn new(database: &dyn RootQueryDb) -> Self {
-        let (ids, packages): (Vec<_>, FxHashMap<_, _>) = database
-            .all_packages()
+        let (ids, packages): (Vec<_>, FxHashMap<_, _>) = all_packages(database)
             .iter()
             .map(|package| {
                 let mut package_data = PackageData::clone(package.data(database));

--- a/crates/base_db/src/editioned_file_id.rs
+++ b/crates/base_db/src/editioned_file_id.rs
@@ -52,7 +52,7 @@ impl EditionedFileId {
         ) -> Option<Box<[Diagnostic]>> {
             let parse = file_id.parse(database);
             let errors = parse.errors();
-            match &*errors {
+            match errors {
                 [] => None,
                 [..] => Some(errors.into()),
             }

--- a/crates/base_db/src/editioned_file_id.rs
+++ b/crates/base_db/src/editioned_file_id.rs
@@ -2,7 +2,7 @@
 //! is interned (so queries can take it) and stores only the underlying `span::EditionedFileId`.
 
 use salsa::Database;
-use syntax::Edition;
+use syntax::{Diagnostic, Edition, ast};
 use vfs::FileId;
 
 use crate::SourceDatabase;
@@ -20,6 +20,45 @@ pub struct RawEditionedFileId {
 #[derive(PartialOrd, Ord)]
 pub struct EditionedFileId {
     field: RawEditionedFileId,
+}
+
+impl EditionedFileId {
+    pub fn parse(
+        self,
+        database: &dyn SourceDatabase,
+    ) -> syntax::Parse {
+        #[salsa::tracked(lru = 128)]
+        pub fn parse(
+            database: &dyn SourceDatabase,
+            file_id: EditionedFileId,
+        ) -> syntax::Parse {
+            let _p = tracing::info_span!("parse", ?file_id).entered();
+            let (file_id, edition) = (file_id.file_id(database), file_id.edition(database));
+            let text = database.file_text(file_id).text(database);
+            syntax::parse(text, edition)
+        }
+        parse(database, self)
+    }
+
+    // firewall query
+    pub fn parse_errors(
+        self,
+        database: &dyn SourceDatabase,
+    ) -> Option<&[Diagnostic]> {
+        #[salsa::tracked(returns(as_deref))]
+        pub fn parse_errors(
+            database: &dyn SourceDatabase,
+            file_id: EditionedFileId,
+        ) -> Option<Box<[Diagnostic]>> {
+            let parse = file_id.parse(database);
+            let errors = parse.errors();
+            match &*errors {
+                [] => None,
+                [..] => Some(errors.into()),
+            }
+        }
+        parse_errors(database, self)
+    }
 }
 
 impl EditionedFileId {

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -217,6 +217,10 @@ pub struct PackageData {
     /// Note that this may contain more dependencies than the package actually uses.
     /// A common example is the test package which is included but only actually is active when
     /// declared in source via `extern package test`.
+    ///
+    /// Dependencies can be cyclic, although wgsl-analyzer will log a warning for that.
+    /// Having an accurate package graph is important and code has to account for possible cycles
+    /// to avoid infinite loops.
     pub dependencies: Vec<Dependency>,
     pub origin: PackageOrigin,
 }

--- a/crates/base_db/src/lib.rs
+++ b/crates/base_db/src/lib.rs
@@ -350,18 +350,6 @@ impl PackageDisplayName {
     }
 }
 
-/// Database which stores all significant input facts: source code and project
-/// model. Everything else in rust-analyzer is derived from these queries.
-#[query_group::query_group]
-pub trait RootQueryDb: SourceDatabase + salsa::Database {
-    #[salsa::invoke(parse)]
-    #[salsa::lru(128)]
-    fn parse(
-        &self,
-        key: EditionedFileId,
-    ) -> Parse;
-}
-
 #[salsa_macros::db]
 pub trait SourceDatabase: salsa::Database {
     /// Text of the file.
@@ -432,7 +420,7 @@ impl Nonce {
 }
 
 fn parse(
-    database: &dyn RootQueryDb,
+    database: &dyn SourceDatabase,
     file_id: EditionedFileId,
 ) -> Parse {
     let RawEditionedFileId { file_id, edition } = file_id.unpack(database);

--- a/crates/base_db/src/lib.rs
+++ b/crates/base_db/src/lib.rs
@@ -360,12 +360,6 @@ pub trait RootQueryDb: SourceDatabase + salsa::Database {
         &self,
         key: EditionedFileId,
     ) -> Parse;
-
-    /// Returns the packages in topological order.
-    ///
-    /// **Warning**: do not use this query in `hir-*` packages! It kills incrementality across crate metadata modifications.
-    #[salsa::input]
-    fn all_packages(&self) -> Arc<Box<[Package]>>;
 }
 
 #[salsa_macros::db]

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -50,7 +50,7 @@ impl<'database> Semantics<'database> {
         &self,
         file_id: EditionedFileId,
     ) -> ast::SourceFile {
-        self.database.parse(file_id).tree()
+        file_id.parse(self.database).tree()
     }
 
     #[must_use]

--- a/crates/hir_def/src/database.rs
+++ b/crates/hir_def/src/database.rs
@@ -8,9 +8,7 @@
 )]
 use std::fmt::{self, Debug};
 
-use base_db::{
-    EditionedFileId, Lookup as _, RootQueryDb, SourceDatabase, impl_intern_key, impl_intern_lookup,
-};
+use base_db::{EditionedFileId, Lookup as _, SourceDatabase, impl_intern_key, impl_intern_lookup};
 use salsa::plumbing::AsId as _;
 use syntax::{Parse, ast};
 use triomphe::Arc;
@@ -168,7 +166,7 @@ fn parse_or_resolve(
     database: &dyn DefDatabase,
     file_id: EditionedFileId,
 ) -> Parse {
-    database.parse(file_id)
+    file_id.parse(database)
 }
 
 fn ast_id_map(
@@ -181,7 +179,7 @@ fn ast_id_map(
 }
 
 #[query_group::query_group(InternDatabaseStorage)]
-pub trait InternDatabase: RootQueryDb {
+pub trait InternDatabase: SourceDatabase {
     #[salsa::interned]
     fn intern_import(
         &self,

--- a/crates/hir_def/src/test_db.rs
+++ b/crates/hir_def/src/test_db.rs
@@ -3,6 +3,7 @@ use std::{fmt, panic};
 use base_db::{
     EditionedFileId, FileSourceRootInput, FileText, Nonce, RootQueryDb as _, SourceDatabase,
     SourceRootId, SourceRootInput, change::Change, input::SourceRoot,
+    set_all_packages_with_durability,
 };
 use salsa::{Durability, Storage};
 use syntax::Edition;
@@ -26,7 +27,7 @@ impl Default for TestDatabase {
             nonce: Nonce::default(),
         };
         // This needs to be here otherwise the first `Change` will panic.
-        database.set_all_packages(Arc::new(Box::new([])));
+        set_all_packages_with_durability(&mut database, [], Durability::LOW);
         database
     }
 }

--- a/crates/hir_def/src/test_db.rs
+++ b/crates/hir_def/src/test_db.rs
@@ -1,9 +1,8 @@
 use std::{fmt, panic};
 
 use base_db::{
-    EditionedFileId, FileSourceRootInput, FileText, Nonce, RootQueryDb as _, SourceDatabase,
-    SourceRootId, SourceRootInput, change::Change, input::SourceRoot,
-    set_all_packages_with_durability,
+    EditionedFileId, FileSourceRootInput, FileText, Nonce, SourceDatabase, SourceRootId,
+    SourceRootInput, change::Change, input::SourceRoot, set_all_packages_with_durability,
 };
 use salsa::{Durability, Storage};
 use syntax::Edition;

--- a/crates/hir_ty/src/test_db.rs
+++ b/crates/hir_ty/src/test_db.rs
@@ -1,9 +1,8 @@
 use std::{fmt, panic};
 
 use base_db::{
-    EditionedFileId, FileSourceRootInput, FileText, Nonce, RootQueryDb as _, SourceDatabase,
-    SourceRootId, SourceRootInput, change::Change, input::SourceRoot,
-    set_all_packages_with_durability,
+    EditionedFileId, FileSourceRootInput, FileText, Nonce, SourceDatabase, SourceRootId,
+    SourceRootInput, change::Change, input::SourceRoot, set_all_packages_with_durability,
 };
 use hir_def::database::{DefDatabase as _, ExtensionsConfig};
 use salsa::Durability;

--- a/crates/hir_ty/src/test_db.rs
+++ b/crates/hir_ty/src/test_db.rs
@@ -3,6 +3,7 @@ use std::{fmt, panic};
 use base_db::{
     EditionedFileId, FileSourceRootInput, FileText, Nonce, RootQueryDb as _, SourceDatabase,
     SourceRootId, SourceRootInput, change::Change, input::SourceRoot,
+    set_all_packages_with_durability,
 };
 use hir_def::database::{DefDatabase as _, ExtensionsConfig};
 use salsa::Durability;
@@ -31,7 +32,7 @@ impl Default for TestDatabase {
             Durability::MEDIUM,
         );
         // This needs to be here otherwise the first `Change` will panic.
-        value.set_all_packages(Arc::new(Box::new([])));
+        set_all_packages_with_durability(&mut value, [], Durability::LOW);
         value
     }
 }

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -8,7 +8,7 @@ use std::{fmt, panic};
 pub use base_db;
 use base_db::{
     FileId, FileSourceRootInput, FileText, Files, Nonce, RootQueryDb as _, SourceDatabase,
-    SourceRoot, SourceRootId, SourceRootInput, change::Change,
+    SourceRoot, SourceRootId, SourceRootInput, change::Change, set_all_packages_with_durability,
 };
 use hir_def::database::{DefDatabase as _, ExtensionsConfig};
 use line_index::LineIndex;
@@ -133,7 +133,7 @@ impl RootDatabase {
             nonce: Nonce::new(),
         };
         // This needs to be here otherwise the first `Change` will panic.
-        database.set_all_packages(Arc::new(Box::new([])));
+        set_all_packages_with_durability(&mut database, [], Durability::HIGH);
         // CrateGraphBuilder::default().set_in_db(&mut database);
         // database.set_proc_macros_with_durability(Default::default(), Durability::MEDIUM);
         // database.set_local_roots_with_durability(Default::default(), Durability::MEDIUM);

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -7,8 +7,8 @@ use std::{fmt, panic};
 
 pub use base_db;
 use base_db::{
-    FileId, FileSourceRootInput, FileText, Files, Nonce, RootQueryDb as _, SourceDatabase,
-    SourceRoot, SourceRootId, SourceRootInput, change::Change, set_all_packages_with_durability,
+    FileId, FileSourceRootInput, FileText, Files, Nonce, SourceDatabase, SourceRoot, SourceRootId,
+    SourceRootInput, change::Change, set_all_packages_with_durability,
 };
 use hir_def::database::{DefDatabase as _, ExtensionsConfig};
 use line_index::LineIndex;
@@ -223,7 +223,7 @@ impl SnippetCapability {
 }
 
 #[query_group::query_group]
-pub trait LineIndexDatabase: base_db::RootQueryDb {
+pub trait LineIndexDatabase: base_db::SourceDatabase {
     #[salsa::invoke_interned(line_index)]
     fn line_index(
         &self,

--- a/crates/ide/src/debug_command.rs
+++ b/crates/ide/src/debug_command.rs
@@ -6,7 +6,7 @@ pub(crate) fn debug_command(
     file_position: FilePosition,
 ) -> Option<()> {
     let file_id = EditionedFileId::from_file(database, file_position.file_id);
-    let _file = database.parse(file_id).tree();
+    let _file = file_id.parse(database).tree();
 
     None
 }

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -332,7 +332,7 @@ pub fn diagnostics(
     file_id: FileId,
 ) -> Vec<Diagnostic> {
     let file_id = EditionedFileId::from_file(database, file_id);
-    let parse = database.parse(file_id);
+    let parse = file_id.parse(database);
 
     let mut diagnostics = Vec::new();
 

--- a/crates/ide/src/formatting.rs
+++ b/crates/ide/src/formatting.rs
@@ -1,4 +1,4 @@
-use base_db::{EditionedFileId, FileId, RootQueryDb as _, SourceDatabase as _, TextRange};
+use base_db::{EditionedFileId, FileId, SourceDatabase as _, TextRange};
 use hir_def::database::DefDatabase as _;
 use rowan::NodeOrToken;
 use syntax::{AstNode as _, SyntaxNode, ast};
@@ -12,7 +12,7 @@ pub(crate) fn format(
     range: Option<TextRange>,
 ) -> Option<SyntaxNode> {
     let file_id = EditionedFileId::from_file(database, file_id);
-    let file = database.parse(file_id).tree();
+    let file = file_id.parse(database).tree();
 
     let node = match range {
         None => file.syntax().clone_for_update(),

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -1,4 +1,4 @@
-use base_db::{EditionedFileId, FilePosition, RootQueryDb as _, SourceDatabase as _};
+use base_db::{EditionedFileId, FilePosition, SourceDatabase as _};
 use hir::{HasSource as _, Local, Semantics, definition::Definition};
 use hir_def::{InFile, database::DefDatabase as _};
 use ide_db::RootDatabase;
@@ -12,7 +12,7 @@ pub(crate) fn goto_definition(
 ) -> Option<NavigationTarget> {
     let semantics = &Semantics::new(database);
     let file_id = EditionedFileId::from_file(database, file_position.file_id);
-    let file = database.parse(file_id).tree();
+    let file = file_id.parse(database).tree();
     let token = file.syntax().token_at_offset(file_position.offset);
 
     #[expect(

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -1,6 +1,4 @@
-use base_db::{
-    EditionedFileId, FilePosition, FileRange, RangeInfo, RootQueryDb as _, SourceDatabase as _,
-};
+use base_db::{EditionedFileId, FilePosition, FileRange, RangeInfo, SourceDatabase as _};
 use hir::Semantics;
 use hir_def::database::DefDatabase as _;
 use ide_db::RootDatabase;
@@ -79,7 +77,7 @@ pub(crate) fn hover(
 ) -> Option<RangeInfo<HoverResult>> {
     let _semantics = &Semantics::new(database);
     let file_id = EditionedFileId::from_file(database, file_range.file_id);
-    let _file = database.parse(file_id).tree();
+    let _file = file_id.parse(database).tree();
     // TODO: Implement hovering and https://github.com/wgsl-analyzer/wgsl-analyzer/issues/362
     None
 }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -19,8 +19,8 @@ mod view_syntax_tree;
 use std::panic;
 
 use base_db::{
-    EditionedFileId, FilePosition, FileRange, FileSet, RangeInfo, RootQueryDb as _,
-    SourceDatabase as _, SourceRoot, TextRange, change::Change, input::SourceRootId,
+    EditionedFileId, FilePosition, FileRange, FileSet, RangeInfo, SourceDatabase as _, SourceRoot,
+    TextRange, change::Change, input::SourceRootId,
 };
 use diagnostics::Diagnostic;
 use hir::{ExtensionsConfig, diagnostics::DiagnosticsConfig};
@@ -298,7 +298,7 @@ impl Analysis {
         &self,
         file_id: FileId,
     ) -> Cancellable<Parse> {
-        self.with_db(|database| database.parse(EditionedFileId::from_file(database, file_id)))
+        self.with_db(|database| EditionedFileId::from_file(database, file_id).parse(database))
     }
 
     /// Renders the package graph to `GraphViz` "dot" syntax.
@@ -340,8 +340,8 @@ impl Analysis {
     ) -> Cancellable<Vec<Fold>> {
         self.with_db(|database| {
             folding_ranges::folding_ranges(
-                &database
-                    .parse(EditionedFileId::from_file(database, file_id))
+                &EditionedFileId::from_file(database, file_id)
+                    .parse(database)
                     .tree(),
             )
         })

--- a/crates/ide/src/view_syntax_tree.rs
+++ b/crates/ide/src/view_syntax_tree.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 
-use base_db::{EditionedFileId, RootQueryDb as _, SourceDatabase as _, TextRange};
+use base_db::{EditionedFileId, TextRange};
 use hir_def::database::DefDatabase as _;
 use ide_db::{LineIndexDatabase as _, RootDatabase};
 use line_index::{LineCol, LineIndex};
@@ -21,7 +21,7 @@ pub(crate) fn view_syntax_tree(
     file_id: FileId,
 ) -> String {
     let file_id = EditionedFileId::from_file(database, file_id);
-    let syntax_node = database.parse(file_id).syntax();
+    let syntax_node = file_id.parse(database).syntax();
     let line_index = database.line_index(file_id.file_id(database));
 
     let ctx = SyntaxTreeCtx {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -9,21 +9,10 @@ pub use edition::Edition;
 pub use parser::{Diagnostic, parse_entrypoint};
 use rowan::GreenNode;
 
+#[derive(Debug)]
 pub struct Parse {
     green_node: GreenNode,
     errors: Vec<Diagnostic>,
-}
-impl fmt::Debug for Parse {
-    fn fmt(
-        &self,
-        formatter: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        formatter
-            .debug_struct("Parse")
-            .field("green_node", &self.green_node)
-            .field("errors", &self.errors)
-            .finish()
-    }
 }
 
 impl PartialEq for Parse {

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -21,21 +21,10 @@ pub struct ParserContext {
     edition: Edition,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Diagnostic {
     pub message: String,
     pub range: rowan::TextRange,
-}
-
-impl fmt::Debug for Diagnostic {
-    fn fmt(
-        &self,
-        f: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        f.debug_struct("Diagnostic")
-            .field("message", &self.message)
-            .field("range", &self.range)
-            .finish()
-    }
 }
 
 impl fmt::Display for Diagnostic {

--- a/crates/project-model/Cargo.toml
+++ b/crates/project-model/Cargo.toml
@@ -21,7 +21,7 @@ serde.workspace = true
 toml = { version = "1.1.2", default-features = false, features = [
 	"parse",
 	"serde",
-	"std"
+	"std",
 ] }
 
 [dev-dependencies]

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -50,6 +50,13 @@ impl Parse {
     pub fn tree(&self) -> ast::SourceFile {
         ast::SourceFile::cast(self.syntax()).unwrap()
     }
+
+    pub fn ok(self) -> Result<ast::SourceFile, Vec<Diagnostic>> {
+        match self.errors() {
+            errors if !errors.is_empty() => Err(errors.to_vec()),
+            _ => Ok(self.tree()),
+        }
+    }
 }
 
 #[must_use]


### PR DESCRIPTION
# Objective

Part of migrating to new salsa API.

## Solution

Move `parse` to `EditionedFileId`.
See https://github.com/rust-lang/rust-analyzer/pull/21944

## Testing

Fairly trivia, just a refactor
