### PR TITLE
Add module graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,6 @@ dependencies = [
  "dashmap",
  "edition",
  "expect-test",
- "la-arena",
  "rowan",
  "rustc-hash 2.1.2",
  "salsa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,7 @@ dependencies = [
  "base-db",
  "either",
  "expect-test",
+ "indexmap",
  "la-arena",
  "query-group-macro",
  "rowan",

--- a/crates/base_db/Cargo.toml
+++ b/crates/base_db/Cargo.toml
@@ -13,14 +13,12 @@ doctest = false
 [dependencies]
 dashmap.workspace = true
 edition.workspace = true
-la-arena.workspace = true
 rowan.workspace = true
 rustc-hash.workspace = true
 salsa.workspace = true
 salsa-macros.workspace = true
 syntax.workspace = true
 tracing.workspace = true
-# remove this when refactoring to PackageCraphBuilder
 triomphe.workspace = true
 vfs.workspace = true
 

--- a/crates/base_db/src/change.rs
+++ b/crates/base_db/src/change.rs
@@ -3,7 +3,6 @@
 
 use std::fmt;
 
-use la_arena::Idx;
 use rustc_hash::FxHashMap;
 use salsa::{Durability, Setter as _};
 use triomphe::Arc;

--- a/crates/base_db/src/editioned_file_id.rs
+++ b/crates/base_db/src/editioned_file_id.rs
@@ -79,20 +79,12 @@ impl EditionedFileId {
         let source_root = database
             .source_root(database.file_source_root(file_id).source_root_id(database))
             .source_root(database);
-        let edition = if let Some((_, Some(extension))) = source_root
+        let edition = source_root
             .path_for_file(file_id)
             .and_then(|file| file.name_and_extension())
-        {
-            if extension.eq_ignore_ascii_case("wesl") {
-                Edition::LATEST
-            } else if extension.eq_ignore_ascii_case("wgsl") {
-                Edition::Wgsl
-            } else {
-                Edition::CURRENT
-            }
-        } else {
-            Edition::CURRENT
-        };
+            .and_then(|(_, extension)| extension)
+            .and_then(Edition::from_file_extension)
+            .unwrap_or(Edition::CURRENT);
 
         Self::new(database, file_id, edition)
     }

--- a/crates/base_db/src/editioned_file_id.rs
+++ b/crates/base_db/src/editioned_file_id.rs
@@ -6,7 +6,7 @@ use syntax::{Diagnostic, ast};
 pub use syntax::{Edition, ExtensionsConfig};
 use vfs::FileId;
 
-use crate::SourceDatabase;
+use crate::{SourceDatabase, file_package};
 
 /// File together with an edition.
 /// Simpler than Rust-Analyzer, because we do not macros.
@@ -76,6 +76,10 @@ impl EditionedFileId {
         database: &dyn SourceDatabase,
         file_id: FileId,
     ) -> Self {
+        if let Some(package) = file_package(database, file_id) {
+            return Self::new(database, file_id, package.data(database).edition);
+        }
+
         let source_root = database
             .source_root(database.file_source_root(file_id).source_root_id(database))
             .source_root(database);

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -210,7 +210,7 @@ pub struct PackageData {
     pub root_file_id: FileId,
     pub edition: Edition,
     /// A name used for UI. For purposes of analysis, packages are anonymous.
-    /// (only names in `Dependency` matters).
+    /// (only names in [`Dependency`] matters).
     pub display_name: Option<String>,
     /// The dependencies of this package.
     ///

--- a/crates/base_db/src/lib.rs
+++ b/crates/base_db/src/lib.rs
@@ -14,19 +14,18 @@ use std::{
     sync::{Once, atomic::AtomicUsize},
 };
 
+use crate::input::{Dependency, PackageData, PackageId, PackageName};
 use dashmap::{DashMap, Entry};
-pub use input::{SourceRoot, SourceRootId};
 use rustc_hash::FxHasher;
-pub use salsa;
 use salsa::{Durability, Setter as _};
-pub use salsa_macros;
-use syntax::{Parse, ast::Name};
 use triomphe::Arc;
-pub use util_types::*;
-pub use vfs::{AnchoredPath, AnchoredPathBuf, FileId, VfsPath, file_set::FileSet};
 
 pub use crate::editioned_file_id::{EditionedFileId, ExtensionsConfig, RawEditionedFileId};
-use crate::input::{Dependency, PackageData, PackageId, PackageName};
+pub use input::{SourceRoot, SourceRootId};
+pub use salsa;
+pub use salsa_macros;
+pub use util_types::*;
+pub use vfs::{AnchoredPath, AnchoredPathBuf, FileId, VfsPath, file_set::FileSet};
 
 #[macro_export]
 macro_rules! impl_intern_key {

--- a/crates/base_db/src/lib.rs
+++ b/crates/base_db/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
     sync::{Once, atomic::AtomicUsize},
 };
 
-use crate::input::{Dependency, PackageData, PackageId, PackageName};
+use crate::input::{PackageData, PackageId, PackageName};
 use dashmap::{DashMap, Entry};
 use rustc_hash::FxHasher;
 use salsa::{Durability, Setter as _};
@@ -288,7 +288,7 @@ pub struct ExtraPackageData {
     /// absent (a dummy package for the code snippet, for example).
     ///
     /// For purposes of analysis, packages are anonymous (only names in
-    /// `Dependency` matters). This name should only be used for UI.
+    /// [`crate::input::Dependency`] matters). This name should only be used for UI.
     pub display_name: Option<PackageDisplayName>,
 }
 

--- a/crates/base_db/src/lib.rs
+++ b/crates/base_db/src/lib.rs
@@ -421,15 +421,6 @@ impl Nonce {
     }
 }
 
-fn parse(
-    database: &dyn SourceDatabase,
-    file_id: EditionedFileId,
-) -> Parse {
-    let RawEditionedFileId { file_id, edition } = file_id.unpack(database);
-    let source = database.file_text(file_id).text(database);
-    syntax::parse(source, edition)
-}
-
 #[must_use]
 #[non_exhaustive]
 pub struct DbPanicContext;
@@ -500,4 +491,44 @@ pub fn all_packages(database: &dyn salsa::Database) -> std::sync::Arc<[Package]>
     AllPackages::try_get(database).map_or_else(std::sync::Arc::default, |all_packages| {
         all_packages.packages(database)
     })
+}
+
+/// I believe this exists because each file has a different `FileSourceRootInput`.
+/// So Salsa cannot reuse computations that are driven by a `FileSourceRootInput`.
+/// TODO: Rust-Analyzer will remove this when the vfs gets rewritten.
+#[doc(hidden)]
+#[salsa::interned]
+pub struct InternedSourceRootId {
+    pub id: SourceRootId,
+}
+
+#[salsa::tracked]
+pub fn source_root_package<'db>(
+    database: &'db dyn SourceDatabase,
+    id: InternedSourceRootId<'db>,
+) -> Option<Package> {
+    let packages = AllPackages::get(database).packages(database);
+    let id = id.id(database);
+
+    packages.iter().copied().find(|package| {
+        let root_file = package.data(database).root_file_id;
+        database
+            .file_source_root(root_file)
+            .source_root_id(database)
+            == id
+    })
+}
+
+/// Returns the package for a given file, if the file is a part of one.
+pub fn file_package(
+    database: &dyn SourceDatabase,
+    file_id: vfs::FileId,
+) -> Option<Package> {
+    let _p = tracing::info_span!("file_package").entered();
+
+    let source_root = database.file_source_root(file_id);
+    source_root_package(
+        database,
+        InternedSourceRootId::new(database, source_root.source_root_id(database)),
+    )
 }

--- a/crates/edition/src/lib.rs
+++ b/crates/edition/src/lib.rs
@@ -39,6 +39,16 @@ impl Edition {
     pub fn iter() -> impl Iterator<Item = Self> {
         [Self::Wgsl, Self::Wesl2025Unstable].iter().copied()
     }
+
+    /// Guesses the edition based on the file extension.
+    #[must_use]
+    pub fn from_file_extension(extension: &str) -> Option<Self> {
+        match extension {
+            "wesl" => Some(Self::LATEST),
+            "wgsl" => Some(Self::Wgsl),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -154,7 +154,7 @@ impl<'database> Semantics<'database> {
             definition.resolver(self.database)
         } else {
             let module_info = self.database.item_tree(file_id);
-            Resolver::default().push_module_scope(file_id, module_info)
+            Resolver::new(file_id, module_info)
         }
     }
 
@@ -401,7 +401,7 @@ impl ChildContainer {
             | Self::TypeAliasId(_) => {
                 let file_id = self.file_id(database);
                 let module_info = database.item_tree(file_id);
-                Resolver::default().push_module_scope(file_id, module_info)
+                Resolver::new(file_id, module_info)
             },
         }
     }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -599,7 +599,7 @@ impl HasSource for Local {
             .map_err(drop)
             .ok()?;
 
-        let root = database.parse_or_resolve(file_id).syntax();
+        let root = file_id.parse(database).syntax();
         Some(InFile::new(file_id, binding.to_node(&root)))
     }
 }
@@ -913,7 +913,7 @@ fn validate_identifiers(
 ) {
     let item_tree = database.item_tree(file_id);
     let ast_id_map = database.ast_id_map(file_id);
-    let root = database.parse_or_resolve(file_id).syntax();
+    let root = file_id.parse(database).syntax();
 
     macro_rules! validate {
         (

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 [dependencies]
 base-db.workspace = true
 either.workspace = true
+indexmap.workspace = true
 la-arena.workspace = true
 query-group.workspace = true
 rowan.workspace = true

--- a/crates/hir_def/src/database.rs
+++ b/crates/hir_def/src/database.rs
@@ -319,7 +319,7 @@ impl DefinitionWithBodyId {
     ) -> Resolver {
         let file_id = self.file_id(database);
         let module_info = database.item_tree(file_id);
-        Resolver::default().push_module_scope(file_id, module_info)
+        Resolver::new(file_id, module_info)
     }
 }
 
@@ -357,7 +357,7 @@ impl ModuleDefinitionId {
     ) -> Resolver {
         let file_id = self.file_id(database);
         let module_info = database.item_tree(file_id);
-        Resolver::default().push_module_scope(file_id, module_info)
+        Resolver::new(file_id, module_info)
     }
 }
 

--- a/crates/hir_def/src/database.rs
+++ b/crates/hir_def/src/database.rs
@@ -37,11 +37,6 @@ pub trait DefDatabase: InternDatabase + SourceDatabase {
     #[salsa::input]
     fn extensions(&self) -> ExtensionsConfig;
 
-    fn parse_or_resolve(
-        &self,
-        key: EditionedFileId,
-    ) -> Parse;
-
     fn ast_id_map(
         &self,
         key: EditionedFileId,
@@ -157,18 +152,11 @@ fn signature_with_source_map(
     }
 }
 
-fn parse_or_resolve(
-    database: &dyn DefDatabase,
-    file_id: EditionedFileId,
-) -> Parse {
-    file_id.parse(database)
-}
-
 fn ast_id_map(
     database: &dyn DefDatabase,
     file_id: EditionedFileId,
 ) -> Arc<AstIdMap> {
-    let parsed = database.parse_or_resolve(file_id);
+    let parsed = file_id.parse(database);
     let map = AstIdMap::from_source(&parsed.tree());
     Arc::new(map)
 }
@@ -323,7 +311,7 @@ impl DefinitionWithBodyId {
     }
 }
 
-/// All module items.
+/// The definitions which can be visible in the module.
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, salsa_macros::Supertype)]
 pub enum ModuleDefinitionId {
     Function(FunctionId),
@@ -358,6 +346,20 @@ impl ModuleDefinitionId {
         let file_id = self.file_id(database);
         let module_info = database.item_tree(file_id);
         Resolver::new(file_id, module_info)
+    }
+
+    #[must_use]
+    pub const fn with_body(self) -> Option<DefinitionWithBodyId> {
+        match self {
+            Self::Function(id) => Some(DefinitionWithBodyId::Function(id)),
+            Self::GlobalVariable(id) => Some(DefinitionWithBodyId::GlobalVariable(id)),
+            Self::GlobalConstant(id) => Some(DefinitionWithBodyId::GlobalConstant(id)),
+            Self::GlobalAssertStatement(id) => {
+                Some(DefinitionWithBodyId::GlobalAssertStatement(id))
+            },
+            Self::Override(id) => Some(DefinitionWithBodyId::Override(id)),
+            Self::Struct(_) | Self::TypeAlias(_) => None,
+        }
     }
 }
 

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -197,7 +197,7 @@ impl ItemTree {
         database: &dyn DefDatabase,
         file_id: EditionedFileId,
     ) -> Arc<Self> {
-        let source = database.parse_or_resolve(file_id).tree();
+        let source = file_id.parse(database).tree();
 
         let lower_ctx = lower::Ctx::new(database, file_id);
         let mut tree = lower_ctx.lower_source_file(&source);

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -8,6 +8,7 @@ pub mod expression;
 pub mod expression_store;
 pub mod item_tree;
 pub mod mod_path;
+pub mod name_resolution;
 pub mod resolver;
 pub mod signature;
 #[cfg(test)]
@@ -22,6 +23,10 @@ use database::DefDatabase;
 use item_tree::{ItemTreeNode, ModuleItemId};
 use rowan::NodeOrToken;
 use syntax::{AstNode, SyntaxNode, SyntaxToken, pointer::AstPointer};
+
+pub type FxIndexSet<T> = indexmap::IndexSet<T, rustc_hash::FxBuildHasher>;
+pub type FxIndexMap<K, V> =
+    indexmap::IndexMap<K, V, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 
 /// `InFile<T>` stores a value of `T` inside a particular file/syntax tree.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -71,7 +71,7 @@ impl<T> InFile<T> {
         &self,
         database: &dyn database::DefDatabase,
     ) -> SyntaxNode {
-        database.parse_or_resolve(self.file_id).syntax()
+        self.file_id.parse(database).syntax()
     }
 }
 
