### PR TITLE
parse hex float literals

### DIFF
--- a/crates/hir_def/src/expression.rs
+++ b/crates/hir_def/src/expression.rs
@@ -255,7 +255,6 @@ fn parse_hex_float(hex: &str) -> f64 {
     (whole + frac) * f64::exp2(exponent as f64)
 }
 
-
 impl Expression {
     pub fn walk_child_expressions<Function: FnMut(ExpressionId)>(
         &self,
@@ -299,7 +298,6 @@ impl Expression {
         }
     }
 }
-
 
 #[cfg(test)]
 mod hex_float_tests {

--- a/crates/hir_def/src/expression.rs
+++ b/crates/hir_def/src/expression.rs
@@ -151,7 +151,7 @@ pub enum SwitchCaseSelector {
     Default,
 }
 
-/// Parses a literal from the given `ast::LiteralKind`.
+/// Parses a literal from the given [`ast::LiteralKind`].
 ///
 /// # Panics
 ///
@@ -174,14 +174,9 @@ pub fn parse_literal(literal: ast::LiteralKind) -> Literal {
             // Float suffixes are not accepted by `f32::from_str`. Ignore them
             let (text, float_variant) = split_float_suffix(literal.text());
             let value = match text.strip_prefix("0x").or_else(|| text.strip_prefix("0X")) {
-                Some(_hex) => {
-                    // TODO: Hex floats need to be handled
-                    // See: https://github.com/wgsl-analyzer/wgsl-analyzer/issues/617
-                    Ok(0_f64)
-                },
-                None => f64::from_str(text),
-            }
-            .expect("invalid literal");
+                Some(hex) => parse_hex_float(hex),
+                None => f64::from_str(text).expect("invalid literal"),
+            };
             Literal::Float(value.to_bits(), float_variant)
         },
         ast::LiteralKind::True(_) => Literal::Bool(true),
@@ -213,6 +208,53 @@ fn split_float_suffix(number: &str) -> (&str, BuiltinFloat) {
         (number, BuiltinFloat::Abstract)
     }
 }
+
+/// Parses a hex float string (without the `0x`/`0X` prefix or type suffix).
+///
+/// Accepts formats like:
+/// - `a.fp+2` (whole.fraction p exponent)
+/// - `1p9` (whole p exponent, no fraction)
+/// - `.3` (no whole, fraction only, no exponent)
+/// - `ff.13p13` (multi-digit whole and fraction)
+///
+/// # Panics
+///
+/// Panics if the input is malformed.
+fn parse_hex_float(hex: &str) -> f64 {
+    // Split on 'p' or 'P' to get mantissa and exponent parts
+    let (mantissa_str, exponent) = match hex.find(['p', 'P']) {
+        Some(pos) => {
+            let exp: i32 = hex[pos + 1..].parse().expect("invalid hex float exponent");
+            (&hex[..pos], exp)
+        },
+        None => (hex, 0),
+    };
+
+    // Split mantissa on '.' to get whole and fractional parts
+    let (whole_str, frac_str) = match mantissa_str.find('.') {
+        Some(pos) => (&mantissa_str[..pos], &mantissa_str[pos + 1..]),
+        None => (mantissa_str, ""),
+    };
+
+    // Parse the whole part
+    let whole: f64 = if whole_str.is_empty() {
+        0.0
+    } else {
+        u64::from_str_radix(whole_str, 16).expect("invalid hex float whole part") as f64
+    };
+
+    // Parse the fractional part: each hex digit is worth 1/16 of the previous
+    let mut frac = 0.0_f64;
+    let mut place = 1.0_f64 / 16.0;
+    for ch in frac_str.chars() {
+        let digit = ch.to_digit(16).expect("invalid hex float fraction digit");
+        frac += digit as f64 * place;
+        place /= 16.0;
+    }
+
+    (whole + frac) * f64::exp2(exponent as f64)
+}
+
 
 impl Expression {
     pub fn walk_child_expressions<Function: FnMut(ExpressionId)>(
@@ -255,5 +297,68 @@ impl Expression {
             },
             Self::Missing | Self::Literal(_) => {},
         }
+    }
+}
+
+
+#[cfg(test)]
+mod hex_float_tests {
+    use super::parse_hex_float;
+
+    #[test]
+    fn simple_whole() {
+        assert_eq!(parse_hex_float("1p0"), 1.0);
+        assert_eq!(parse_hex_float("ap0"), 10.0);
+        assert_eq!(parse_hex_float("ffp0"), 255.0);
+    }
+
+    #[test]
+    fn with_exponent() {
+        assert_eq!(parse_hex_float("1p9"), 512.0);
+        assert_eq!(parse_hex_float("1p+4"), 16.0);
+        assert_eq!(parse_hex_float("1p-1"), 0.5);
+    }
+
+    #[test]
+    fn with_fraction() {
+        assert_eq!(parse_hex_float("0.0"), 0.0);
+        assert_eq!(parse_hex_float("1.0"), 1.0);
+        assert_eq!(parse_hex_float("0.8"), 0.5);
+        assert_eq!(parse_hex_float("0.4"), 0.25);
+    }
+
+    #[test]
+    fn fraction_and_exponent() {
+        // 0xa.fp+2 = (10 + 15/16) * 4 = 43.75
+        assert_eq!(parse_hex_float("a.fp+2"), 43.75);
+        // 0x1.fp-4 = (1 + 15/16) * 2^-4 = 0.12109375
+        assert_eq!(parse_hex_float("1.fp-4"), 0.12109375);
+        // 0x3.2p+2 = (3 + 2/16) * 4 = 12.5
+        assert_eq!(parse_hex_float("3.2p+2"), 12.5);
+    }
+
+    #[test]
+    fn no_exponent_with_dot() {
+        assert_eq!(parse_hex_float(".3"), 0.1875);
+        assert_eq!(parse_hex_float("a."), 10.0);
+    }
+
+    #[test]
+    fn multi_digit_fraction() {
+        // 0xff.13p13 = (255 + 1/16 + 3/256) * 2^13
+        let expected = 255.07421875 * 8192.0;
+        assert_eq!(parse_hex_float("ff.13p13"), expected);
+    }
+
+    #[test]
+    fn uppercase() {
+        assert_eq!(parse_hex_float("1P+4"), 16.0);
+        assert_eq!(parse_hex_float("A.FP+2"), 43.75);
+    }
+
+    #[test]
+    fn wgsl_spec_example() {
+        // 0x80.8p-5 = (128 + 8/16) * 2^-5 = 4.015625
+        assert_eq!(parse_hex_float("80.8p-5"), 4.015625);
     }
 }

