### PR TITLE
Add helpful error message for missing let initializer

### DIFF
--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -238,4 +238,34 @@ impl<'source> ParserCallbacks<'source> for Parser<'source> {
             "global let declarations are not allowed".to_owned(),
         ));
     }
+
+    /// Called when semantic assertion `!1` in rule `let_declaration` is visited.
+    fn assertion_let_declaration_1(&self) -> Option<Self::Diagnostic> {
+        (self.peek(0) == Token::Semicolon).then(|| {
+            self.create_diagnostic(
+                self.span(),
+                "let declaration requires initializer".to_owned(),
+            )
+        })
+    }
+
+    /// Called when semantic assertion `!1` in rule `let_declaration_semi` is visited.
+    fn assertion_let_declaration_semi_1(&self) -> Option<Self::Diagnostic> {
+        (self.peek(0) == Token::Semicolon).then(|| {
+            self.create_diagnostic(
+                self.span(),
+                "let declaration requires initializer".to_owned(),
+            )
+        })
+    }
+
+    /// Called when semantic assertion `!1` in rule `const_declaration_semi` is visited.
+    fn assertion_const_declaration_semi_1(&self) -> Option<Self::Diagnostic> {
+        (self.peek(0) == Token::Semicolon).then(|| {
+            self.create_diagnostic(
+                self.span(),
+                "const declaration requires initializer".to_owned(),
+            )
+        })
+    }
 }

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -2335,6 +2335,40 @@ fn let_statement_recover_3() {
 }
 
 #[test]
+fn let_statement_missing_initializer() {
+    // A let declaration with a type but no initializer should produce
+    // a clear "requires an initializer" error.
+    check_statement(
+        "let stack: array<f32, 10>;",
+        expect![[r#"
+            SourceFile@0..26
+              LetDeclaration@0..26
+                Let@0..3 "let"
+                Blankspace@3..4 " "
+                Name@4..9
+                  Identifier@4..9 "stack"
+                Colon@9..10 ":"
+                Blankspace@10..11 " "
+                TypeSpecifier@11..25
+                  Path@11..16
+                    Identifier@11..16 "array"
+                  TemplateList@16..25
+                    TemplateStart@16..17 "<"
+                    IdentExpression@17..20
+                      Path@17..20
+                        Identifier@17..20 "f32"
+                    Comma@20..21 ","
+                    Blankspace@21..22 " "
+                    Literal@22..24
+                      IntLiteral@22..24 "10"
+                    TemplateEnd@24..25 ">"
+                Semicolon@25..26 ";"
+
+            error at 25..26: let declaration requires initializer"#]],
+    );
+}
+
+#[test]
 fn annotation_with_invalid_statement_recover() {
     check(
         "fn foo() {

--- a/crates/parser/src/wesl.llw
+++ b/crates/parser/src/wesl.llw
@@ -359,10 +359,10 @@ function_call: ident_expression argument_expression_list;
 // duplicated so it can be used with and without a semicolon
 variable_declaration: 'var' template_list typed_ident ['=' expression];
 variable_declaration_semi^: 'var' template_list typed_ident ['=' expression] ';';
-let_declaration: 'let' typed_ident '=' expression;
-let_declaration_semi^: 'let' typed_ident '=' expression ';';
+let_declaration: 'let' typed_ident !1 '=' expression;
+let_declaration_semi^: 'let' typed_ident !1 '=' expression ';';
 const_declaration: 'const' typed_ident '=' expression;
-const_declaration_semi^: 'const' typed_ident '=' expression ';';
+const_declaration_semi^: 'const' typed_ident !1 '=' expression ';';
 override_declaration_semi^: 'override' typed_ident ['=' expression] ';';
 
 // duplicated so it can be used in `for` statement without semicolon


### PR DESCRIPTION
# Objective

Fixes #721

## Solution

When a let declaration is missing the '=' and initializer expression, the parser now emits a specific diagnostic: 'let declaration requires an initializer expression' in addition to the generic syntax error. This provides users with help if they write code like:
```wgsl
let stack: array<f32, 10>;
```

## Testing

Parser snapshot tests