@@ -133,10 +133,7 @@ pub trait HasSource {
         database: &dyn DefDatabase,
     ) -> InFile<Self::Value> {
         let InFile { file_id, value } = self.ast_ptr(database);
-        InFile::new(
-            file_id,
-            value.to_node(&database.parse_or_resolve(file_id).syntax()),
-        )
+        InFile::new(file_id, value.to_node(&file_id.parse(database).syntax()))
     }
     fn ast_ptr(
         &self,

--- a/crates/hir_def/src/name_resolution.rs
+++ b/crates/hir_def/src/name_resolution.rs
@@ -1,3 +1,6 @@
 mod modules_map;
 
-pub use modules_map::{ModuleData, ModulesMap, module_data, package_modules_map};
+#[cfg(test)]
+mod tests;
+
+pub use modules_map::{ModuleData, ModulesMap, module_data, modules_map_query};

--- a/crates/hir_def/src/name_resolution.rs
+++ b/crates/hir_def/src/name_resolution.rs
@@ -1,0 +1,3 @@
+mod modules_map;
+
+pub use modules_map::{ModuleData, ModulesMap, module_data, package_modules_map};

--- a/crates/hir_def/src/name_resolution/modules_map.rs
+++ b/crates/hir_def/src/name_resolution/modules_map.rs
@@ -8,31 +8,10 @@ use vfs::FileId;
 
 use crate::{FxIndexMap, database::DefDatabase, item_tree::Name};
 
-/// Used for
-/// - `import foo::|` autocompletions. When I'm typing `foo::|` then I need to know what valid names come next.
-/// - Open symbol by name. `all_symbols() => for each crate: crate_symbols() => for each file (ignore visibility): file_symbols()`
-/// - Unit test discovery. `unit_tests() => for each file (ignore visibility): file_unit_tests()`
-/// - Check all files. `check_all() => for each file (ignore visibility): check()`
+/// A map of all modules and their children in a package.
 ///
-///
-/// Ruff has this kind of info as well <https://github.com/astral-sh/ruff/blob/b409cbeea655e402152d9c0d2057e180d3b660b8/crates/ty_python_semantic/src/semantic_model.rs#L187>
-/// Ruff does read children: https://github.com/astral-sh/ruff/blob/b409cbeea655e402152d9c0d2057e180d3b660b8/crates/ty_module_resolver/src/module.rs#L123
-/// `#[salsa::tracked] all_submodule_names_for_package(db, module: Module<'db>) -> Option<Vec<Module<'db>>>` is what they got
-///
-/// Ruff does it tree shaped https://github.com/astral-sh/ruff/blob/a88b2f619c3065de00c75f44903e4d74c37b7796/crates/ty_module_resolver/src/list.rs#L12
-/// for all_symbols, import completions (via the list_modules function),
-///
-/// We can do `import foo::bar;` and `import super::bar;` with the current API. We'd just call `SourceRoot.resolve_path` at the right time. Hmm
-///
-///  Any query that depends on `fn all_files()` will be re-executed whenever any file is added or removed.
-/// How do I get salsa to memoize just the right bit? Like
-/// - source root changes => need to recompute the entire "tree" structure
-/// - children(file_id) -> Vec<FileId> needs to be one of those tracked functions. It should see that the result hasn't changed and thus skippy skip the rest
-/// The only way of beating all that would be by making the Change itself touch the relevant bits. Then the parents and children would be inputs and we'd do set_whatever.
-///
-/// Also hmm basically no part of the language server does path lookups.
-/// There's a bit in r-a that deals with moving and renaming files.
-///
+/// Used for name resolution.
+/// Can also be used to iterate over all modules in a package to discover all symbols or all unit tests.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ModulesMap {
     pub root: FileId,

--- a/crates/hir_def/src/name_resolution/modules_map.rs
+++ b/crates/hir_def/src/name_resolution/modules_map.rs
@@ -84,6 +84,8 @@ pub fn modules_map_query(
     for file_id in source_root.iter() {
         modules_map.add_file(file_id, &source_root);
     }
+    // Clear the name of the root module, since we only want names that can be used in shader code
+    modules_map.modules[&modules_map.root].name = None;
 
     modules_map.keep_reachable();
 

--- a/crates/hir_def/src/name_resolution/modules_map.rs
+++ b/crates/hir_def/src/name_resolution/modules_map.rs
@@ -1,0 +1,140 @@
+use base_db::{
+    EditionedFileId, InternedSourceRootId, Package, SourceDatabase, SourceRoot, file_package,
+};
+use rustc_hash::FxHashMap;
+use vfs::FileId;
+
+use crate::{FxIndexMap, item_tree::Name};
+
+/// Used for
+/// - `import foo::|` autocompletions. When I'm typing `foo::|` then I need to know what valid names come next.
+/// - Open symbol by name. `all_symbols() => for each crate: crate_symbols() => for each file (ignore visibility): file_symbols()`
+/// - Unit test discovery. `unit_tests() => for each file (ignore visibility): file_unit_tests()`
+/// - Check all files. `check_all() => for each file (ignore visibility): check()`
+///
+///
+/// Ruff has this kind of info as well <https://github.com/astral-sh/ruff/blob/b409cbeea655e402152d9c0d2057e180d3b660b8/crates/ty_python_semantic/src/semantic_model.rs#L187>
+/// Ruff does read children: https://github.com/astral-sh/ruff/blob/b409cbeea655e402152d9c0d2057e180d3b660b8/crates/ty_module_resolver/src/module.rs#L123
+/// `#[salsa::tracked] all_submodule_names_for_package(db, module: Module<'db>) -> Option<Vec<Module<'db>>>` is what they got
+///
+/// Ruff does it tree shaped https://github.com/astral-sh/ruff/blob/a88b2f619c3065de00c75f44903e4d74c37b7796/crates/ty_module_resolver/src/list.rs#L12
+/// for all_symbols, import completions (via the list_modules function),
+///
+/// We can do `import foo::bar;` and `import super::bar;` with the current API. We'd just call `SourceRoot.resolve_path` at the right time. Hmm
+///
+///  Any query that depends on `fn all_files()` will be re-executed whenever any file is added or removed.
+/// How do I get salsa to memoize just the right bit? Like
+/// - source root changes => need to recompute the entire "tree" structure
+/// - children(file_id) -> Vec<FileId> needs to be one of those tracked functions. It should see that the result hasn't changed and thus skippy skip the rest
+/// The only way of beating all that would be by making the Change itself touch the relevant bits. Then the parents and children would be inputs and we'd do set_whatever.
+///
+/// Also hmm basically no part of the language server does path lookups.
+/// There's a bit in r-a that deals with moving and renaming files.
+///
+#[salsa_macros::tracked]
+pub struct ModulesMap<'db> {
+    #[tracked]
+    #[returns(ref)]
+    pub modules: FxIndexMap<FileId, ModuleData>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ModuleData {
+    /// What is the name of this module, when looking at the absolute module path.
+    /// Is empty when it is the root module.
+    pub name: Option<Name>,
+    /// Where does this module come from?
+    pub origin: EditionedFileId,
+    /// Declared visibility of this module.
+    // pub visibility: Visibility,
+    /// Parent module in the same `DefMap`.
+    pub parent: Option<FileId>,
+    pub children: FxIndexMap<Name, FileId>,
+}
+
+// TODO: Look into the incrementality of this
+#[salsa_macros::tracked(returns(ref))]
+pub fn module_data<'db>(
+    database: &'db dyn SourceDatabase,
+    file_id: EditionedFileId,
+) -> Option<ModuleData> {
+    let raw_file_id = file_id.file_id(database);
+    let package = file_package(database, raw_file_id)?;
+    let modules = package_modules_map(database, package);
+
+    // TODO: Is cloned the right thing to use here?
+    modules.modules(database).get(&raw_file_id).cloned()
+}
+
+#[salsa_macros::tracked]
+pub fn package_modules_map<'db>(
+    database: &'db dyn SourceDatabase,
+    package: Package,
+) -> ModulesMap<'db> {
+    let package_data = package.data(database);
+    let source_root = database
+        .source_root(
+            database
+                .file_source_root(package_data.root_file_id)
+                .source_root_id(database),
+        )
+        .source_root(database);
+
+    let mut modules = FxIndexMap::from_iter(source_root.iter().map(|file_id| {
+        (
+            file_id,
+            ModuleData {
+                name: None,
+                origin: EditionedFileId::new(database, file_id, package_data.edition),
+                parent: None,
+                children: FxIndexMap::default(),
+            },
+        )
+    }));
+    for file_id in source_root.iter() {
+        add_file(&mut modules, file_id, &source_root);
+    }
+
+    ModulesMap::new(database, modules)
+}
+
+fn add_file(
+    modules: &mut FxIndexMap<FileId, ModuleData>,
+    file_id: FileId,
+    source_root: &SourceRoot,
+) -> Option<()> {
+    let path = source_root.path_for_file(file_id)?;
+    let (name, extension) = path.name_and_extension()?;
+    // TODO: in another place we're doing extension.eq_ignore_ascii_case("wesl")
+    // Though I think we are assuming case sensitivity in other parts of the code???
+    if !matches!(extension, Some("wesl" | "wgsl")) {
+        return None;
+    }
+    let name = Name::from(name);
+
+    let file_node = &mut modules[&file_id];
+    file_node.name = Some(name.clone());
+
+    // TODO: This cannot account for the case where a module is missing. After all, missing modules do not have a file id.
+    // > File not found: We assume an empty module as the current module, and continue with that.
+    // > https://github.com/wgsl-tooling-wg/wesl-spec/blob/main/Imports.md#import-resolution-algorithm
+    let parent_path = get_parent_path(path)?;
+    if let Some(parent_id) = source_root.file_for_path(&parent_path) {
+        file_node.parent = Some(*parent_id);
+        modules[parent_id].children.insert(name, file_id);
+    }
+    Some(())
+}
+
+/// Goes from a path like `foo/bar.wesl` to `foo.wesl`
+fn get_parent_path(path: &vfs::VfsPath) -> Option<vfs::VfsPath> {
+    let mut parent_path = path.parent()?;
+    let (name, extension) = parent_path.name_and_extension()?;
+    if extension.is_some() {
+        return None;
+    }
+    // Only wesl files can have child modules
+    let file_name = format!("{name}.wesl");
+    parent_path.pop();
+    parent_path.join(&file_name)
+}

--- a/crates/hir_def/src/name_resolution/modules_map.rs
+++ b/crates/hir_def/src/name_resolution/modules_map.rs
@@ -1,12 +1,8 @@
-use base_db::{
-    EditionedFileId, InternedSourceRootId, Package, SourceDatabase, SourceRoot, file_package,
-};
-use rustc_hash::FxHashMap;
+use base_db::{EditionedFileId, Package, SourceDatabase, SourceRoot, file_package};
 use std::fmt::Write as _;
-use syntax::Edition;
 use vfs::FileId;
 
-use crate::{FxIndexMap, database::DefDatabase, item_tree::Name};
+use crate::{FxIndexMap, item_tree::Name};
 
 /// A map of all modules and their children in a package.
 ///
@@ -15,6 +11,7 @@ use crate::{FxIndexMap, database::DefDatabase, item_tree::Name};
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ModulesMap {
     pub root: FileId,
+    /// All modules in the project, including unreachable modules.
     pub modules: FxIndexMap<FileId, ModuleData>,
 }
 