--- a/crates/hir_def/src/expression.rs
+++ b/crates/hir_def/src/expression.rs
@@ -237,6 +237,10 @@ fn parse_hex_float(hex: &str) -> f64 {
     };
 
     // Parse the whole part
+    #[expect(
+        clippy::as_conversions,
+        reason = "if this is incorrect, please open an issue"
+    )]
     let whole: f64 = if whole_str.is_empty() {
         0.0
     } else {
@@ -248,11 +252,11 @@ fn parse_hex_float(hex: &str) -> f64 {
     let mut place = 1.0_f64 / 16.0;
     for ch in frac_str.chars() {
         let digit = ch.to_digit(16).expect("invalid hex float fraction digit");
-        frac += digit as f64 * place;
+        frac += f64::from(digit) * place;
         place /= 16.0;
     }
 
-    (whole + frac) * f64::exp2(exponent as f64)
+    (whole + frac) * f64::exp2(f64::from(exponent))
 }
 
 impl Expression {
@@ -300,6 +304,7 @@ impl Expression {
 }
 
 #[cfg(test)]
+#[expect(clippy::float_cmp, reason = "the whole point")]
 mod hex_float_tests {
     use super::parse_hex_float;
 
@@ -330,7 +335,7 @@ mod hex_float_tests {
         // 0xa.fp+2 = (10 + 15/16) * 4 = 43.75
         assert_eq!(parse_hex_float("a.fp+2"), 43.75);
         // 0x1.fp-4 = (1 + 15/16) * 2^-4 = 0.12109375
-        assert_eq!(parse_hex_float("1.fp-4"), 0.12109375);
+        assert_eq!(parse_hex_float("1.fp-4"), 0.121_093_75);
         // 0x3.2p+2 = (3 + 2/16) * 4 = 12.5
         assert_eq!(parse_hex_float("3.2p+2"), 12.5);
     }
@@ -344,7 +349,7 @@ mod hex_float_tests {
     #[test]
     fn multi_digit_fraction() {
         // 0xff.13p13 = (255 + 1/16 + 3/256) * 2^13
-        let expected = 255.07421875 * 8192.0;
+        let expected = 255.074_218_75 * 8192.0;
         assert_eq!(parse_hex_float("ff.13p13"), expected);
     }
 
@@ -357,6 +362,6 @@ mod hex_float_tests {
     #[test]
     fn wgsl_spec_example() {
         // 0x80.8p-5 = (128 + 8/16) * 2^-5 = 4.015625
-        assert_eq!(parse_hex_float("80.8p-5"), 4.015625);
+        assert_eq!(parse_hex_float("80.8p-5"), 4.015_625);
     }
 }


### PR DESCRIPTION
# Objective

Fixes #617

Hex float literals like `0xa.fp+2` were previously parsed as `0.0`.

## Solution

Added `parse_hex_float()` that correctly handles the WGSL hex float
format: whole part, fractional part, and binary exponent (p/P).

## Testing

Includes 8 test cases covering all format variations.
