### PR TITLE
resolve rustdoc warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,17 +207,17 @@ rust-2024-compatibility = { level = "deny", priority = -1 }
 unused = { level = "allow", priority = 1 }
 
 [workspace.lints.rustdoc]
+bare_urls = "warn"
 broken_intra_doc_links = "warn"
-private_intra_doc_links = "allow"
-missing_crate_level_docs = "warn"
-# missing_doc_code_examples = "warn"
-private_doc_tests = "warn"
 invalid_codeblock_attributes = "warn"
 invalid_html_tags = "warn"
 invalid_rust_codeblocks = "warn"
-bare_urls = "warn"
-unescaped_backticks = "warn"
+missing_crate_level_docs = "warn"
+# missing_doc_code_examples = "warn"
+private_doc_tests = "warn"
+private_intra_doc_links = "allow"
 redundant_explicit_links = "warn"
+unescaped_backticks = "warn"
 
 [profile.dev]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,19 @@ rust-2021-compatibility = { level = "deny", priority = -1 }
 rust-2024-compatibility = { level = "deny", priority = -1 }
 unused = { level = "allow", priority = 1 }
 
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "warn"
+private_intra_doc_links = "allow"
+missing_crate_level_docs = "warn"
+# missing_doc_code_examples = "warn"
+private_doc_tests = "warn"
+invalid_codeblock_attributes = "warn"
+invalid_html_tags = "warn"
+invalid_rust_codeblocks = "warn"
+bare_urls = "warn"
+unescaped_backticks = "warn"
+redundant_explicit_links = "warn"
+
 [profile.dev]
 debug = 1
 

--- a/crates/base_db/src/lib.rs
+++ b/crates/base_db/src/lib.rs
@@ -1,3 +1,5 @@
+//! Basic database traits.
+
 pub mod change;
 pub mod input;
 