@@ -141,7 +138,7 @@ impl ModulesMap {
             path: &str,
             module: FileId,
         ) {
-            writeln!(buffer, "{path}");
+            _ = writeln!(buffer, "{path}");
 
             let mut children: Vec<_> = modules.modules[&module].children.iter().collect();
             children.sort_by(|(name_a, _), (name_b, _)| Ord::cmp(name_a, name_b));

--- a/crates/hir_def/src/name_resolution/modules_map.rs
+++ b/crates/hir_def/src/name_resolution/modules_map.rs
@@ -11,7 +11,7 @@ use crate::{FxIndexMap, item_tree::Name};
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ModulesMap {
     pub root: FileId,
-    /// All modules in the project, including unreachable modules.
+    /// All reachable modules in the project.
     pub modules: FxIndexMap<FileId, ModuleData>,
 }
 
@@ -111,7 +111,7 @@ impl ModulesMap {
         // > https://github.com/wgsl-tooling-wg/wesl-spec/blob/main/Imports.md#import-resolution-algorithm
         if let Some(parent_id) = source_root.file_for_path(&get_parent_path(path)?) {
             // .wesl files will shadow .wgsl files
-            let is_slot_empty = self.modules[parent_id].children.contains_key(&name);
+            let is_slot_empty = !self.modules[parent_id].children.contains_key(&name);
             if extension == Some("wesl") || is_slot_empty {
                 self.modules[&file_id].parent = Some(*parent_id);
                 self.modules[parent_id].children.insert(name, file_id);

--- a/crates/hir_def/src/name_resolution/modules_map.rs
+++ b/crates/hir_def/src/name_resolution/modules_map.rs
@@ -2,10 +2,11 @@ use base_db::{
     EditionedFileId, InternedSourceRootId, Package, SourceDatabase, SourceRoot, file_package,
 };
 use rustc_hash::FxHashMap;
+use std::fmt::Write as _;
 use syntax::Edition;
 use vfs::FileId;
 
-use crate::{FxIndexMap, item_tree::Name};
+use crate::{FxIndexMap, database::DefDatabase, item_tree::Name};
 
 /// Used for
 /// - `import foo::|` autocompletions. When I'm typing `foo::|` then I need to know what valid names come next.
@@ -32,10 +33,9 @@ use crate::{FxIndexMap, item_tree::Name};
 /// Also hmm basically no part of the language server does path lookups.
 /// There's a bit in r-a that deals with moving and renaming files.
 ///
-#[salsa_macros::tracked]
-pub struct ModulesMap<'db> {
-    #[tracked]
-    #[returns(ref)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ModulesMap {
+    pub root: FileId,
     pub modules: FxIndexMap<FileId, ModuleData>,
 }
 
@@ -72,17 +72,17 @@ pub fn module_data<'db>(
 ) -> Option<ModuleData> {
     let raw_file_id = file_id.file_id(database);
     let package = file_package(database, raw_file_id)?;
-    let modules = package_modules_map(database, package);
+    let modules = modules_map_query(database, package);
 
     // TODO: Is cloned the right thing to use here?
-    modules.modules(database).get(&raw_file_id).cloned()
+    modules.modules.get(&raw_file_id).cloned()
 }
 
-#[salsa_macros::tracked]
-pub fn package_modules_map(
+#[salsa_macros::tracked(returns(ref))]
+pub fn modules_map_query(
     database: &dyn SourceDatabase,
     package: Package,
-) -> ModulesMap<'_> {
+) -> ModulesMap {
     let package_data = package.data(database);
     let source_root = database
         .source_root(
@@ -104,7 +104,10 @@ pub fn package_modules_map(
         add_file(&mut modules, file_id, &source_root);
     }
 
-    ModulesMap::new(database, modules)
+    ModulesMap {
+        root: package_data.root_file_id,
+        modules,
+    }
 }
 
 fn add_file(
@@ -144,4 +147,29 @@ fn get_parent_path(path: &vfs::VfsPath) -> Option<vfs::VfsPath> {
     let file_name = format!("{name}.wesl");
     parent_path.pop();
     parent_path.join(&file_name)
+}
+
+impl ModulesMap {
+    #[must_use]
+    pub fn dump(&self) -> String {
+        let mut buffer = String::new();
+        go(&mut buffer, self, "package", self.root);
+        return buffer;
+
+        fn go(
+            buffer: &mut String,
+            modules: &ModulesMap,
+            path: &str,
+            module: FileId,
+        ) {
+            writeln!(buffer, "{path}");
+
+            let mut children: Vec<_> = modules.modules[&module].children.iter().collect();
+            children.sort_by(|(name_a, _), (name_b, _)| Ord::cmp(name_a, name_b));
+            for (name, child) in children {
+                let path = format!("{path}::{}", name.as_str());
+                go(buffer, modules, &path, *child);
+            }
+        }
+    }
 }

--- a/crates/hir_def/src/name_resolution/modules_map.rs
+++ b/crates/hir_def/src/name_resolution/modules_map.rs
@@ -24,7 +24,7 @@ pub struct ModuleData {
     pub origin: EditionedFileId,
     /// Declared visibility of this module.
     // pub visibility: Visibility,
-    /// Parent module in the same `DefMap`.
+    /// Parent module in the same [`ModulesMap`].
     pub parent: Option<FileId>,
     pub children: FxIndexMap<Name, FileId>,
 }
@@ -68,7 +68,7 @@ pub fn modules_map_query(
         )
         .source_root(database);
 
-    let mut modules: FxIndexMap<_, _> = source_root
+    let modules: FxIndexMap<_, _> = source_root
         .iter()
         .map(|file_id| {
             let origin = EditionedFileId::new(database, file_id, package_data.edition);
@@ -76,56 +76,67 @@ pub fn modules_map_query(
         })
         .collect();
 
-    for file_id in source_root.iter() {
-        add_file(&mut modules, file_id, &source_root);
-    }
-
-    ModulesMap {
+    let mut modules_map = ModulesMap {
         root: package_data.root_file_id,
         modules,
-    }
-}
+    };
 
-fn add_file(
-    modules: &mut FxIndexMap<FileId, ModuleData>,
-    file_id: FileId,
-    source_root: &SourceRoot,
-) -> Option<()> {
-    let path = source_root.path_for_file(file_id)?;
-    let (name, extension) = path.name_and_extension()?;
-    if !matches!(extension, Some("wesl" | "wgsl")) {
-        return None;
+    for file_id in source_root.iter() {
+        modules_map.add_file(file_id, &source_root);
     }
-    let name = Name::from(name);
 
-    let file_node = &mut modules[&file_id];
-    file_node.name = Some(name.clone());
+    modules_map.keep_reachable();
 
-    // TODO: This cannot account for the case where a module is missing. After all, missing modules do not have a file id.
-    // > File not found: We assume an empty module as the current module, and continue with that.
-    // > https://github.com/wgsl-tooling-wg/wesl-spec/blob/main/Imports.md#import-resolution-algorithm
-    let parent_path = get_parent_path(path)?;
-    if let Some(parent_id) = source_root.file_for_path(&parent_path) {
-        file_node.parent = Some(*parent_id);
-        modules[parent_id].children.insert(name, file_id);
-    }
-    Some(())
-}
-
-/// Goes from a path like `foo/bar.wesl` to `foo.wesl`.
-fn get_parent_path(path: &vfs::VfsPath) -> Option<vfs::VfsPath> {
-    let mut parent_path = path.parent()?;
-    let (name, extension) = parent_path.name_and_extension()?;
-    if extension.is_some() {
-        return None;
-    }
-    // Only wesl files can have child modules
-    let file_name = format!("{name}.wesl");
-    parent_path.pop();
-    parent_path.join(&file_name)
+    modules_map
 }
 
 impl ModulesMap {
+    fn add_file(
+        &mut self,
+        file_id: FileId,
+        source_root: &SourceRoot,
+    ) -> Option<()> {
+        let path = source_root.path_for_file(file_id)?;
+        let (name, extension) = path.name_and_extension()?;
+        if !matches!(extension, Some("wesl" | "wgsl")) {
+            return None;
+        }
+        let name = Name::from(name);
+        self.modules[&file_id].name = Some(name.clone());
+
+        // TODO: This cannot account for the case where a module is missing. After all, missing modules do not have a file id.
+        // > File not found: We assume an empty module as the current module, and continue with that.
+        // > https://github.com/wgsl-tooling-wg/wesl-spec/blob/main/Imports.md#import-resolution-algorithm
+        if let Some(parent_id) = source_root.file_for_path(&get_parent_path(path)?) {
+            // .wesl files will shadow .wgsl files
+            let is_slot_empty = self.modules[parent_id].children.contains_key(&name);
+            if extension == Some("wesl") || is_slot_empty {
+                self.modules[&file_id].parent = Some(*parent_id);
+                self.modules[parent_id].children.insert(name, file_id);
+            }
+        }
+        Some(())
+    }
+
+    fn keep_reachable(&mut self) {
+        fn keep_children(
+            root: FileId,
+            old_modules: &mut FxIndexMap<FileId, ModuleData>,
+            new_modules: &mut FxIndexMap<FileId, ModuleData>,
+        ) {
+            let module = old_modules.swap_remove(&root).unwrap();
+            for child_id in module.children.values() {
+                keep_children(*child_id, old_modules, new_modules);
+            }
+            new_modules.insert(root, module);
+        }
+        let mut new_modules = FxIndexMap::default();
+        keep_children(self.root, &mut self.modules, &mut new_modules);
+
+        self.modules = new_modules;
+        self.modules.shrink_to_fit();
+    }
+
     #[must_use]
     pub fn dump(&self) -> String {
         let mut buffer = String::new();
@@ -148,4 +159,17 @@ impl ModulesMap {
             }
         }
     }
+}
+
+/// Goes from a path like `foo/bar.wesl` to `foo.wesl`.
+fn get_parent_path(path: &vfs::VfsPath) -> Option<vfs::VfsPath> {
+    let mut parent_path = path.parent()?;
+    let (name, extension) = parent_path.name_and_extension()?;
+    if extension.is_some() {
+        return None;
+    }
+    // Only wesl files can have child modules
+    let file_name = format!("{name}.wesl");
+    parent_path.pop();
+    parent_path.join(&file_name)
 }

--- a/crates/hir_def/src/name_resolution/modules_map.rs
+++ b/crates/hir_def/src/name_resolution/modules_map.rs
@@ -2,6 +2,7 @@ use base_db::{
     EditionedFileId, InternedSourceRootId, Package, SourceDatabase, SourceRoot, file_package,
 };
 use rustc_hash::FxHashMap;
+use syntax::Edition;
 use vfs::FileId;
 
 use crate::{FxIndexMap, item_tree::Name};
@@ -52,6 +53,17 @@ pub struct ModuleData {
     pub children: FxIndexMap<Name, FileId>,
 }
 
+impl ModuleData {
+    fn new(origin: EditionedFileId) -> Self {
+        Self {
+            name: None,
+            origin,
+            parent: None,
+            children: FxIndexMap::default(),
+        }
+    }
+}
+
 // TODO: Look into the incrementality of this
 #[salsa_macros::tracked(returns(ref))]
 pub fn module_data<'db>(
@@ -67,10 +79,10 @@ pub fn module_data<'db>(
 }
 
 #[salsa_macros::tracked]
-pub fn package_modules_map<'db>(
-    database: &'db dyn SourceDatabase,
+pub fn package_modules_map(
+    database: &dyn SourceDatabase,
     package: Package,
-) -> ModulesMap<'db> {
+) -> ModulesMap<'_> {
     let package_data = package.data(database);
     let source_root = database
         .source_root(
@@ -80,17 +92,14 @@ pub fn package_modules_map<'db>(
         )
         .source_root(database);
 
-    let mut modules = FxIndexMap::from_iter(source_root.iter().map(|file_id| {
-        (
-            file_id,
-            ModuleData {
-                name: None,
-                origin: EditionedFileId::new(database, file_id, package_data.edition),
-                parent: None,
-                children: FxIndexMap::default(),
-            },
-        )
-    }));
+    let mut modules: FxIndexMap<_, _> = source_root
+        .iter()
+        .map(|file_id| {
+            let origin = EditionedFileId::new(database, file_id, package_data.edition);
+            (file_id, ModuleData::new(origin))
+        })
+        .collect();
+
     for file_id in source_root.iter() {
         add_file(&mut modules, file_id, &source_root);
     }
@@ -105,8 +114,6 @@ fn add_file(
 ) -> Option<()> {
     let path = source_root.path_for_file(file_id)?;
     let (name, extension) = path.name_and_extension()?;
-    // TODO: in another place we're doing extension.eq_ignore_ascii_case("wesl")
-    // Though I think we are assuming case sensitivity in other parts of the code???
     if !matches!(extension, Some("wesl" | "wgsl")) {
         return None;
     }
@@ -126,7 +133,7 @@ fn add_file(
     Some(())
 }
 
-/// Goes from a path like `foo/bar.wesl` to `foo.wesl`
+/// Goes from a path like `foo/bar.wesl` to `foo.wesl`.
 fn get_parent_path(path: &vfs::VfsPath) -> Option<vfs::VfsPath> {
     let mut parent_path = path.parent()?;
     let (name, extension) = parent_path.name_and_extension()?;

--- a/crates/hir_def/src/name_resolution/tests.rs
+++ b/crates/hir_def/src/name_resolution/tests.rs
@@ -9,6 +9,7 @@ fn render_modules_map(wa_fixture: &str) -> String {
     modules_map_query(&database, package).dump()
 }
 
+#[expect(clippy::needless_pass_by_value, reason = "matches expect! macro")]
 fn check(
     wa_fixture: &str,
     expect: Expect,

--- a/crates/hir_def/src/name_resolution/tests.rs
+++ b/crates/hir_def/src/name_resolution/tests.rs
@@ -1,0 +1,39 @@
+use expect_test::{Expect, expect};
+use test_fixture::WithFixture as _;
+
+use crate::{name_resolution::modules_map_query, test_db::TestDatabase};
+
+fn render_modules_map(wa_fixture: &str) -> String {
+    let database = TestDatabase::with_files(wa_fixture);
+    let package = database.fetch_test_package();
+    modules_map_query(&database, package).dump()
+}
+
+fn check(
+    wa_fixture: &str,
+    expect: Expect,
+) {
+    let actual = render_modules_map(wa_fixture);
+    expect.assert_eq(&actual);
+}
+
+#[test]
+fn crate_modules_map_smoke_test() {
+    check(
+        r#"
+//- /shaders.wesl
+use package::foo::bar::g;
+
+//- /shaders/foo.wesl
+fn f() {}
+
+//- /shaders/foo/bar.wesl
+fn g() {}
+"#,
+        expect![[r#"
+            package
+            package::foo
+            package::foo::bar
+        "#]],
+    );
+}

--- a/crates/hir_def/src/name_resolution/tests.rs
+++ b/crates/hir_def/src/name_resolution/tests.rs
@@ -41,6 +41,9 @@ fn g() {}
 
 #[test]
 fn module_map_ignores_unreachable() {
+    // The current implementation ignores files that do not have a corresponding parent
+    // See: https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1182
+
     check(
         r#"
 //- /shaders.wesl

--- a/crates/hir_def/src/name_resolution/tests.rs
+++ b/crates/hir_def/src/name_resolution/tests.rs
@@ -38,3 +38,40 @@ fn g() {}
         "#]],
     );
 }
+
+#[test]
+fn module_map_ignores_unreachable() {
+    check(
+        r#"
+//- /shaders.wesl
+
+//- /shaders/foo.wesl
+
+//- /shaders/bar/unreachable.wesl
+
+//- /shaders/foo/bar.wesl
+"#,
+        expect![[r#"
+            package
+            package::foo
+            package::foo::bar
+        "#]],
+    );
+}
+
+#[test]
+fn module_map_wesl_shadows_wgsl() {
+    check(
+        r#"
+//- /shaders.wesl
+
+//- /shaders/foo.wesl
+
+//- /shaders/foo.wgsl
+"#,
+        expect![[r#"
+            package
+            package::foo
+        "#]],
+    );
+}

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -64,34 +64,27 @@ pub struct Resolver {
     scopes: Vec<Scope>,
 }
 
-impl Default for Resolver {
-    fn default() -> Self {
+impl Resolver {
+    #[must_use]
+    pub fn new(
+        file_id: EditionedFileId,
+        module_info: Arc<ItemTree>,
+    ) -> Self {
+        let module_scope = ModuleScope {
+            module_info,
+            file_id,
+        };
         Self {
-            scopes: vec![Scope::Builtin],
+            scopes: vec![Scope::Builtin, Scope::Module(module_scope)],
         }
     }
-}
 
-impl Resolver {
     #[must_use]
     pub fn push_scope(
         mut self,
         scope: Scope,
     ) -> Self {
         self.scopes.push(scope);
-        self
-    }
-
-    #[must_use]
-    pub fn push_module_scope(
-        mut self,
-        file_id: EditionedFileId,
-        item_tree: Arc<ItemTree>,
-    ) -> Self {
-        self.scopes.push(Scope::Module(ModuleScope {
-            module_info: item_tree,
-            file_id,
-        }));
         self
     }
 

--- a/crates/hir_def/src/test_db.rs
+++ b/crates/hir_def/src/test_db.rs
@@ -132,6 +132,6 @@ impl TestDatabase {
             .iter()
             .copied()
             .find(|package| package.data(self).display_name.as_deref() == Some("wa_test_fixture"))
-            .unwrap_or(*all_packages.last().unwrap())
+            .unwrap_or_else(|| *all_packages.last().unwrap())
     }
 }

--- a/crates/hir_def/src/test_db.rs
+++ b/crates/hir_def/src/test_db.rs
@@ -12,7 +12,6 @@ use triomphe::Arc;
 use vfs::{AnchoredPath, FileId, VfsPath, file_set::FileSet};
 
 #[salsa_macros::db]
-#[derive(Clone)]
 pub(crate) struct TestDatabase {
     storage: salsa::Storage<Self>,
     files: Arc<base_db::Files>,
@@ -32,12 +31,22 @@ impl Default for TestDatabase {
     }
 }
 
+impl Clone for TestDatabase {
+    fn clone(&self) -> Self {
+        Self {
+            storage: self.storage.clone(),
+            files: self.files.clone(),
+            nonce: Nonce::new(),
+        }
+    }
+}
+
 impl fmt::Debug for TestDatabase {
     fn fmt(
         &self,
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
-        f.debug_struct("TestDB").finish()
+        f.debug_struct("TestDatabase").finish()
     }
 }
 
@@ -122,7 +131,7 @@ impl TestDatabase {
         all_packages
             .iter()
             .copied()
-            .find(|package| package.data(self).display_name.as_deref() == Some("ra_test_fixture"))
+            .find(|package| package.data(self).display_name.as_deref() == Some("wa_test_fixture"))
             .unwrap_or(*all_packages.last().unwrap())
     }
 }

--- a/crates/hir_def/src/test_db.rs
+++ b/crates/hir_def/src/test_db.rs
@@ -1,8 +1,9 @@
 use std::{fmt, panic};
 
 use base_db::{
-    EditionedFileId, FileSourceRootInput, FileText, Nonce, SourceDatabase, SourceRootId,
-    SourceRootInput, change::Change, input::SourceRoot, set_all_packages_with_durability,
+    EditionedFileId, FileSourceRootInput, FileText, Nonce, Package, SourceDatabase, SourceRootId,
+    SourceRootInput, all_packages, change::Change, input::SourceRoot,
+    set_all_packages_with_durability,
 };
 use salsa::{Durability, Storage};
 use syntax::Edition;
@@ -112,5 +113,16 @@ impl SourceDatabase for TestDatabase {
             self.nonce,
             salsa::plumbing::ZalsaDatabase::zalsa(self).current_revision(),
         )
+    }
+}
+
+impl TestDatabase {
+    pub(crate) fn fetch_test_package(&self) -> Package {
+        let all_packages = all_packages(self);
+        all_packages
+            .iter()
+            .copied()
+            .find(|package| package.data(self).display_name.as_deref() == Some("ra_test_fixture"))
+            .unwrap_or(*all_packages.last().unwrap())
     }
 }

--- a/crates/hir_ty/src/database.rs
+++ b/crates/hir_ty/src/database.rs
@@ -99,7 +99,7 @@ fn field_types(
 
     let file_id = r#struct.lookup(database).file_id;
     let module_info = database.item_tree(file_id);
-    let resolver = Resolver::default().push_module_scope(file_id, module_info);
+    let resolver = Resolver::new(file_id, module_info);
 
     let mut type_context = TypeLoweringContext::new(database, &resolver, &data.store);
 
@@ -131,7 +131,7 @@ fn type_alias_type(
 
     let file_id = type_alias.lookup(database).file_id;
     let module_info = database.item_tree(file_id);
-    let resolver = Resolver::default().push_module_scope(file_id, module_info);
+    let resolver = Resolver::new(file_id, module_info);
 
     let mut type_context = TypeLoweringContext::new(database, &resolver, &data.store);
     let result = type_context.lower_type(data.r#type);
@@ -155,7 +155,7 @@ fn function_type(
 
     let file_id = function.lookup(database).file_id;
     let module_info = database.item_tree(file_id);
-    let resolver = Resolver::default().push_module_scope(file_id, module_info);
+    let resolver = Resolver::new(file_id, module_info);
 
     let mut type_context = TypeLoweringContext::new(database, &resolver, &data.store);
 

--- a/crates/hir_ty/src/test_db.rs
+++ b/crates/hir_ty/src/test_db.rs
@@ -160,7 +160,17 @@ impl TestDatabase {
                     let ingredient = self.ingredient_debug_name(database_key.ingredient_index());
                     Some(ingredient.to_string())
                 },
-                _ => None,
+                salsa::EventKind::DidValidateMemoizedValue { .. }
+                | salsa::EventKind::WillBlockOn { .. }
+                | salsa::EventKind::WillIterateCycle { .. }
+                | salsa::EventKind::WillCheckCancellation
+                | salsa::EventKind::DidSetCancellationFlag
+                | salsa::EventKind::WillDiscardStaleOutput { .. }
+                | salsa::EventKind::DidDiscard { .. }
+                | salsa::EventKind::DidDiscardAccumulated { .. }
+                | salsa::EventKind::DidInternValue { .. }
+                | salsa::EventKind::DidReuseInternedValue { .. }
+                | salsa::EventKind::DidValidateInternedValue { .. } => None,
             })
             .collect();
         (executed, events)

--- a/crates/hir_ty/src/test_db.rs
+++ b/crates/hir_ty/src/test_db.rs
@@ -5,7 +5,7 @@ use base_db::{
     SourceRootInput, change::Change, input::SourceRoot, set_all_packages_with_durability,
 };
 use hir_def::database::DefDatabase as _;
-use salsa::Durability;
+use salsa::{Database as _, Durability};
 use syntax::{Edition, ExtensionsConfig};
 use triomphe::Arc;
 use vfs::{AnchoredPath, FileId, VfsPath, file_set::FileSet};
@@ -139,26 +139,25 @@ impl SourceDatabase for TestDatabase {
 impl TestDatabase {
     pub(crate) fn log(
         &self,
-        f: impl FnOnce(),
+        callback: impl FnOnce(),
     ) -> Vec<salsa::Event> {
         *self.events.lock().unwrap() = Some(Vec::new());
-        f();
+        callback();
         self.events.lock().unwrap().take().unwrap()
     }
 
     pub(crate) fn log_executed(
         &self,
-        f: impl FnOnce(),
+        callback: impl FnOnce(),
     ) -> (Vec<String>, Vec<salsa::Event>) {
-        let events = self.log(f);
+        let events = self.log(callback);
         let executed = events
             .iter()
-            .filter_map(|e| match e.kind {
+            .filter_map(|event| match event.kind {
                 // This is pretty horrible, but `Debug` is the only way to inspect
                 // QueryDescriptor at the moment.
                 salsa::EventKind::WillExecute { database_key } => {
-                    let ingredient = (self as &dyn salsa::Database)
-                        .ingredient_debug_name(database_key.ingredient_index());
+                    let ingredient = self.ingredient_debug_name(database_key.ingredient_index());
                     Some(ingredient.to_string())
                 },
                 _ => None,

--- a/crates/hir_ty/src/test_db.rs
+++ b/crates/hir_ty/src/test_db.rs
@@ -1,4 +1,4 @@
-use std::{fmt, panic};
+use std::{fmt, panic, sync::Mutex};
 
 use base_db::{
     EditionedFileId, FileSourceRootInput, FileText, Nonce, SourceDatabase, SourceRootId,
@@ -11,17 +11,27 @@ use triomphe::Arc;
 use vfs::{AnchoredPath, FileId, VfsPath, file_set::FileSet};
 
 #[salsa_macros::db]
-#[derive(Clone)]
 pub(crate) struct TestDatabase {
     storage: salsa::Storage<Self>,
     files: Arc<base_db::Files>,
+    events: Arc<Mutex<Option<Vec<salsa::Event>>>>,
     nonce: Nonce,
 }
 impl Default for TestDatabase {
     fn default() -> Self {
+        let events = Arc::<Mutex<Option<Vec<salsa::Event>>>>::default();
         let mut value = Self {
-            storage: salsa::Storage::default(),
+            storage: salsa::Storage::new(Some(Box::new({
+                let events = events.clone();
+                move |event| {
+                    let mut events = events.lock().unwrap();
+                    if let Some(events) = &mut *events {
+                        events.push(event);
+                    }
+                }
+            }))),
             files: Arc::default(),
+            events,
             nonce: Nonce::new(),
         };
         value.set_extensions_with_durability(ExtensionsConfig::none(), Durability::MEDIUM);
@@ -31,12 +41,23 @@ impl Default for TestDatabase {
     }
 }
 
+impl Clone for TestDatabase {
+    fn clone(&self) -> Self {
+        Self {
+            storage: self.storage.clone(),
+            files: self.files.clone(),
+            events: self.events.clone(),
+            nonce: Nonce::new(),
+        }
+    }
+}
+
 impl fmt::Debug for TestDatabase {
     fn fmt(
         &self,
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
-        f.debug_struct("TestDB").finish()
+        f.debug_struct("TestDatabase").finish()
     }
 }
 
@@ -112,5 +133,37 @@ impl SourceDatabase for TestDatabase {
             self.nonce,
             salsa::plumbing::ZalsaDatabase::zalsa(self).current_revision(),
         )
+    }
+}
+
+impl TestDatabase {
+    pub(crate) fn log(
+        &self,
+        f: impl FnOnce(),
+    ) -> Vec<salsa::Event> {
+        *self.events.lock().unwrap() = Some(Vec::new());
+        f();
+        self.events.lock().unwrap().take().unwrap()
+    }
+
+    pub(crate) fn log_executed(
+        &self,
+        f: impl FnOnce(),
+    ) -> (Vec<String>, Vec<salsa::Event>) {
+        let events = self.log(f);
+        let executed = events
+            .iter()
+            .filter_map(|e| match e.kind {
+                // This is pretty horrible, but `Debug` is the only way to inspect
+                // QueryDescriptor at the moment.
+                salsa::EventKind::WillExecute { database_key } => {
+                    let ingredient = (self as &dyn salsa::Database)
+                        .ingredient_debug_name(database_key.ingredient_index());
+                    Some(ingredient.to_string())
+                },
+                _ => None,
+            })
+            .collect();
+        (executed, events)
     }
 }

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -1,6 +1,7 @@
 #![expect(clippy::use_debug, reason = "tests")]
 
 mod builtins;
+mod incremental;
 mod simple;
 use std::fmt::Write as _;
 
@@ -9,7 +10,9 @@ use expect_test::Expect;
 use hir_def::{
     HasSource as _,
     body::{Body, BodySourceMap},
-    database::{DefDatabase as _, DefinitionWithBodyId, InternDatabase as _, Location},
+    database::{
+        DefDatabase as _, DefinitionWithBodyId, InternDatabase as _, Location, ModuleDefinitionId,
+    },
     expression_store::SyntheticSyntax,
     item_tree::ModuleItemId,
 };
@@ -37,7 +40,7 @@ fn infer(
     let (mut database, file_id) = TestDatabase::with_single_file(wa_fixture);
     database.set_extensions_with_durability(extensions, Durability::MEDIUM);
     let file_id = EditionedFileId::new(&database, file_id.file_id, file_id.edition);
-    let root = database.parse_or_resolve(file_id).syntax();
+    let root = file_id.parse(&database).syntax();
     let mut buffer = String::new();
     let mut infer_def = |inference_result: Arc<InferenceResult>,
                          _body: Arc<Body>,
@@ -127,7 +130,10 @@ fn infer(
     let module_info = database.item_tree(file_id);
     let mut definitions = module_definitions(&database, file_id, &module_info);
     definitions.sort_by_key(|definition| text_size(*definition, &database));
-    for definition in definitions {
+    for definition in definitions
+        .into_iter()
+        .filter_map(ModuleDefinitionId::with_body)
+    {
         let (body, source_map) = database.body_with_source_map(definition);
         let infer = database.infer(definition);
         infer_def(infer, body, source_map);
@@ -137,39 +143,53 @@ fn infer(
 }
 
 fn text_size(
-    definition: DefinitionWithBodyId,
+    definition: ModuleDefinitionId,
     database: &TestDatabase,
 ) -> base_db::TextSize {
     match definition {
-        DefinitionWithBodyId::Function(item) => item
+        ModuleDefinitionId::Function(item) => item
             .lookup(database)
             .source(database)
             .value
             .syntax()
             .text_range()
             .start(),
-        DefinitionWithBodyId::GlobalConstant(item) => item
+        ModuleDefinitionId::GlobalConstant(item) => item
             .lookup(database)
             .source(database)
             .value
             .syntax()
             .text_range()
             .start(),
-        DefinitionWithBodyId::GlobalVariable(item) => item
+        ModuleDefinitionId::GlobalVariable(item) => item
             .lookup(database)
             .source(database)
             .value
             .syntax()
             .text_range()
             .start(),
-        DefinitionWithBodyId::Override(item) => item
+        ModuleDefinitionId::Override(item) => item
             .lookup(database)
             .source(database)
             .value
             .syntax()
             .text_range()
             .start(),
-        DefinitionWithBodyId::GlobalAssertStatement(item) => item
+        ModuleDefinitionId::GlobalAssertStatement(item) => item
+            .lookup(database)
+            .source(database)
+            .value
+            .syntax()
+            .text_range()
+            .start(),
+        ModuleDefinitionId::Struct(item) => item
+            .lookup(database)
+            .source(database)
+            .value
+            .syntax()
+            .text_range()
+            .start(),
+        ModuleDefinitionId::TypeAlias(item) => item
             .lookup(database)
             .source(database)
             .value
@@ -182,33 +202,37 @@ fn text_size(
 fn module_definitions(
     database: &TestDatabase,
     file_id: EditionedFileId,
-    item_tree: &Arc<hir_def::item_tree::ItemTree>,
-) -> Vec<DefinitionWithBodyId> {
+    item_tree: &hir_def::item_tree::ItemTree,
+) -> Vec<ModuleDefinitionId> {
     item_tree
         .top_level_items()
         .iter()
-        .filter_map(|item| {
+        .flat_map(|item| {
             Some(match item {
                 ModuleItemId::Function(id) => {
-                    DefinitionWithBodyId::Function(Location::new(file_id, *id).intern(database))
+                    ModuleDefinitionId::Function(Location::new(file_id, *id).intern(database))
                 },
-                ModuleItemId::GlobalVariable(id) => DefinitionWithBodyId::GlobalVariable(
-                    Location::new(file_id, *id).intern(database),
-                ),
-                ModuleItemId::GlobalConstant(id) => DefinitionWithBodyId::GlobalConstant(
-                    Location::new(file_id, *id).intern(database),
-                ),
+                ModuleItemId::GlobalVariable(id) => {
+                    ModuleDefinitionId::GlobalVariable(Location::new(file_id, *id).intern(database))
+                },
+                ModuleItemId::GlobalConstant(id) => {
+                    ModuleDefinitionId::GlobalConstant(Location::new(file_id, *id).intern(database))
+                },
                 ModuleItemId::Override(id) => {
-                    DefinitionWithBodyId::Override(Location::new(file_id, *id).intern(database))
+                    ModuleDefinitionId::Override(Location::new(file_id, *id).intern(database))
                 },
                 ModuleItemId::GlobalAssertStatement(id) => {
-                    DefinitionWithBodyId::GlobalAssertStatement(
+                    ModuleDefinitionId::GlobalAssertStatement(
                         Location::new(file_id, *id).intern(database),
                     )
                 },
-                ModuleItemId::TypeAlias(_)
-                | ModuleItemId::Struct(_)
-                | ModuleItemId::ImportStatement(_) => return None,
+                ModuleItemId::TypeAlias(id) => {
+                    ModuleDefinitionId::TypeAlias(Location::new(file_id, *id).intern(database))
+                },
+                ModuleItemId::Struct(id) => {
+                    ModuleDefinitionId::Struct(Location::new(file_id, *id).intern(database))
+                },
+                ModuleItemId::ImportStatement(id) => return None,
             })
         })
         .collect()

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -207,7 +207,7 @@ fn module_definitions(
     item_tree
         .top_level_items()
         .iter()
-        .flat_map(|item| {
+        .filter_map(|item| {
             Some(match item {
                 ModuleItemId::Function(id) => {
                     ModuleDefinitionId::Function(Location::new(file_id, *id).intern(database))

--- a/crates/hir_ty/src/tests/incremental.rs
+++ b/crates/hir_ty/src/tests/incremental.rs
@@ -82,9 +82,11 @@ fn foo() {
 }
 
 #[test]
-#[should_panic(
-    expected = "we need to improve our incrementality, see: https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1178"
+#[expect(
+    clippy::should_panic_without_expect,
+    reason = "we need to improve our incrementality, see: https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1178"
 )]
+#[should_panic]
 fn typing_inside_a_function_should_not_invalidate_types_in_another() {
     let (mut database, position) = TestDatabase::with_position(
         "

--- a/crates/hir_ty/src/tests/incremental.rs
+++ b/crates/hir_ty/src/tests/incremental.rs
@@ -1,10 +1,11 @@
-use base_db::{EditionedFileId, SourceDatabase};
+use base_db::{EditionedFileId, SourceDatabase as _};
 use expect_test::{Expect, expect};
-use hir_def::database::{DefDatabase, DefinitionWithBodyId, ModuleDefinitionId};
-use test_fixture::WithFixture;
+use hir_def::database::{DefDatabase as _, DefinitionWithBodyId, ModuleDefinitionId};
+use test_fixture::WithFixture as _;
 
 use crate::{
-    database::HirDatabase, infer::InferenceResult, test_db::TestDatabase, tests::module_definitions,
+    database::HirDatabase as _, infer::InferenceResult, test_db::TestDatabase,
+    tests::module_definitions,
 };
 
 #[test]
@@ -81,7 +82,9 @@ fn foo() {
 }
 
 #[test]
-#[should_panic] // TODO: This is a bug, the test should pass.
+#[should_panic(
+    expected = "we need to improve our incrementality, see: https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1178"
+)]
 fn typing_inside_a_function_should_not_invalidate_types_in_another() {
     let (mut database, position) = TestDatabase::with_position(
         "
@@ -184,20 +187,21 @@ fn baz() -> i32 {
 
 /// Executes a function and checks if the most important events happened exactly n times.
 /// Also checks the full list of events, which may change as the implementation changes.
+#[expect(clippy::needless_pass_by_value, reason = "matches expect! macro")]
 fn execute_assert_events(
     database: &TestDatabase,
-    f: impl FnOnce(),
+    callback: impl FnOnce(),
     required: &[(&str, usize)],
     expect: Expect,
 ) {
-    let (executed, events) = database.log_executed(f);
+    let (executed, events) = database.log_executed(callback);
     expect.assert_debug_eq(&executed);
     for (event, count) in required {
-        let n = executed.iter().filter(|it| it.contains(event)).count();
+        let actual_count = executed.iter().filter(|it| it.contains(event)).count();
         assert_eq!(
-            n,
+            actual_count,
             *count,
-            "Expected {event} to be executed {count} times, but only got {n}:\n \
+            "Expected {event} to be executed {count} times, but only got {actual_count}:\n \
              Executed: {executed:#?}\n \
              Event log: {events:#?}",
             events = events

--- a/crates/hir_ty/src/tests/incremental.rs
+++ b/crates/hir_ty/src/tests/incremental.rs
@@ -1,0 +1,210 @@
+use base_db::{EditionedFileId, SourceDatabase};
+use expect_test::{Expect, expect};
+use hir_def::database::{DefDatabase, DefinitionWithBodyId, ModuleDefinitionId};
+use test_fixture::WithFixture;
+
+use crate::{
+    database::HirDatabase, infer::InferenceResult, test_db::TestDatabase, tests::module_definitions,
+};
+
+#[test]
+fn typing_whitespace_inside_a_function_should_not_invalidate_types() {
+    let (mut database, position) = TestDatabase::with_position(
+        "
+//- /package.wesl
+fn foo() {
+    let a = $01 + 1;
+}
+    ",
+    );
+    let file_id = EditionedFileId::from_file(&database, position.file_id);
+    execute_assert_events(
+        &database,
+        || {
+            let module_info = database.item_tree(file_id);
+            let definitions = module_definitions(&database, file_id, &module_info);
+            for definition in definitions {
+                if let ModuleDefinitionId::Function(id) = definition {
+                    let inference_results = database.infer(DefinitionWithBodyId::Function(id));
+                    assert!(inference_results.diagnostics().is_empty());
+                }
+            }
+        },
+        &[("infer", 1)],
+        expect_test::expect![[r#"
+            [
+                "item_tree_shim",
+                "parse",
+                "ast_id_map_shim",
+                "infer_shim",
+                "body_shim",
+                "body_with_source_map_shim",
+                "function_data_shim",
+                "expression_scopes_shim",
+            ]
+        "#]],
+    );
+
+    let new_text = "
+fn foo() {
+    let a = 1 
+    + 
+    1;
+}";
+
+    database.set_file_text(position.file_id, new_text);
+
+    execute_assert_events(
+        &database,
+        || {
+            let module_info = database.item_tree(file_id);
+            let definitions = module_definitions(&database, file_id, &module_info);
+            for definition in definitions {
+                if let ModuleDefinitionId::Function(id) = definition {
+                    let inference_results = database.infer(DefinitionWithBodyId::Function(id));
+                    assert!(inference_results.diagnostics().is_empty());
+                }
+            }
+        },
+        &[("infer", 0)],
+        expect_test::expect![[r#"
+            [
+                "parse",
+                "item_tree_shim",
+                "ast_id_map_shim",
+                "body_with_source_map_shim",
+                "body_shim",
+                "function_data_shim",
+            ]
+        "#]],
+    );
+}
+
+#[test]
+#[should_panic] // TODO: This is a bug, the test should pass.
+fn typing_inside_a_function_should_not_invalidate_types_in_another() {
+    let (mut database, position) = TestDatabase::with_position(
+        "
+//- /package.wesl
+fn foo() -> f32 {
+    return 1.0 + 2.0;
+}
+fn bar() -> i32 {
+    return $01 + 1;
+}
+fn baz() -> i32 {
+    return 1 + 1;
+}",
+    );
+    let file_id = EditionedFileId::from_file(&database, position.file_id);
+    execute_assert_events(
+        &database,
+        || {
+            let module_info = database.item_tree(file_id);
+            let definitions = module_definitions(&database, file_id, &module_info);
+            for definition in definitions {
+                if let ModuleDefinitionId::Function(id) = definition {
+                    let inference_results = database.infer(DefinitionWithBodyId::Function(id));
+                    assert!(inference_results.diagnostics().is_empty());
+                }
+            }
+        },
+        &[("infer", 3)],
+        expect_test::expect![[r#"
+            [
+                "item_tree_shim",
+                "parse",
+                "ast_id_map_shim",
+                "infer_shim",
+                "body_shim",
+                "body_with_source_map_shim",
+                "function_data_shim",
+                "expression_scopes_shim",
+                "infer_shim",
+                "body_shim",
+                "body_with_source_map_shim",
+                "function_data_shim",
+                "expression_scopes_shim",
+                "infer_shim",
+                "body_shim",
+                "body_with_source_map_shim",
+                "function_data_shim",
+                "expression_scopes_shim",
+            ]
+        "#]],
+    );
+
+    let new_text = "
+fn foo() -> f32 {
+    return 1.0 + 2.0;
+}
+fn bar() -> i32 {
+    return 1 + 1;
+}
+fn baz() -> i32 {
+    return 1 + 1;
+}";
+
+    database.set_file_text(position.file_id, new_text);
+
+    execute_assert_events(
+        &database,
+        || {
+            let module_info = database.item_tree(file_id);
+            let definitions = module_definitions(&database, file_id, &module_info);
+            for definition in definitions {
+                if let ModuleDefinitionId::Function(id) = definition {
+                    let inference_results = database.infer(DefinitionWithBodyId::Function(id));
+                    assert!(inference_results.diagnostics().is_empty());
+                }
+            }
+        },
+        &[("infer", 0)],
+        expect_test::expect![[r#"
+            [
+                "parse",
+                "item_tree_shim",
+                "ast_id_map_shim",
+                "body_with_source_map_shim",
+                "body_shim",
+                "function_data_shim",
+                "infer_shim",
+                "body_with_source_map_shim",
+                "body_shim",
+                "function_data_shim",
+                "infer_shim",
+                "body_with_source_map_shim",
+                "body_shim",
+                "function_data_shim",
+                "infer_shim",
+            ]
+        "#]],
+    );
+}
+
+/// Executes a function and checks if the most important events happened exactly n times.
+/// Also checks the full list of events, which may change as the implementation changes.
+fn execute_assert_events(
+    database: &TestDatabase,
+    f: impl FnOnce(),
+    required: &[(&str, usize)],
+    expect: Expect,
+) {
+    let (executed, events) = database.log_executed(f);
+    expect.assert_debug_eq(&executed);
+    for (event, count) in required {
+        let n = executed.iter().filter(|it| it.contains(event)).count();
+        assert_eq!(
+            n,
+            *count,
+            "Expected {event} to be executed {count} times, but only got {n}:\n \
+             Executed: {executed:#?}\n \
+             Event log: {events:#?}",
+            events = events
+                .iter()
+                .filter(|event| !matches!(event.kind, salsa::EventKind::WillCheckCancellation))
+                .map(|event| { format!("{:?}", event.kind) })
+                .collect::<Vec<_>>(),
+        );
+    }
+}

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -250,7 +250,7 @@ pub fn diagnostics(
         .into_iter()
         .map(|diagnostic| {
             let file_id = diagnostic.file_id();
-            let root = database.parse_or_resolve(file_id).syntax();
+            let root = file_id.parse(database).syntax();
             match diagnostic {
                 AnyDiagnostic::AssignmentNotAReference { left_side, actual } => {
                     let source = left_side.value.to_node(&root);

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -15,6 +15,7 @@ mod navigation_target;
 pub mod signature_help;
 mod status;
 mod typing;
+mod view_module_graph;
 mod view_package_graph;
 mod view_syntax_tree;
 
@@ -309,6 +310,14 @@ impl Analysis {
         file_id: FileId,
     ) -> Cancellable<Parse> {
         self.with_db(|database| EditionedFileId::from_file(database, file_id).parse(database))
+    }
+
+    /// Renders the module graph to `GraphViz` "dot" syntax.
+    pub fn view_module_graph(
+        &self,
+        file_id: FileId,
+    ) -> Cancellable<String> {
+        self.with_db(|database| view_module_graph::view_module_graph(database, file_id))
     }
 
     /// Renders the package graph to `GraphViz` "dot" syntax.

--- a/crates/ide/src/status.rs
+++ b/crates/ide/src/status.rs
@@ -21,7 +21,6 @@ pub(crate) fn status(
 
     // format_to!(buf, "{}\n", collect_query(CompressedFileTextQuery.in_db(db)));
     // format_to!(buf, "{}\n", collect_query(ParseQuery.in_db(db)));
-    // format_to!(buf, "{}\n", collect_query(ParseMacroExpansionQuery.in_db(db)));
     // format_to!(buf, "{}\n", collect_query(LibrarySymbolsQuery.in_db(db)));
     // format_to!(buf, "{}\n", collect_query(ModuleSymbolsQuery.in_db(db)));
     // format_to!(buf, "{} in total\n", memory_usage());

--- a/crates/ide/src/status.rs
+++ b/crates/ide/src/status.rs
@@ -1,4 +1,4 @@
-use base_db::{ExtraPackageData, Package, input::PackageData};
+use base_db::{ExtraPackageData, Package, file_package, input::PackageData};
 use ide_db::RootDatabase;
 use itertools::Itertools as _;
 use stdx::format_to;
@@ -32,12 +32,10 @@ pub(crate) fn status(
     // format_to!(buf, "{} block def maps\n", collect_query_count(BlockDefMapQuery.in_db(db)));
 
     if let Some(file_id) = file_id {
-        format_to!(buffer, "\nCrates for file {}:\n", file_id.index());
-        let packages: Vec<Package> = Vec::new(); // TODO: populate this
-        if packages.is_empty() {
-            format_to!(buffer, "Does not belong to any package");
-        }
-        for package_id in packages {
+        format_to!(buffer, "\nPackage for file {}:\n", file_id.index());
+        let package: Option<Package> = file_package(database, file_id);
+
+        if let Some(package_id) = package {
             let PackageData {
                 root_file_id,
                 display_name,
@@ -74,6 +72,8 @@ pub(crate) fn status(
                 .map(|dep| format!("{}={:?}", dep.name, dep.package_id))
                 .format(", ");
             format_to!(buffer, "    Dependencies: {}\n", deps);
+        } else {
+            format_to!(buffer, "Does not belong to any package");
         }
     }
 

--- a/crates/ide/src/view_module_graph.rs
+++ b/crates/ide/src/view_module_graph.rs
@@ -4,6 +4,7 @@ use base_db::{EditionedFileId, file_package};
 use dot::{Id, LabelText};
 use hir_def::{
     FxIndexMap,
+    item_tree::Name,
     name_resolution::{ModuleData, modules_map_query},
 };
 use ide_db::RootDatabase;
@@ -30,10 +31,10 @@ pub(crate) fn view_module_graph(
         Cow::Borrowed(&modules_map_query(database, package).modules)
     } else {
         let mut modules_to_render = FxIndexMap::default();
-        modules_to_render.insert(
+        let file_name = modules_to_render.insert(
             file_id,
             ModuleData {
-                name: None,
+                name: Some(Name::from("[standalone file]")),
                 origin: EditionedFileId::from_file(database, file_id),
                 parent: None,
                 children: FxIndexMap::default(),
@@ -128,7 +129,7 @@ impl<'edge> dot::Labeller<'edge, FileId, Edge<'edge>> for DotModuleGraph<'_> {
         let name = self.modules_to_render[n]
             .name
             .as_ref()
-            .map_or("(unnamed module)", |name| name.as_str());
+            .map_or("package", |name| name.as_str());
         LabelText::LabelStr(name.into())
     }
 }

--- a/crates/ide/src/view_module_graph.rs
+++ b/crates/ide/src/view_module_graph.rs
@@ -29,21 +29,20 @@ pub(crate) fn view_module_graph(
 ) -> String {
     // TODO: This only renders the children. It should render an edge for each import and inline usage of another module.
     let package = file_package(database, file_id);
-    let modules_to_render = match package {
-        Some(package) => Cow::Borrowed(package_modules_map(database, package).modules(database)),
-        None => {
-            let mut modules_to_render = FxIndexMap::default();
-            modules_to_render.insert(
-                file_id,
-                ModuleData {
-                    name: None,
-                    origin: EditionedFileId::from_file(database, file_id),
-                    parent: None,
-                    children: FxIndexMap::default(),
-                },
-            );
-            Cow::Owned(modules_to_render)
-        },
+    let modules_to_render = if let Some(package) = package {
+        Cow::Borrowed(package_modules_map(database, package).modules(database))
+    } else {
+        let mut modules_to_render = FxIndexMap::default();
+        modules_to_render.insert(
+            file_id,
+            ModuleData {
+                name: None,
+                origin: EditionedFileId::from_file(database, file_id),
+                parent: None,
+                children: FxIndexMap::default(),
+            },
+        );
+        Cow::Owned(modules_to_render)
     };
 
     let graph = DotModuleGraph { modules_to_render };

--- a/crates/ide/src/view_module_graph.rs
+++ b/crates/ide/src/view_module_graph.rs
@@ -1,0 +1,126 @@
+use std::borrow::Cow;
+
+use base_db::{EditionedFileId, file_package};
+use dot::{Id, LabelText};
+use hir_def::{
+    FxIndexMap,
+    name_resolution::{ModuleData, package_modules_map},
+};
+use ide_db::{
+    FxHashMap, RootDatabase,
+    base_db::{SourceDatabase as _, salsa::plumbing::AsId},
+};
+use vfs::FileId;
+
+/// # Feature: View Module Graph
+///
+/// Renders the currently loaded module graph as an SVG graphic.
+/// Requires the `dot` tool, which is part of graphviz, to be installed.
+///
+/// Only renders a detailed graph for modules in the current package.
+/// Only workspace packages are included, no packages.io dependencies or sysroot packages.
+///
+/// | Editor  | Action Name |
+/// |---------|-------------|
+/// | VS Code | **wgsl-analyzer: View Module Graph** |
+pub(crate) fn view_module_graph(
+    database: &RootDatabase,
+    file_id: FileId,
+) -> String {
+    // TODO: This only renders the children. It should render an edge for each import and inline usage of another module.
+    let package = file_package(database, file_id);
+    let modules_to_render = match package {
+        Some(package) => Cow::Borrowed(package_modules_map(database, package).modules(database)),
+        None => {
+            let mut modules_to_render = FxIndexMap::default();
+            modules_to_render.insert(
+                file_id,
+                ModuleData {
+                    name: None,
+                    origin: EditionedFileId::from_file(database, file_id),
+                    parent: None,
+                    children: FxIndexMap::default(),
+                },
+            );
+            Cow::Owned(modules_to_render)
+        },
+    };
+
+    let graph = DotModuleGraph { modules_to_render };
+
+    let mut dot = Vec::new();
+    dot::render(&graph, &mut dot).unwrap();
+    String::from_utf8(dot).unwrap()
+}
+
+struct DotModuleGraph<'db> {
+    modules_to_render: Cow<'db, FxIndexMap<FileId, ModuleData>>,
+}
+
+type Edge<'edge> = (FileId, FileId);
+
+impl<'edge> dot::GraphWalk<'edge, FileId, Edge<'edge>> for DotModuleGraph<'_> {
+    fn nodes(&'edge self) -> dot::Nodes<'edge, FileId> {
+        self.modules_to_render.keys().copied().collect()
+    }
+
+    fn edges(&'edge self) -> dot::Edges<'edge, Edge<'edge>> {
+        self.modules_to_render
+            .iter()
+            .flat_map(|(package, module_data)| {
+                module_data
+                    .children
+                    .values()
+                    .copied()
+                    .filter(|dependency| self.modules_to_render.contains_key(dependency))
+                    .map(move |dependency| (*package, dependency))
+            })
+            .collect()
+    }
+
+    fn source(
+        &'edge self,
+        edge: &Edge<'edge>,
+    ) -> FileId {
+        edge.0
+    }
+
+    fn target(
+        &'edge self,
+        edge: &Edge<'edge>,
+    ) -> FileId {
+        edge.1
+    }
+}
+
+impl<'edge> dot::Labeller<'edge, FileId, Edge<'edge>> for DotModuleGraph<'_> {
+    fn graph_id(&'edge self) -> Id<'edge> {
+        Id::new("wgsl_analyzer_package_graph").unwrap()
+    }
+
+    fn node_id(
+        &'edge self,
+        n: &FileId,
+    ) -> Id<'edge> {
+        let id = n.index();
+        Id::new(format!("_{id:?}")).unwrap()
+    }
+
+    fn node_shape(
+        &'edge self,
+        _node: &FileId,
+    ) -> Option<LabelText<'edge>> {
+        Some(LabelText::LabelStr("box".into()))
+    }
+
+    fn node_label(
+        &'edge self,
+        n: &FileId,
+    ) -> LabelText<'edge> {
+        let name = self.modules_to_render[n]
+            .name
+            .as_ref()
+            .map_or("(unnamed module)", |name| name.as_str());
+        LabelText::LabelStr(name.into())
+    }
+}

--- a/crates/ide/src/view_module_graph.rs
+++ b/crates/ide/src/view_module_graph.rs
@@ -57,7 +57,19 @@ type Edge<'edge> = (FileId, FileId);
 
 impl<'edge> dot::GraphWalk<'edge, FileId, Edge<'edge>> for DotModuleGraph<'_> {
     fn nodes(&'edge self) -> dot::Nodes<'edge, FileId> {
-        self.modules_to_render.keys().copied().collect()
+        let modules: FxIndexMap<_, _> = self
+            .modules_to_render
+            .clone()
+            .into_owned()
+            .sorted_by(|file_a, module_a, file_b, module_b| {
+                if let Some(name) = &module_a.name {
+                    module_a.name.cmp(&module_b.name)
+                } else {
+                    file_a.cmp(file_b)
+                }
+            })
+            .collect();
+        modules.keys().copied().collect()
     }
 
     fn edges(&'edge self) -> dot::Edges<'edge, Edge<'edge>> {

--- a/crates/ide/src/view_module_graph.rs
+++ b/crates/ide/src/view_module_graph.rs
@@ -4,7 +4,7 @@ use base_db::{EditionedFileId, file_package};
 use dot::{Id, LabelText};
 use hir_def::{
     FxIndexMap,
-    name_resolution::{ModuleData, package_modules_map},
+    name_resolution::{ModuleData, modules_map_query},
 };
 use ide_db::{
     FxHashMap, RootDatabase,
@@ -30,7 +30,7 @@ pub(crate) fn view_module_graph(
     // TODO: This only renders the children. It should render an edge for each import and inline usage of another module.
     let package = file_package(database, file_id);
     let modules_to_render = if let Some(package) = package {
-        Cow::Borrowed(package_modules_map(database, package).modules(database))
+        Cow::Borrowed(&modules_map_query(database, package).modules)
     } else {
         let mut modules_to_render = FxIndexMap::default();
         modules_to_render.insert(

--- a/crates/ide/src/view_module_graph.rs
+++ b/crates/ide/src/view_module_graph.rs
@@ -6,10 +6,7 @@ use hir_def::{
     FxIndexMap,
     name_resolution::{ModuleData, modules_map_query},
 };
-use ide_db::{
-    FxHashMap, RootDatabase,
-    base_db::{SourceDatabase as _, salsa::plumbing::AsId},
-};
+use ide_db::RootDatabase;
 use vfs::FileId;
 
 /// # Feature: View Module Graph
@@ -94,7 +91,7 @@ impl<'edge> dot::GraphWalk<'edge, FileId, Edge<'edge>> for DotModuleGraph<'_> {
 
 impl<'edge> dot::Labeller<'edge, FileId, Edge<'edge>> for DotModuleGraph<'_> {
     fn graph_id(&'edge self) -> Id<'edge> {
-        Id::new("wgsl_analyzer_package_graph").unwrap()
+        Id::new("wgsl_analyzer_module_graph").unwrap()
     }
 
     fn node_id(

--- a/crates/ide/src/view_module_graph.rs
+++ b/crates/ide/src/view_module_graph.rs
@@ -31,7 +31,7 @@ pub(crate) fn view_module_graph(
         Cow::Borrowed(&modules_map_query(database, package).modules)
     } else {
         let mut modules_to_render = FxIndexMap::default();
-        let file_name = modules_to_render.insert(
+        modules_to_render.insert(
             file_id,
             ModuleData {
                 name: Some(Name::from("[standalone file]")),

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -46,7 +46,7 @@ impl<'database> CompletionContext<'database> {
             determine_location(&semantics, file.syntax(), position.offset, &token);
 
         let module_info = database.item_tree(file_id);
-        let mut resolver = Resolver::default().push_module_scope(file_id, module_info);
+        let mut resolver = Resolver::new(file_id, module_info);
 
         let nearest_scope = token
             .siblings_with_tokens(Direction::Prev) // spellchecker:disable-line

--- a/crates/project-model/src/lib.rs
+++ b/crates/project-model/src/lib.rs
@@ -78,10 +78,6 @@ impl ProjectManifest {
                 return Some(manifest);
             }
 
-            if !search_parents {
-                return None;
-            }
-
             let mut curr = Some(path);
             while let Some(path) = curr {
                 let candidate = path.join(target_file_name);
@@ -90,7 +86,11 @@ impl ProjectManifest {
                 {
                     return Some(manifest);
                 }
-                curr = path.parent();
+                if search_parents {
+                    curr = path.parent();
+                } else {
+                    return None;
+                }
             }
 
             None

--- a/crates/test-fixture/src/lib.rs
+++ b/crates/test-fixture/src/lib.rs
@@ -10,7 +10,6 @@ use base_db::{
     input::{Dependency, PackageData, PackageId, PackageName, PackageOrigin},
 };
 use edition::Edition;
-use rustc_hash::FxHashMap;
 use test_utils::{CURSOR_MARKER, ESCAPED_CURSOR_MARKER, RangeOrOffset, extract_range_or_offset};
 use triomphe::Arc;
 
@@ -185,6 +184,10 @@ impl ChangeFixture {
                 let previous = packages.insert(
                     PackageName::new("wa_test_fixture").unwrap(),
                     (package_id, default_package),
+                );
+                assert!(
+                    previous.is_none(),
+                    "multiple crates with same name: wa_test_fixture"
                 );
             }
             roots.last_mut().unwrap().0.insert(file_id, path);

--- a/crates/test-fixture/src/lib.rs
+++ b/crates/test-fixture/src/lib.rs
@@ -10,6 +10,7 @@ use base_db::{
     input::{Dependency, PackageData, PackageId, PackageName, PackageOrigin},
 };
 use edition::Edition;
+use rustc_hash::FxHashMap;
 use test_utils::{CURSOR_MARKER, ESCAPED_CURSOR_MARKER, RangeOrOffset, extract_range_or_offset};
 use triomphe::Arc;
 
@@ -110,7 +111,7 @@ impl ChangeFixture {
         let mut package_dependencies = Vec::new();
 
         let mut file_id = FileId::from_raw(0);
-        let mut roots: Vec<(FileSet, PackageData)> = Vec::new();
+        let mut roots: Vec<(FileSet, PackageOrigin)> = Vec::new();
 
         let mut file_position = None;
 
@@ -153,10 +154,10 @@ impl ChangeFixture {
                     dependencies: Vec::new(),
                     origin,
                 };
-                let package_id = PackageId::from_raw(u32::try_from(roots.len()).unwrap());
-                roots.push((FileSet::default(), package));
+                roots.push((FileSet::default(), origin));
 
-                let previous = packages.insert(crate_name.clone(), package_id);
+                let package_id = PackageId::from_raw(u32::try_from(packages.len()).unwrap());
+                let previous = packages.insert(crate_name.clone(), (package_id, package));
                 assert!(
                     previous.is_none(),
                     "multiple crates with same name: {crate_name}"
@@ -178,7 +179,13 @@ impl ChangeFixture {
                     dependencies: Vec::new(),
                     origin: PackageOrigin::Local,
                 };
-                roots.push((FileSet::default(), default_package));
+                roots.push((FileSet::default(), PackageOrigin::Local));
+
+                let package_id = PackageId::from_raw(u32::try_from(packages.len()).unwrap());
+                let previous = packages.insert(
+                    PackageName::new("wa_test_fixture").unwrap(),
+                    (package_id, default_package),
+                );
             }
             roots.last_mut().unwrap().0.insert(file_id, path);
             files.push(RawEditionedFileId {
@@ -189,21 +196,22 @@ impl ChangeFixture {
         }
 
         for (from, to) in package_dependencies {
-            let from_id = packages[&from];
-            let to_id = packages[&to];
-            roots[from_id.to_raw_usize()]
-                .1
-                .dependencies
-                .push(Dependency {
-                    name: to.clone(),
-                    package_id: to_id,
-                });
+            let (to_id, _) = packages[&to];
+            let (_, from_data) = &mut packages[&from];
+            from_data.dependencies.push(Dependency {
+                name: to.clone(),
+                package_id: to_id,
+            });
+        }
+
+        for (package_id, package_data) in packages.into_values() {
+            source_change.change_package(package_id, Some(package_data));
         }
 
         source_change.set_roots(
             roots
                 .into_iter()
-                .map(|(file_set, package)| match package.origin {
+                .map(|(file_set, origin)| match origin {
                     PackageOrigin::Local => SourceRoot::new_local(file_set),
                     PackageOrigin::Library | PackageOrigin::Language => {
                         SourceRoot::new_library(file_set)

--- a/crates/wgsl-analyzer/src/handlers/request.rs
+++ b/crates/wgsl-analyzer/src/handlers/request.rs
@@ -24,11 +24,23 @@ use crate::{
     global_state::GlobalStateSnapshot,
     lsp::{
         self,
-        extensions::{self, PositionOrRange, ViewPackageGraphParameters},
+        extensions::{
+            self, PositionOrRange, ViewModuleGraphParameters, ViewPackageGraphParameters,
+        },
         from_proto, to_proto,
     },
     try_default,
 };
+
+pub(crate) fn handle_view_module_graph(
+    snap: GlobalStateSnapshot,
+    parameters: ViewModuleGraphParameters,
+) -> anyhow::Result<String> {
+    let _p = tracing::info_span!("handle_view_module_graph").entered();
+    let file_id = try_default!(from_proto::file_id(&snap, &parameters.text_document.uri)?);
+    let dot = snap.analysis.view_module_graph(file_id)?;
+    Ok(dot)
+}
 
 pub(crate) fn handle_view_package_graph(
     snap: GlobalStateSnapshot,

--- a/crates/wgsl-analyzer/src/lsp/extensions.rs
+++ b/crates/wgsl-analyzer/src/lsp/extensions.rs
@@ -168,6 +168,22 @@ pub struct ViewPackageGraphParameters {
     pub full: bool,
 }
 
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ViewModuleGraphParameters {
+    pub text_document: TextDocumentIdentifier,
+}
+
+pub enum ViewModuleGraphRequest {}
+
+impl Request for ViewModuleGraphRequest {
+    type Params = ViewModuleGraphParameters;
+    type Result = String;
+
+    const MESSAGE_DIRECTION: MessageDirection = MessageDirection::ClientToServer;
+    const METHOD: LspRequestMethod = LspRequestMethod::new("wgsl-analyzer/viewModuleGraph");
+}
+
 pub enum ViewPackageGraphRequest {}
 
 impl Request for ViewPackageGraphRequest {

--- a/crates/wgsl-analyzer/src/main_loop.rs
+++ b/crates/wgsl-analyzer/src/main_loop.rs
@@ -983,6 +983,9 @@ impl GlobalState {
             .on::<RETRY, lsp::extensions::AnalyzerStatusRequest>(
                 handlers::request::handle_analyzer_status,
             )
+            .on::<RETRY, lsp::extensions::ViewModuleGraphRequest>(
+                handlers::request::handle_view_module_graph,
+            )
             .on::<RETRY, lsp::extensions::ViewPackageGraphRequest>(
                 handlers::request::handle_view_package_graph,
             )

--- a/docs/book/src/contributing/architecture.md
+++ b/docs/book/src/contributing/architecture.md
@@ -175,7 +175,7 @@ These crates also define various intermediate representations of the core.
 
 `ItemTree` condenses a single `SyntaxTree` into a "summary" data structure, which is stable over modifications to function bodies.
 
-`ModuleMap` contains the module tree of a package and stores module scopes.
+`ModuleMap` contains the module tree of a package. `ModuleData` incrementally keeps track of the children of a given module.
 
 `Body` stores information about expressions.
 

--- a/docs/book/src/contributing/architecture.md
+++ b/docs/book/src/contributing/architecture.md
@@ -175,7 +175,7 @@ These crates also define various intermediate representations of the core.
 
 `ItemTree` condenses a single `SyntaxTree` into a "summary" data structure, which is stable over modifications to function bodies.
 
-`DefMap` contains the module tree of a crate and stores module scopes.
+`ModuleMap` contains the module tree of a package and stores module scopes.
 
 `Body` stores information about expressions.
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -113,6 +113,11 @@
 				"category": "wgsl-analyzer (debug command)"
 			},
 			{
+				"command": "wgsl-analyzer.viewModuleGraph",
+				"title": "View Module Graph",
+				"category": "wgsl-analyzer"
+			},
+			{
 				"command": "wgsl-analyzer.viewPackageGraph",
 				"title": "View Package Graph",
 				"category": "wgsl-analyzer"

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -74,7 +74,7 @@ export function createClient(
 							const parent = uri.fsPath.substring(0, parentBackslash);
 
 							if (parent.startsWith(folder)) {
-								const path = vscode.Uri.file(parent + pathSeparator + "Cargo.toml");
+								const path = vscode.Uri.file(parent + pathSeparator + "wesl.toml");
 								void vscode.workspace.fs.stat(path).then(async () => {
 									const choice = await vscode.window.showInformationMessage(
 										`This file does not belong to a loaded project. It looks like it might belong to the workspace at ${path.path}, do you want to add it to the linked projects?`,
@@ -89,7 +89,7 @@ export function createClient(
 											break;
 										case "Yes": {
 											const pathToInsert =
-												"." + parent.substring(folder.length) + pathSeparator + "Cargo.toml";
+												"." + parent.substring(folder.length) + pathSeparator + "wesl.toml";
 											const value = config
 												// biome-ignore lint/suspicious/noExplicitAny: Signature comes from upstream
 												.get<any[]>("linkedProjects")

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -11,7 +11,14 @@ import {
 	type SnippetTextDocumentEdit,
 } from "./snippets";
 import type { SyntaxElement } from "./syntax_tree_provider";
-import { isWeslDocument, isWeslEditor, isWeslTomlDocument, log, sleep, unwrapUndefinable } from "./utilities";
+import {
+	isWeslDocument,
+	isWeslEditor,
+	isWeslTomlDocument,
+	log,
+	sleep,
+	unwrapUndefinable,
+} from "./utilities";
 
 export function analyzerStatus(context: InitializedContext): Cmd {
 	const tdcp = new (class implements vscode.TextDocumentContentProvider {

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -11,7 +11,7 @@ import {
 	type SnippetTextDocumentEdit,
 } from "./snippets";
 import type { SyntaxElement } from "./syntax_tree_provider";
-import { isWeslDocument, isWeslEditor, log, sleep, unwrapUndefinable } from "./utilities";
+import { isWeslDocument, isWeslEditor, isWeslTomlDocument, log, sleep, unwrapUndefinable } from "./utilities";
 
 export function analyzerStatus(context: InitializedContext): Cmd {
 	const tdcp = new (class implements vscode.TextDocumentContentProvider {
@@ -495,10 +495,9 @@ function packageGraph(context: InitializedContext, full: boolean): Cmd {
 
 function moduleGraph(context: InitializedContext): Cmd {
 	return async () => {
-		const weslEditor = context.activeWeslEditor;
-		if (!weslEditor) {
-			return;
-		}
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) return;
+		if (!(isWeslDocument(editor.document) || isWeslTomlDocument(editor.document))) return;
 
 		const nodeModulesPath = vscode.Uri.file(path.join(context.extensionPath, "node_modules"));
 
@@ -514,7 +513,7 @@ function moduleGraph(context: InitializedContext): Cmd {
 		);
 		const client = context.client;
 		const parameters = {
-			textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(weslEditor.document),
+			textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(editor.document),
 		};
 		const dot = await client.sendRequest(wa.viewModuleGraph, parameters);
 		const uri = panel.webview.asWebviewUri(nodeModulesPath);

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -489,7 +489,40 @@ function packageGraph(context: InitializedContext, full: boolean): Cmd {
 		const dot = await client.sendRequest(wa.viewPackageGraph, parameters);
 		const uri = panel.webview.asWebviewUri(nodeModulesPath);
 
-		const html = `
+		panel.webview.html = renderGraph(dot, uri);
+	};
+}
+
+function moduleGraph(context: InitializedContext): Cmd {
+	return async () => {
+		const weslEditor = context.activeWeslEditor;
+		if (!weslEditor) {
+			return;
+		}
+
+		const nodeModulesPath = vscode.Uri.file(path.join(context.extensionPath, "node_modules"));
+
+		const panel = vscode.window.createWebviewPanel(
+			"wgsl-analyzer.module-graph",
+			"wgsl-analyzer module graph",
+			vscode.ViewColumn.Two,
+			{
+				enableScripts: true,
+				retainContextWhenHidden: true,
+				localResourceRoots: [nodeModulesPath],
+			},
+		);
+		const client = context.client;
+		const parameters = { textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(weslEditor.document) };
+		const dot = await client.sendRequest(wa.viewModuleGraph, parameters);
+		const uri = panel.webview.asWebviewUri(nodeModulesPath);
+
+		panel.webview.html = renderGraph(dot, uri);
+	};
+}
+
+function renderGraph(dot: string, nodeModulesUri: vscode.Uri) {
+	return `
             <!DOCTYPE html>
             <meta charset="utf-8">
             <head>
@@ -507,9 +540,9 @@ function packageGraph(context: InitializedContext, full: boolean): Cmd {
                 </style>
             </head>
             <body>
-                <script type="text/javascript" src="${uri}/d3/dist/d3.min.js"></script>
-                <script type="text/javascript" src="${uri}/@hpcc-js/wasm/dist/graphviz.umd.js"></script>
-                <script type="text/javascript" src="${uri}/d3-graphviz/build/d3-graphviz.min.js"></script>
+                <script type="text/javascript" src="${nodeModulesUri}/d3/dist/d3.min.js"></script>
+                <script type="text/javascript" src="${nodeModulesUri}/@hpcc-js/wasm/dist/graphviz.umd.js"></script>
+                <script type="text/javascript" src="${nodeModulesUri}/d3-graphviz/build/d3-graphviz.min.js"></script>
                 <div id="graph"></div>
                 <script>
                     let dot = \`${dot}\`;
@@ -531,9 +564,10 @@ function packageGraph(context: InitializedContext, full: boolean): Cmd {
                 </script>
             </body>
             `;
+}
 
-		panel.webview.html = html;
-	};
+export function viewModuleGraph(context: InitializedContext): Cmd {
+	return moduleGraph(context);
 }
 
 export function viewPackageGraph(context: InitializedContext): Cmd {

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -513,7 +513,9 @@ function moduleGraph(context: InitializedContext): Cmd {
 			},
 		);
 		const client = context.client;
-		const parameters = { textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(weslEditor.document) };
+		const parameters = {
+			textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(weslEditor.document),
+		};
 		const dot = await client.sendRequest(wa.viewModuleGraph, parameters);
 		const uri = panel.webview.asWebviewUri(nodeModulesPath);
 

--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -358,7 +358,7 @@ export class Context implements WgslAnalyzerExtensionApi {
 		return editor && isWeslEditor(editor) ? editor : undefined;
 	}
 
-	get activeWeslTomlEditor(): WeslEditor | undefined {
+	get activeWeslTomlEditor(): vscode.TextEditor | undefined {
 		const editor = vscode.window.activeTextEditor;
 		return editor && isWeslTomlEditor(editor) ? editor : undefined;
 	}

--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -10,7 +10,14 @@ import * as wa from "./lsp_ext";
 import type { WgslAnalyzerExtensionApi } from "./main";
 import { PersistentState } from "./persistent_state";
 import { type SyntaxElement, SyntaxTreeProvider } from "./syntax_tree_provider";
-import { isWeslDocument, isWeslEditor, isWeslTomlEditor, LazyOutputChannel, log, type WeslEditor } from "./utilities";
+import {
+	isWeslDocument,
+	isWeslEditor,
+	isWeslTomlEditor,
+	LazyOutputChannel,
+	log,
+	type WeslEditor,
+} from "./utilities";
 
 // We only support local folders, not eg. Live Share (`vlsl:` scheme), so do not activate if
 // only those are in use. We use "Empty" to represent these scenarios.

--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -10,7 +10,7 @@ import * as wa from "./lsp_ext";
 import type { WgslAnalyzerExtensionApi } from "./main";
 import { PersistentState } from "./persistent_state";
 import { type SyntaxElement, SyntaxTreeProvider } from "./syntax_tree_provider";
-import { isWeslDocument, isWeslEditor, LazyOutputChannel, log, type WeslEditor } from "./utilities";
+import { isWeslDocument, isWeslEditor, isWeslTomlEditor, LazyOutputChannel, log, type WeslEditor } from "./utilities";
 
 // We only support local folders, not eg. Live Share (`vlsl:` scheme), so do not activate if
 // only those are in use. We use "Empty" to represent these scenarios.
@@ -349,6 +349,11 @@ export class Context implements WgslAnalyzerExtensionApi {
 	get activeWeslEditor(): WeslEditor | undefined {
 		const editor = vscode.window.activeTextEditor;
 		return editor && isWeslEditor(editor) ? editor : undefined;
+	}
+
+	get activeWeslTomlEditor(): WeslEditor | undefined {
+		const editor = vscode.window.activeTextEditor;
+		return editor && isWeslTomlEditor(editor) ? editor : undefined;
 	}
 
 	get extensionPath(): string {

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -46,6 +46,9 @@ export const runFlycheck = new lc.NotificationType<{
 export const viewSyntaxTree = new lc.RequestType<ViewSyntaxTreeParameters, string, void>(
 	"wgsl-analyzer/viewSyntaxTree",
 );
+export const viewModuleGraph = new lc.RequestType<ViewModuleGraphParameters, string, void>(
+	"wgsl-analyzer/viewModuleGraph",
+);
 export const viewPackageGraph = new lc.RequestType<ViewPackageGraphParameters, string, void>(
 	"wgsl-analyzer/viewPackageGraph",
 );
@@ -122,6 +125,21 @@ export const fetchDependencyList = new lc.RequestType<
 	void
 >("wgsl-analyzer/fetchDependencyList");
 
+export interface FetchModuleGraphParameters {}
+
+export interface FetchModuleGraphResult {
+	modules: {
+		name: string;
+		path: string;
+	}[];
+}
+
+export const fetchModuleGraph = new lc.RequestType<
+	FetchModuleGraphParameters,
+	FetchModuleGraphResult,
+	void
+>("wgsl-analyzer/fetchModuleGraph");
+
 export interface FetchPackageGraphParameters {}
 
 export interface FetchPackageGraphResult {
@@ -143,6 +161,9 @@ export type SyntaxTreeParameters = {
 	range: lc.Range | null;
 };
 export type ViewSyntaxTreeParameters = {
+	textDocument: lc.TextDocumentIdentifier;
+};
+export type ViewModuleGraphParameters = {
 	textDocument: lc.TextDocumentIdentifier;
 };
 export type ViewPackageGraphParameters = { full: boolean };

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -155,6 +155,7 @@ function createCommands(): Record<string, CommandFactory> {
 		joinLines: { enabled: commands.joinLines },
 		viewFileText: { enabled: commands.viewFileText },
 		viewItemTree: { enabled: commands.viewItemTree },
+		viewModuleGraph: { enabled: commands.viewModuleGraph },
 		viewPackageGraph: { enabled: commands.viewPackageGraph },
 		viewFullPackageGraph: { enabled: commands.viewFullPackageGraph },
 		openDocs: { enabled: commands.openDocs },

--- a/editors/code/src/utilities.ts
+++ b/editors/code/src/utilities.ts
@@ -88,6 +88,15 @@ export function isWeslEditor(editor: vscode.TextEditor): editor is WeslEditor {
 	return isWeslDocument(editor.document);
 }
 
+export function isWeslTomlDocument(document: vscode.TextDocument): document is WeslDocument {
+	// ideally `document.languageId` should be 'toml' but user might not have a toml extension installed
+	return document.uri.scheme === "file" && document.fileName.endsWith("wesl.toml");
+}
+
+export function isWeslTomlEditor(editor: vscode.TextEditor): editor is WeslEditor {
+	return isWeslTomlDocument(editor.document);
+}
+
 export function isDocumentInWorkspace(document: WeslDocument): boolean {
 	const workspaceFolders = vscode.workspace.workspaceFolders;
 	if (!workspaceFolders) {

--- a/editors/code/src/utilities.ts
+++ b/editors/code/src/utilities.ts
@@ -88,12 +88,12 @@ export function isWeslEditor(editor: vscode.TextEditor): editor is WeslEditor {
 	return isWeslDocument(editor.document);
 }
 
-export function isWeslTomlDocument(document: vscode.TextDocument): document is WeslDocument {
+export function isWeslTomlDocument(document: vscode.TextDocument): boolean {
 	// ideally `document.languageId` should be 'toml' but user might not have a toml extension installed
-	return document.uri.scheme === "file" && document.fileName.endsWith("wesl.toml");
+	return document.uri.scheme === "file" && document.uri.path.endsWith("/wesl.toml");
 }
 
-export function isWeslTomlEditor(editor: vscode.TextEditor): editor is WeslEditor {
+export function isWeslTomlEditor(editor: vscode.TextEditor): boolean {
 	return isWeslTomlDocument(editor.document);
 }
 


### PR DESCRIPTION
# Objective

Working towards #632 . This adds a (somewhat incremental) module graph to `hir_def`.

## Solution

- Adds a "get package for a file". Unlike in Rust, there is at most one package for a given file.
- Adds a modules map. The r-a equivalent looks very similar https://github.com/rust-lang/rust-analyzer/blob/06aba0c8d642a9c637079f19bb5e2ae88f3ec035/crates/hir-def/src/nameres.rs#L872-L874 . The big difference is that we aren't building a whole `DefMap` around it. 
- The new "view module graph" command is a variation of "view package graph". For now it only shows the trivial tree. Later it should do this https://github.com/rust-lang/rust-analyzer/issues/15547

## Testing

One smoke test was added for the modules. 

Two tests for incrementality were added, although one of them currently fails.

Further testing is very possible, but I suspect that it's not too useful until we've got import statements.


## Showcase

Here's lygia's module graph 🥳 

<img width="1045" height="736" alt="module-graph" src="https://github.com/user-attachments/assets/65528adf-b6c3-4f25-b67d-141bbc10f855" />