@@ -111,7 +113,7 @@ impl Files {
     /// Contents of a file.
     ///
     /// # Panics
-    /// If called with a file id that has not been added by the [`Change`]s.
+    /// If called with a file id that has not been added by the [`change::Change`]s.
     #[must_use]
     pub fn file_text(
         &self,
@@ -169,7 +171,7 @@ impl Files {
     /// Source root of the file.
     ///
     /// # Panics
-    /// If the source root has not been set. This can only happen if there were some incorrect [`Change`]s.
+    /// If the source root has not been set. This can only happen if there were some incorrect [`change::Change`]s.
     #[must_use]
     pub fn source_root(
         &self,
@@ -210,7 +212,7 @@ impl Files {
     /// Gets the source root for a file.
     ///
     /// # Panics
-    /// If the source root has not been set. This can only happen if there were some incorrect [`Change`]s.
+    /// If the source root has not been set. This can only happen if there were some incorrect [`change::Change`]s.
     #[must_use]
     pub fn file_source_root(
         &self,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1,3 +1,5 @@
+//! A high-level object-oriented access to code.
+
 pub mod database;
 pub mod definition;
 pub mod diagnostics;

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -3,7 +3,7 @@ name = "hir-def"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
-description = "RPC Api for the `proc-macro-srv` crate of wgsl-analyzer."
+description = "RPC API for wgsl-analyzer."
 repository.workspace = true
 license.workspace = true
 

--- a/crates/hir_def/src/ast_id.rs
+++ b/crates/hir_def/src/ast_id.rs
@@ -66,7 +66,7 @@ impl AstIdMap {
     ///
     /// # Panics
     ///
-    /// Panics if `N` cannot be cast to the [`SyntaxKind`].
+    /// Panics if `N` cannot be cast to the [`syntax::SyntaxKind`].
     #[must_use]
     pub fn get<N: AstNode>(
         &self,

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -1,3 +1,5 @@
+//! RPC API.
+
 mod ast_id;
 pub mod attributes;
 pub mod body;

--- a/crates/ide-db/src/lib.rs
+++ b/crates/ide-db/src/lib.rs
@@ -1,3 +1,5 @@
+//! IDE database.
+
 #![expect(
     clippy::trailing_empty_array,
     reason = "Clippy has a false positive for the query_group macro, see: https://github.com/rust-lang/rust-clippy/issues/16754"

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -25,7 +25,7 @@ salsa.workspace = true
 smallvec.workspace = true
 smol_str.workspace = true
 triomphe.workspace = true
-# local deps
+# local dependencies
 ide-completion.workspace = true
 ide-db.workspace = true
 syntax.workspace = true

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -1,3 +1,5 @@
+//! Core data structure representing IDE state.
+
 #[cfg(test)]
 mod fixture;
 

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -7,11 +7,11 @@ use smallvec::SmallVec;
 use smol_str::{SmolStr, format_smolstr};
 use stdx::never;
 
-/// `CompletionItem` describes a single completion entity which expands to 1 or more entries in the
+/// [`CompletionItem`] describes a single completion entity which expands to 1 or more entries in the
 /// editor pop-up.
 ///
 /// It is basically a POD with various properties. To construct a [`CompletionItem`],
-/// use [`Builder::new`] method and the [`Builder`] struct.
+/// use [`Builder::build`] method and the [`Builder`] struct.
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct CompletionItem {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1,3 +1,5 @@
+//! Parser for WGSL code, supporting language extensions such as naga and WESL.
+
 mod cst_builder;
 mod lexer;
 mod parser;

--- a/crates/parser/src/syntax_kind.rs
+++ b/crates/parser/src/syntax_kind.rs
@@ -18,7 +18,7 @@ pub enum SyntaxKind {
     #[doc(hidden)]
     TOMBSTONE,
     SourceFile,
-    /// A name that can be referenced by a [`NameRef`]
+    /// <https://www.w3.org/TR/WGSL/#name>
     Name,
     /// a function
     FunctionDeclaration,

--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -1,17 +1,18 @@
 //! In `wgsl-analyzer`, we maintain a strict separation between pure abstract
 //! semantic project model and a concrete model of a particular build system.
 //!
-//! Pure model is represented by the [`base_db::PackageGraph`] from another package.
+//! Pure model is represented by the [`PackageGraph`] from another package.
 //!
 //! In this crate, we are concerned with "real world" project models.
 //!
 //! Specifically, here we have a representation for a `wesl-rs` project
-//! ([`WeslWorkspace`]) and for manually specified layout ([`ProjectJson`]).
+//! ([`WeslToml`]) and for manually specified layout ([`ProjectManifest::ProjectJson`]).
 //!
 //! Roughly, the things we do here are:
 //!
-//! * Project discovery (where's the relevant wesl.toml for the current dir).
-//! * Lowering of concrete model to a [`base_db::PackageGraph`]
+//! * Project discovery (where is the relevant `wesl.toml` for the current directory?)
+//! * Lowering of concrete model to a [`PackageGraph`]
+
 mod manifest_path;
 mod package_graph;
 mod package_interner;

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -1,3 +1,5 @@
+//! Concrete syntax tree definitions.
+
 pub mod algorithms;
 pub mod ast;
 pub mod pointer;

--- a/crates/test-fixture/src/fixture.rs
+++ b/crates/test-fixture/src/fixture.rs
@@ -38,7 +38,7 @@
 //!
 //! ```ignore
 //! r#"
-//! //- /main.wgsl package:a deps:b
+//! //- /main.wgsl package:a dependencies:b
 //! fn main() {
 //!     b::foo();
 //! }
@@ -65,10 +65,10 @@ pub struct Fixture {
     pub package: Option<String>,
     /// Specifies dependencies of this package. This must be used with `package` meta.
     ///
-    /// Syntax: `deps:hir-def,ide-assists`.
-    pub deps: Vec<String>,
+    /// Syntax: `dependencies:my-package,my-other-package`.
+    pub dependencies: Vec<String>,
     /// Specifies the edition of this package. This must be used with `package` meta. If
-    /// this is not specified, ([`base_db::input::Edition::CURRENT`]) will be used.
+    /// this is not specified, the current default edition will be used.
     /// This must be used with `package` meta.
     ///
     /// Syntax: `edition:2021`.
@@ -80,7 +80,7 @@ pub struct Fixture {
     /// This is implied if this file belongs to a library source root.
     ///
     /// Use this if you want to test something that checks if a package is a workspace
-    /// member via [`PackageOrigin`](base_db::input::PackageOrigin).
+    /// member via [`base_db::input::PackageOrigin`].
     ///
     /// Syntax: `library`.
     pub library: bool,
@@ -151,7 +151,7 @@ impl FixtureWithProjectMeta {
         Self { fixture: result }
     }
 
-    //- /lib.wgsl package:foo deps:bar,baz
+    //- /lib.wgsl package:foo dependencies:bar,baz
     fn parse_meta_line(
         meta: &str,
         line: usize,
@@ -169,7 +169,7 @@ impl FixtureWithProjectMeta {
         );
 
         let mut package = None;
-        let mut deps = Vec::new();
+        let mut dependencies = Vec::new();
         let mut edition = None;
         let mut library = false;
         for component in components {
@@ -183,7 +183,7 @@ impl FixtureWithProjectMeta {
                 .unwrap_or_else(|| panic!("invalid meta line: {meta:?}"));
             match key {
                 "package" => package = Some(value.to_owned()),
-                "deps" => deps = value.split(',').map(ToOwned::to_owned).collect(),
+                "dependencies" => dependencies = value.split(',').map(ToOwned::to_owned).collect(),
 
                 "edition" => edition = Some(value.to_owned()),
                 _ => panic!("bad component: {component:?}"),
@@ -193,7 +193,7 @@ impl FixtureWithProjectMeta {
         Fixture {
             path,
             package,
-            deps,
+            dependencies,
             edition,
             library,
             text: String::new(),
@@ -227,7 +227,7 @@ mod tests {
     fn parse_fixture_gets_full_meta() {
         let FixtureWithProjectMeta { fixture: parsed } = FixtureWithProjectMeta::parse(
             r#"
-//- /lib.wgsl package:foo deps:bar,baz
+//- /lib.wgsl package:foo dependencies:bar,baz
 const a = 3;
 "#,
         );

--- a/crates/test-fixture/src/lib.rs
+++ b/crates/test-fixture/src/lib.rs
@@ -137,10 +137,10 @@ impl ChangeFixture {
             }
 
             assert!(meta.path.starts_with(SOURCE_ROOT_PREFIX));
-            if !meta.deps.is_empty() {
+            if !meta.dependencies.is_empty() {
                 assert!(
                     meta.package.is_some(),
-                    "can't specify deps without naming the crate"
+                    "cannot specify dependencies without naming the crate"
                 );
             }
 
@@ -161,7 +161,7 @@ impl ChangeFixture {
                     previous.is_none(),
                     "multiple crates with same name: {crate_name}"
                 );
-                for dep in meta.deps {
+                for dep in meta.dependencies {
                     let dep = PackageName::normalize_dashes(&dep);
                     package_dependencies.push((crate_name.clone(), dep));
                 }
@@ -231,20 +231,20 @@ enum SourceRootKind {
 struct FileMeta {
     path: String,
     package: Option<(String, PackageOrigin)>,
-    deps: Vec<String>,
+    dependencies: Vec<String>,
     edition: Edition,
 }
 
 impl FileMeta {
     fn from_fixture(fixture: Fixture) -> Self {
-        let deps = fixture.deps;
+        let dependencies = fixture.dependencies;
 
         Self {
             path: fixture.path,
             package: fixture
                 .package
                 .map(|package_name| parse_package(package_name, fixture.library)),
-            deps,
+            dependencies,
             edition: fixture.edition.map_or(Edition::CURRENT, |version| {
                 Edition::from_str(&version).unwrap()
             }),

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 doctest = false
 
 [dependencies]
-# Avoid adding deps here, this crate is widely used in tests it should compile fast!
+# Avoid adding dependencies here. This crate is widely used in tests it should compile fast!
 dissimilar.workspace = true
 paths.workspace = true
 profile.workspace = true

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -269,7 +269,7 @@ pub fn add_cursor(
 ///
 /// Multiline string values are supported:
 ///
-/// ```
+/// ```text
 /// // ^^^ first line
 /// //   | second line
 /// ```
@@ -279,7 +279,7 @@ pub fn add_cursor(
 /// annotation. In those cases the annotation can be explicitly ended with the
 /// `$` character.
 ///
-/// ```
+/// ```text
 /// // ^^^ trailing-ws-wanted  $
 /// ```
 ///

--- a/crates/wgsl-analyzer/src/cli/flags.rs
+++ b/crates/wgsl-analyzer/src/cli/flags.rs
@@ -66,7 +66,7 @@ xflags::xflags! {
         //     /// Only analyze items matching this path.
         //     optional -o, --only path: String
         //     /// Also analyze all dependencies.
-        //     optional --with-deps
+        //     optional --with-dependencies
         //     /// Don't load sysroot crates (`std`, `core` & friends).
         //     optional --no-sysroot
         //     /// Don't set #[cfg(test)].
@@ -201,7 +201,7 @@ pub struct AnalysisStats {
     pub parallel: bool,
     pub source_stats: bool,
     pub only: Option<String>,
-    pub with_deps: bool,
+    pub with_dependencies: bool,
     pub no_test: bool,
     pub skip_lowering: bool,
     pub skip_inference: bool,

--- a/crates/wgsl-analyzer/src/lib.rs
+++ b/crates/wgsl-analyzer/src/lib.rs
@@ -1,3 +1,5 @@
+//! The language server executable.
+
 pub mod cli;
 pub mod config;
 mod diagnostics;

--- a/crates/wgsl-analyzer/src/lsp/extensions.rs
+++ b/crates/wgsl-analyzer/src/lsp/extensions.rs
@@ -950,7 +950,7 @@ pub enum WorkspaceSymbolSearchKind {
 /// the server to format parts of the document during typing.
 ///
 /// This is almost same as [`lsp_types::request::OnTypeFormatting`], but the
-/// result has [`SnippetTextEdit`] in it instead of [`TextEdit`].
+/// result has [`SnippetTextEdit`] in it instead of [`lsp_types::TextEdit`].
 #[derive(Debug)]
 pub enum OnTypeFormatting {}
 

--- a/crates/wgslfmt/src/main.rs
+++ b/crates/wgslfmt/src/main.rs
@@ -1,3 +1,5 @@
+//! Formatter for WGSL code.
+
 #![expect(clippy::print_stderr, reason = "CLI program")]
 #![expect(clippy::print_stdout, reason = "CLI program")]
 #![allow(

--- a/crates/wgslfmt_dprint/src/lib.rs
+++ b/crates/wgslfmt_dprint/src/lib.rs
@@ -1,3 +1,5 @@
+//! [dprint](https://dprint.dev/) plugin for formatting WGSL code.
+
 use anyhow::Result;
 use dprint_core::{
     configuration::{ConfigKeyMap, GlobalConfiguration},

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -372,19 +372,19 @@ export function substituteVariablesInEnv(env: Env): Env {
 	const definedEnvKeys = new Set(Object.keys(env).map((key) => `env:${key}`));
 	const envWithDeps = Object.fromEntries(
 		Object.entries(env).map(([key, value]) => {
-			const deps = new Set<string>();
+			const dependencies = new Set<string>();
 			const depRe = new RegExp(/\$\{(?<depName>.+?)\}/g);
 			let match = undefined;
 			while ((match = depRe.exec(value))) {
 				const depName = unwrapUndefinable(match.groups?.["depName"]);
-				deps.add(depName);
+				dependencies.add(depName);
 				// `depName` at this point can have a form of `expression` or
 				// `prefix:expr`
 				if (!definedEnvKeys.has(depName)) {
 					missingDeps.add(depName);
 				}
 			}
-			return [`env:${key}`, { deps: [...deps], value }];
+			return [`env:${key}`, { dependencies: [...dependencies], value }];
 		}),
 	);
 
@@ -398,7 +398,7 @@ export function substituteVariablesInEnv(env: Env): Env {
 				const envName = unwrapUndefinable(body);
 				envWithDeps[dep] = {
 					value: process.env[envName] ?? "",
-					deps: [],
+					dependencies: [],
 				};
 				resolved.add(dep);
 			} else {
@@ -406,14 +406,14 @@ export function substituteVariablesInEnv(env: Env): Env {
 				// leave values as is, but still mark them as resolved
 				envWithDeps[dep] = {
 					value: "${" + dep + "}",
-					deps: [],
+					dependencies: [],
 				};
 				resolved.add(dep);
 			}
 		} else {
 			envWithDeps[dep] = {
 				value: computeVscodeVar(dep) || "${" + dep + "}",
-				deps: [],
+				dependencies: [],
 			};
 		}
 	}
@@ -424,7 +424,7 @@ export function substituteVariablesInEnv(env: Env): Env {
 		leftToResolveSize = toResolve.size;
 		for (const key of toResolve) {
 			const item = unwrapUndefinable(envWithDeps[key]);
-			if (item.deps.every((dep) => resolved.has(dep))) {
+			if (item.dependencies.every((dep) => resolved.has(dep))) {
 				item.value = item.value.replace(/\$\{(?<depName>.+?)\}/g, (_wholeMatch, depName) => {
 					const item = unwrapUndefinable(envWithDeps[depName]);
 					return item.value;

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -18,9 +18,11 @@ impl Changelog {
             let labels = fetch_labels_with_retry(shell, commit.pr_number)
                 .with_context(|| format!("fetching PR #{}", commit.pr_number))?;
 
-            let skip = labels
-                .iter()
-                .find(|name| name.as_str() == CHORE_LABEL || name.as_str() == DEPENDENCIES_LABEL);
+            let skip = labels.iter().find(|name| {
+                name.as_str() == CHORE_LABEL
+                    || name.as_str() == DEPENDENCIES_LABEL
+                    || name.as_str() == DOCUMENTATION_LABEL
+            });
 
             match skip {
                 None => {
@@ -42,6 +44,7 @@ const REPO_OWNER: &str = "wgsl-analyzer";
 const REPO_NAME: &str = "wgsl-analyzer";
 const CHORE_LABEL: &str = "C-Chore";
 const DEPENDENCIES_LABEL: &str = "C-Dependencies";
+const DOCUMENTATION_LABEL: &str = "C-Documentation";
 
 /// Maximum number of attempts before giving up on a single API call.
 const MAX_RETRIES: u32 = 6;


### PR DESCRIPTION
# Objective

Fixes #882 

## Solution

Mostly add top-level module documentation and fix references to items not imported.

## Testing

```
 techn0@IO  ~/source/wgsl-analyzer   rustdoc-warnings ✚  cargo doc
warning: output filename collision at /home/techn0/source/wgsl-analyzer/target/doc/naga/index.html
  |
  = note: the lib target `naga` in package `naga v28.0.0 (https://github.com/gfx-rs/wgpu?rev=2b8b5f7cdc1872a412371fc458b100de4d88068d#2b8b5f7c)` has the same output filename as the lib target `naga` in package `naga v28.0.0`
  = note: this is a known bug where multiple crates with the same name use the same path; see <https://github.com/rust-lang/cargo/issues/6313>
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
   Generated /home/techn0/source/wgsl-analyzer/target/doc/base_db/index.html and 19 other files
```
