### PR TITLE
Simplify item tree by replacing ModuleItemId with FileAstId

### DIFF
--- a/crates/hir/src/definition.rs
+++ b/crates/hir/src/definition.rs
@@ -71,13 +71,14 @@ fn resolve_path(
     } else if let Some(r#type) = ast::TypeSpecifier::cast(parent) {
         let resolver = semantics.resolver(file_id, r#type.syntax());
 
-        match resolver.resolve(&Path(ModPath::from_src(&r#type.path()?)))? {
-            ResolveKind::Struct(location) => {
-                let id = semantics.database.intern_struct(location);
+        match resolver.resolve(
+            &Path(ModPath::from_src(&r#type.path()?)),
+            semantics.database,
+        )? {
+            ResolveKind::Struct(id) => {
                 Some(Definition::ModuleDef(ModuleDef::Struct(Struct { id })))
             },
-            ResolveKind::TypeAlias(location) => {
-                let id = semantics.database.intern_type_alias(location);
+            ResolveKind::TypeAlias(id) => {
                 Some(Definition::ModuleDef(ModuleDef::TypeAlias(TypeAlias {
                     id,
                 })))

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -4,7 +4,7 @@ pub mod database;
 pub mod definition;
 pub mod diagnostics;
 
-use base_db::{EditionedFileId, FileId, Lookup as _};
+use base_db::{EditionedFileId, FileId, Intern as _, Lookup as _};
 use definition::Definition;
 use diagnostics::{AnyDiagnostic, DiagnosticsConfig};
 use either::Either;
@@ -17,7 +17,7 @@ use hir_def::{
     },
     expression::{ExpressionId, StatementId},
     expression_store::{ExpressionStoreSource, path::Path},
-    item_tree::{self, ItemTree, ModuleItem, Name},
+    item_tree::{self, ItemTree, ModuleItemId, Name},
     resolver::{ResolveKind, Resolver},
     signature::{FieldId, ParameterId},
 };
@@ -189,35 +189,27 @@ impl<'database> Semantics<'database> {
             resolver = resolver.push_expression_scope(function, expression_scopes, scope_id);
         }
 
-        let value = resolver.resolve(path)?;
+        let value = resolver.resolve(path, self.database)?;
 
         let definition = match value {
             ResolveKind::Local(binding) => Definition::Local(Local {
                 parent: resolver.body_owner()?,
                 binding,
             }),
-            ResolveKind::GlobalVariable(location) => {
-                let id = self.database.intern_global_variable(location);
+            ResolveKind::GlobalVariable(id) => {
                 Definition::ModuleDef(ModuleDef::GlobalVariable(GlobalVariable { id }))
             },
-            ResolveKind::GlobalConstant(location) => {
-                let id = self.database.intern_global_constant(location);
+            ResolveKind::GlobalConstant(id) => {
                 Definition::ModuleDef(ModuleDef::GlobalConstant(GlobalConstant { id }))
             },
-            ResolveKind::Override(location) => {
-                let id = self.database.intern_override(location);
+            ResolveKind::Override(id) => {
                 Definition::ModuleDef(ModuleDef::Override(Override { id }))
             },
-            ResolveKind::Struct(location) => {
-                let id = self.database.intern_struct(location);
-                Definition::ModuleDef(ModuleDef::Struct(Struct { id }))
-            },
-            ResolveKind::TypeAlias(location) => {
-                let id = self.database.intern_type_alias(location);
+            ResolveKind::Struct(id) => Definition::ModuleDef(ModuleDef::Struct(Struct { id })),
+            ResolveKind::TypeAlias(id) => {
                 Definition::ModuleDef(ModuleDef::TypeAlias(TypeAlias { id }))
             },
-            ResolveKind::Function(location) => {
-                let id = self.database.intern_function(location);
+            ResolveKind::Function(id) => {
                 Definition::ModuleDef(ModuleDef::Function(Function { id }))
             },
         };
@@ -229,88 +221,72 @@ impl<'database> Semantics<'database> {
         &self,
         source: &InFile<ast::ImportStatement>,
     ) -> Option<ImportId> {
-        let import = item_tree::find_item(self.database, source.file_id, &source.value)?;
-        let import_id = self
-            .database
-            .intern_import(Location::new(source.file_id, import));
-        Some(import_id)
+        let ast_id_map = self.database.ast_id_map(source.file_id);
+        let id = ast_id_map.try_ast_id(&source.value)?;
+        Some(Location::new(source.file_id, id).intern(self.database))
     }
 
     fn function_to_def(
         &self,
         source: &InFile<ast::FunctionDeclaration>,
     ) -> Option<FunctionId> {
-        let function = item_tree::find_item(self.database, source.file_id, &source.value)?;
-        let function_id = self
-            .database
-            .intern_function(Location::new(source.file_id, function));
-        Some(function_id)
+        let ast_id_map = self.database.ast_id_map(source.file_id);
+        let id = ast_id_map.try_ast_id(&source.value)?;
+        Some(Location::new(source.file_id, id).intern(self.database))
     }
 
     fn global_constant_to_def(
         &self,
         source: &InFile<ast::ConstantDeclaration>,
     ) -> Option<GlobalConstantId> {
-        let global_constant = item_tree::find_item(self.database, source.file_id, &source.value)?;
-        let id = self
-            .database
-            .intern_global_constant(Location::new(source.file_id, global_constant));
-        Some(id)
+        let ast_id_map = self.database.ast_id_map(source.file_id);
+        let id = ast_id_map.try_ast_id(&source.value)?;
+        Some(Location::new(source.file_id, id).intern(self.database))
     }
 
     fn global_variable_to_def(
         &self,
         source: &InFile<ast::VariableDeclaration>,
     ) -> Option<GlobalVariableId> {
-        let global_variable = item_tree::find_item(self.database, source.file_id, &source.value)?;
-        let id = self
-            .database
-            .intern_global_variable(Location::new(source.file_id, global_variable));
-        Some(id)
+        let ast_id_map = self.database.ast_id_map(source.file_id);
+        let id = ast_id_map.try_ast_id(&source.value)?;
+        Some(Location::new(source.file_id, id).intern(self.database))
     }
 
     fn global_override_to_def(
         &self,
         source: &InFile<ast::OverrideDeclaration>,
     ) -> Option<OverrideId> {
-        let item = item_tree::find_item(self.database, source.file_id, &source.value)?;
-        let id = self
-            .database
-            .intern_override(Location::new(source.file_id, item));
-        Some(id)
+        let ast_id_map = self.database.ast_id_map(source.file_id);
+        let id = ast_id_map.try_ast_id(&source.value)?;
+        Some(Location::new(source.file_id, id).intern(self.database))
     }
 
     fn global_type_alias_to_def(
         &self,
         source: &InFile<ast::TypeAliasDeclaration>,
     ) -> Option<TypeAliasId> {
-        let item = item_tree::find_item(self.database, source.file_id, &source.value)?;
-        let id = self
-            .database
-            .intern_type_alias(Location::new(source.file_id, item));
-        Some(id)
+        let ast_id_map = self.database.ast_id_map(source.file_id);
+        let id = ast_id_map.try_ast_id(&source.value)?;
+        Some(Location::new(source.file_id, id).intern(self.database))
     }
 
     fn global_struct_to_def(
         &self,
         source: &InFile<ast::StructDeclaration>,
     ) -> Option<StructId> {
-        let item = item_tree::find_item(self.database, source.file_id, &source.value)?;
-        let id = self
-            .database
-            .intern_struct(Location::new(source.file_id, item));
-        Some(id)
+        let ast_id_map = self.database.ast_id_map(source.file_id);
+        let id = ast_id_map.try_ast_id(&source.value)?;
+        Some(Location::new(source.file_id, id).intern(self.database))
     }
 
     fn global_assert_statement_to_def(
         &self,
         source: &InFile<ast::AssertStatement>,
     ) -> Option<GlobalAssertStatementId> {
-        let item = item_tree::find_item(self.database, source.file_id, &source.value)?;
-        let id = self
-            .database
-            .intern_global_assert_statement(Location::new(source.file_id, item));
-        Some(id)
+        let ast_id_map = self.database.ast_id_map(source.file_id);
+        let id = ast_id_map.try_ast_id(&source.value)?;
+        Some(Location::new(source.file_id, id).intern(self.database))
     }
 }
 
@@ -443,45 +419,45 @@ impl ChildContainer {
 fn module_item_to_def(
     database: &dyn HirDatabase,
     file_id: EditionedFileId,
-    module_item: ModuleItem,
+    module_item: ModuleItemId,
 ) -> SmallVec<[ModuleDef; 1]> {
     let definition = match module_item {
-        ModuleItem::Function(function) => {
+        ModuleItemId::Function(function) => {
             let location = Location::new(file_id, function);
             let id = database.intern_function(location);
             ModuleDef::Function(Function { id })
         },
-        ModuleItem::Struct(r#struct) => {
+        ModuleItemId::Struct(r#struct) => {
             let location = Location::new(file_id, r#struct);
             let id = database.intern_struct(location);
             ModuleDef::Struct(Struct { id })
         },
-        ModuleItem::GlobalVariable(variable) => {
+        ModuleItemId::GlobalVariable(variable) => {
             let location = Location::new(file_id, variable);
             let id = database.intern_global_variable(location);
             ModuleDef::GlobalVariable(GlobalVariable { id })
         },
-        ModuleItem::GlobalConstant(constant) => {
+        ModuleItemId::GlobalConstant(constant) => {
             let location = Location::new(file_id, constant);
             let id = database.intern_global_constant(location);
             ModuleDef::GlobalConstant(GlobalConstant { id })
         },
-        ModuleItem::Override(constant) => {
+        ModuleItemId::Override(constant) => {
             let location = Location::new(file_id, constant);
             let id = database.intern_override(location);
             ModuleDef::Override(Override { id })
         },
-        ModuleItem::TypeAlias(type_alias) => {
+        ModuleItemId::TypeAlias(type_alias) => {
             let location = Location::new(file_id, type_alias);
             let id = database.intern_type_alias(location);
             ModuleDef::TypeAlias(TypeAlias { id })
         },
-        ModuleItem::GlobalAssertStatement(global_assert_statement) => {
+        ModuleItemId::GlobalAssertStatement(global_assert_statement) => {
             let location = Location::new(file_id, global_assert_statement);
             let id = database.intern_global_assert_statement(location);
             ModuleDef::GlobalAssertStatement(GlobalAssertStatement { id })
         },
-        ModuleItem::ImportStatement(_) => return smallvec::SmallVec::new(),
+        ModuleItemId::ImportStatement(_) => return smallvec::SmallVec::new(),
     };
     smallvec::smallvec![definition]
 }
@@ -842,7 +818,7 @@ impl Module {
     ) -> Vec<ModuleDef> {
         let item_tree = database.item_tree(self.file_id);
         item_tree
-            .items()
+            .top_level_items()
             .iter()
             .flat_map(|item| module_item_to_def(database, self.file_id, *item))
             .collect()
@@ -948,9 +924,9 @@ fn validate_identifiers(
             $accumulator:expr,
             $file_id:expr
         ) => {{
-            let data = $item_tree.get(*$id);
+            let data = &$item_tree[*$id];
             if data.name.as_str().starts_with("__") {
-                let ast_ptr = $ast_id_map.get(data.ast_id);
+                let ast_ptr = $ast_id_map.get(*$id);
                 let node = ast_ptr.to_node(&$root);
                 if let Some(name_node) = node.name() {
                     $accumulator.push(AnyDiagnostic::InvalidIdentifier {
@@ -963,27 +939,27 @@ fn validate_identifiers(
         }};
     }
 
-    for item in item_tree.items() {
+    for item in item_tree.top_level_items() {
         match item {
-            ModuleItem::Function(id) => {
+            ModuleItemId::Function(id) => {
                 validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
             },
-            ModuleItem::GlobalVariable(id) => {
+            ModuleItemId::GlobalVariable(id) => {
                 validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
             },
-            ModuleItem::GlobalConstant(id) => {
+            ModuleItemId::GlobalConstant(id) => {
                 validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
             },
-            ModuleItem::Override(id) => {
+            ModuleItemId::Override(id) => {
                 validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
             },
-            ModuleItem::Struct(id) => {
+            ModuleItemId::Struct(id) => {
                 validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
             },
-            ModuleItem::TypeAlias(id) => {
+            ModuleItemId::TypeAlias(id) => {
                 validate!(id, item_tree, ast_id_map, root, accumulator, file_id);
             },
-            ModuleItem::ImportStatement(_) | ModuleItem::GlobalAssertStatement(_) => {},
+            ModuleItemId::ImportStatement(_) | ModuleItemId::GlobalAssertStatement(_) => {},
         }
     }
 }

--- a/crates/hir_def/src/ast_id.rs
+++ b/crates/hir_def/src/ast_id.rs
@@ -127,3 +127,18 @@ impl<N: AstNode> fmt::Debug for FileAstId<N> {
             .finish()
     }
 }
+
+impl<N: AstNode> FileAstId<N> {
+    // Can't make this a From implementation because of coherence
+    #[inline]
+    #[must_use]
+    pub fn upcast<M: AstNode>(self) -> FileAstId<M>
+    where
+        N: Into<M>,
+    {
+        FileAstId {
+            id: self.id,
+            _marker: PhantomData,
+        }
+    }
+}

--- a/crates/hir_def/src/database.rs
+++ b/crates/hir_def/src/database.rs
@@ -178,51 +178,54 @@ pub trait InternDatabase: SourceDatabase {
     #[salsa::interned]
     fn intern_import(
         &self,
-        location: Location<ImportStatement>,
+        location: Location<ast::ImportStatement>,
     ) -> ImportId;
     #[salsa::interned]
     fn intern_directive(
         &self,
-        location: Location<Directive>,
+        location: Location<ast::Directive>,
     ) -> DirectiveId;
     #[salsa::interned]
     fn intern_function(
         &self,
-        location: Location<Function>,
+        location: Location<ast::FunctionDeclaration>,
     ) -> FunctionId;
     #[salsa::interned]
     fn intern_global_variable(
         &self,
-        location: Location<GlobalVariable>,
+        location: Location<ast::VariableDeclaration>,
     ) -> GlobalVariableId;
     #[salsa::interned]
     fn intern_global_constant(
         &self,
-        location: Location<GlobalConstant>,
+        location: Location<ast::ConstantDeclaration>,
     ) -> GlobalConstantId;
     #[salsa::interned]
     fn intern_override(
         &self,
-        location: Location<Override>,
+        location: Location<ast::OverrideDeclaration>,
     ) -> OverrideId;
     #[salsa::interned]
     fn intern_struct(
         &self,
-        location: Location<Struct>,
+        location: Location<ast::StructDeclaration>,
     ) -> StructId;
     #[salsa::interned]
     fn intern_type_alias(
         &self,
-        location: Location<TypeAlias>,
+        location: Location<ast::TypeAliasDeclaration>,
     ) -> TypeAliasId;
     #[salsa::interned]
     fn intern_global_assert_statement(
         &self,
-        location: Location<GlobalAssertStatement>,
+        location: Location<ast::AssertStatement>,
     ) -> GlobalAssertStatementId;
 }
 
-pub type Location<T> = InFile<ModuleItemId<T>>;
+/// `Location` points to an AST node in any file. Corresponds to `AstId` in Rust-Analyzer.
+///
+/// It is stable across reparses, and can be used as salsa key/value.
+pub type Location<T> = InFile<FileAstId<T>>;
 
 macro_rules! impl_intern {
     ($id:ident, $loc:ty, $intern:ident, $lookup:ident) => {
@@ -233,55 +236,55 @@ macro_rules! impl_intern {
 
 impl_intern!(
     ImportId,
-    Location<ImportStatement>,
+    Location<ast::ImportStatement>,
     intern_import,
     lookup_intern_import
 );
 impl_intern!(
     DirectiveId,
-    Location<Directive>,
+    Location<ast::Directive>,
     intern_directive,
     lookup_intern_directive
 );
 impl_intern!(
     FunctionId,
-    Location<Function>,
+    Location<ast::FunctionDeclaration>,
     intern_function,
     lookup_intern_function
 );
 impl_intern!(
     GlobalVariableId,
-    Location<GlobalVariable>,
+    Location<ast::VariableDeclaration>,
     intern_global_variable,
     lookup_intern_global_variable
 );
 impl_intern!(
     GlobalConstantId,
-    Location<GlobalConstant>,
+    Location<ast::ConstantDeclaration>,
     intern_global_constant,
     lookup_intern_global_constant
 );
 impl_intern!(
     OverrideId,
-    Location<Override>,
+    Location<ast::OverrideDeclaration>,
     intern_override,
     lookup_intern_override
 );
 impl_intern!(
     StructId,
-    Location<Struct>,
+    Location<ast::StructDeclaration>,
     intern_struct,
     lookup_intern_struct
 );
 impl_intern!(
     TypeAliasId,
-    Location<TypeAlias>,
+    Location<ast::TypeAliasDeclaration>,
     intern_type_alias,
     lookup_intern_type_alias
 );
 impl_intern!(
     GlobalAssertStatementId,
-    Location<GlobalAssertStatement>,
+    Location<ast::AssertStatement>,
     intern_global_assert_statement,
     lookup_intern_global_assert_statement
 );

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -6,9 +6,12 @@ pub mod pretty;
 use std::{hash, marker::PhantomData, ops::ControlFlow};
 
 use base_db::EditionedFileId;
-use la_arena::{Arena, Idx};
+use rustc_hash::FxHashMap;
 use smol_str::SmolStr;
-use syntax::{AstNode, TokenText, ast};
+use syntax::{
+    AstNode, TokenText,
+    ast::{self, StructDeclaration},
+};
 use triomphe::Arc;
 
 use crate::{
@@ -67,7 +70,6 @@ impl From<&'_ str> for Name {
 pub struct ImportStatement {
     pub kind: PathKind,
     pub tree: ImportTree,
-    pub ast_id: FileAstId<ast::ImportStatement>,
 }
 
 impl ImportStatement {
@@ -147,63 +149,47 @@ impl ImportTree {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Directive {
-    pub ast_id: FileAstId<ast::Directive>,
-}
+pub struct Directive;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Function {
     pub name: Name,
-    pub ast_id: FileAstId<ast::FunctionDeclaration>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct GlobalVariable {
     pub name: Name,
-    pub ast_id: FileAstId<ast::VariableDeclaration>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct GlobalConstant {
     pub name: Name,
-    pub ast_id: FileAstId<ast::ConstantDeclaration>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Override {
     pub name: Name,
-    pub ast_id: FileAstId<ast::OverrideDeclaration>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TypeAlias {
     pub name: Name,
-    pub ast_id: FileAstId<ast::TypeAliasDeclaration>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct GlobalAssertStatement {
-    pub ast_id: FileAstId<ast::AssertStatement>,
-}
+pub struct GlobalAssertStatement;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Struct {
     pub name: Name,
-    pub ast_id: FileAstId<ast::StructDeclaration>,
 }
 
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct ItemTree {
-    top_level: Vec<ModuleItem>,
-    imports: Arena<ImportStatement>,
-    functions: Arena<Function>,
-    global_variables: Arena<GlobalVariable>,
-    global_constants: Arena<GlobalConstant>,
-    overrides: Arena<Override>,
-    type_aliases: Arena<TypeAlias>,
-    structs: Arena<Struct>,
-    directives: Arena<Directive>,
-    global_assert_statements: Arena<GlobalAssertStatement>,
+    top_level: Vec<ModuleItemId>,
+
+    big_data: FxHashMap<FileAstId<ast::Item>, BigModItem>,
+    small_data: FxHashMap<FileAstId<ast::Item>, SmallModItem>,
 }
 
 impl ItemTree {
@@ -214,167 +200,119 @@ impl ItemTree {
         let source = database.parse_or_resolve(file_id).tree();
 
         let lower_ctx = lower::Ctx::new(database, file_id);
-        let tree = lower_ctx.lower_source_file(&source);
-
+        let mut tree = lower_ctx.lower_source_file(&source);
+        tree.shrink_to_fit();
         Arc::new(tree)
     }
 
     #[must_use]
-    pub fn items(&self) -> &[ModuleItem] {
+    pub fn top_level_items(&self) -> &[ModuleItemId] {
         &self.top_level
     }
 
-    pub fn structs(&self) -> impl Iterator<Item = ModuleItemId<Struct>> + '_ {
+    pub fn structs(&self) -> impl Iterator<Item = FileAstId<StructDeclaration>> + '_ {
         self.top_level.iter().filter_map(|item| match item {
-            ModuleItem::Struct(r#struct) => Some(*r#struct),
-            ModuleItem::ImportStatement(_)
-            | ModuleItem::Function(_)
-            | ModuleItem::GlobalVariable(_)
-            | ModuleItem::GlobalConstant(_)
-            | ModuleItem::Override(_)
-            | ModuleItem::GlobalAssertStatement(_)
-            | ModuleItem::TypeAlias(_) => None,
+            ModuleItemId::Struct(r#struct) => Some(*r#struct),
+            ModuleItemId::ImportStatement(_)
+            | ModuleItemId::Function(_)
+            | ModuleItemId::GlobalVariable(_)
+            | ModuleItemId::GlobalConstant(_)
+            | ModuleItemId::Override(_)
+            | ModuleItemId::GlobalAssertStatement(_)
+            | ModuleItemId::TypeAlias(_) => None,
         })
     }
 
-    #[must_use]
-    pub fn get<M: ItemTreeNode>(
-        &self,
-        id: ModuleItemId<M>,
-    ) -> &M {
-        M::lookup(self, id.index)
+    fn shrink_to_fit(&mut self) {
+        let Self {
+            top_level: _,
+            big_data,
+            small_data,
+        } = self;
+        big_data.shrink_to_fit();
+        small_data.shrink_to_fit();
     }
 }
 
-#[derive(PartialEq, Eq, Debug)]
-pub struct ModuleItemId<N> {
-    pub(crate) index: Idx<N>,
-    _marker: PhantomData<N>,
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum SmallModItem {
+    Function(Function),
+    GlobalVariable(GlobalVariable),
+    GlobalConstant(GlobalConstant),
+    Override(Override),
+    TypeAlias(TypeAlias),
+    Struct(Struct),
+    Directive(Directive),
+    GlobalAssertStatement(GlobalAssertStatement),
 }
 
-impl<N> From<Idx<N>> for ModuleItemId<N> {
-    fn from(index: Idx<N>) -> Self {
-        Self {
-            index,
-            _marker: PhantomData,
-        }
-    }
+#[expect(
+    clippy::enum_variant_names,
+    reason = "Match Rust-Analyzer, we might get more big module items in the future"
+)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum BigModItem {
+    ImportStatement(ImportStatement),
 }
-
-// If we automatically derive this trait, ModuleItemId<N> where N does not implement Hash cannot compile
-impl<N> hash::Hash for ModuleItemId<N> {
-    fn hash<H: hash::Hasher>(
-        &self,
-        state: &mut H,
-    ) {
-        self.index.hash(state);
-    }
-}
-
-impl<N> Clone for ModuleItemId<N> {
-    fn clone(&self) -> Self {
-        Self {
-            index: self.index,
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<N: ItemTreeNode> Copy for ModuleItemId<N> {}
 
 pub trait ItemTreeNode: Clone {
     type Source: AstNode + Into<ast::Item>;
-
-    fn ast_id(&self) -> FileAstId<Self::Source>;
-
-    /// Looks up an instance of `Self` in an item tree.
-    fn lookup(
-        data: &ItemTree,
-        index: Idx<Self>,
-    ) -> &Self;
-
-    /// Downcasts a `ModItem` to a `FileItemTreeId` specific to this type.
-    fn id_from_mod_item(mod_item: ModuleItem) -> Option<ModuleItemId<Self>>;
-
-    /// Upcasts a `FileItemTreeId` to a generic `ModuleItem`.
-    fn id_to_mod_item(id: ModuleItemId<Self>) -> ModuleItem;
 }
 
+#[expect(type_alias_bounds, reason = "TODO:")]
+pub(crate) type ItemTreeAstId<T: ItemTreeNode> = FileAstId<T::Source>;
+
 macro_rules! mod_items {
-    ( $( $r#type:ident in $fld:ident $(-> $ast:ty)? ),+ $(,)? ) => {
+    ( $( $r#type:ident in $fld:ident -> $ast:ty ),+ $(,)? ) => {
         #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-        pub enum ModuleItem {
-            $($r#type(ModuleItemId<$r#type>),)+
+        pub enum ModuleItemId {
+            $($r#type(FileAstId<$ast>),)+
         }
 
-        $(impl From<ModuleItemId<$r#type>> for ModuleItem {
-            fn from(id: ModuleItemId<$r#type>) -> ModuleItem {
-                ModuleItem::$r#type(id)
+        impl ModuleItemId {
+            pub(crate) fn ast_id(self) -> FileAstId<ast::Item> {
+                match self {
+                    $(ModuleItemId::$r#type(it) => it.upcast()),+
+                }
+            }
+        }
+
+        $(impl From<FileAstId<$ast>> for ModuleItemId {
+            fn from(id: FileAstId<$ast>) -> ModuleItemId {
+                ModuleItemId::$r#type(id)
             }
         })+
 
-        $(impl core::ops::Index<la_arena::Idx<$r#type>> for ItemTree {
-            type Output = $r#type;
-
-            fn index(&self, index: la_arena::Idx<$r#type>) -> &Self::Output {
-                &self.$fld[index]
-            }
-        })*
-
         $(
-        $(impl ItemTreeNode for $r#type {
+            impl ItemTreeNode for $r#type {
                 type Source = $ast;
+            }
 
-                fn ast_id(&self) -> FileAstId<Self::Source> {
-                    self.ast_id
-                }
+            impl std::ops::Index<FileAstId<$ast>> for ItemTree {
+                type Output = $r#type;
 
-                fn lookup(data: &ItemTree, index: Idx<Self>) -> &Self {
-                    &data.$fld[index]
-                }
-
-                #[allow(clippy::allow_attributes, unreachable_patterns, reason = "macros should not leak lints")]
-                fn id_from_mod_item(mod_item: ModuleItem) -> Option<ModuleItemId<Self>> {
-                    match mod_item {
-                        ModuleItem::$r#type(id) => Some(id),
-                        _ => None,
+                #[expect(unused_imports, reason = "Either a BigModItem or a SmallModItem will be used here.")]
+                fn index(&self, index: FileAstId<$ast>) -> &Self::Output {
+                    use BigModItem::*;
+                    use SmallModItem::*;
+                    match &self.$fld[&index.upcast()] {
+                        $r#type(item) => item,
+                        _ => panic!("expected item of type `{}` at index `{:?}`", stringify!($r#type), index),
                     }
                 }
-
-                fn id_to_mod_item(id: ModuleItemId<Self>) -> ModuleItem {
-                    ModuleItem::$r#type(id)
-                }
             }
+
         )+
-        )*
     };
 }
 
 mod_items! {
-    ImportStatement in imports -> ast::ImportStatement,
-    Function in functions -> ast::FunctionDeclaration,
-    Struct in structs -> ast::StructDeclaration,
-    GlobalVariable in global_variables -> ast::VariableDeclaration,
-    GlobalConstant in global_constants -> ast::ConstantDeclaration,
-    Override in overrides -> ast::OverrideDeclaration,
-    TypeAlias in type_aliases -> ast::TypeAliasDeclaration,
-    GlobalAssertStatement in global_assert_statements -> ast::AssertStatement,
-}
-
-pub fn find_item<M: ItemTreeNode>(
-    database: &dyn DefDatabase,
-    file_id: EditionedFileId,
-    source: &M::Source,
-) -> Option<ModuleItemId<M>> {
-    let item_tree = database.item_tree(file_id);
-    item_tree.items().iter().find_map(|&item| {
-        let id = M::id_from_mod_item(item)?;
-        let data = M::lookup(&item_tree, id.index);
-        let def_map = database.ast_id_map(file_id);
-
-        let source_ast_id = def_map.try_ast_id(source)?;
-        let item_ast_id = M::ast_id(data);
-
-        (source_ast_id == item_ast_id).then_some(id)
-    })
+    ImportStatement in big_data -> ast::ImportStatement,
+    Function in small_data -> ast::FunctionDeclaration,
+    Struct in small_data -> ast::StructDeclaration,
+    GlobalVariable in small_data -> ast::VariableDeclaration,
+    GlobalConstant in small_data -> ast::ConstantDeclaration,
+    Override in small_data -> ast::OverrideDeclaration,
+    TypeAlias in small_data -> ast::TypeAliasDeclaration,
+    GlobalAssertStatement in small_data -> ast::AssertStatement,
 }

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -10,8 +10,8 @@ use crate::{
     ast_id::AstIdMap,
     database::DefDatabase,
     item_tree::{
-        self, Function, GlobalAssertStatement, ImportStatement, ImportTree, ItemTree, ModuleItem,
-        ModuleItemId,
+        self, BigModItem, Function, GlobalAssertStatement, ImportStatement, ImportTree, ItemTree,
+        ItemTreeAstId, ModuleItemId, SmallModItem,
     },
     mod_path::{ModPath, PathKind},
 };
@@ -21,7 +21,7 @@ pub(crate) struct Ctx<'database> {
     file_id: EditionedFileId,
     source_ast_id_map: Arc<AstIdMap>,
     pub(crate) tree: ItemTree,
-    pub(crate) items: Vec<ModuleItem>,
+    pub(crate) items: Vec<ModuleItemId>,
 }
 
 impl<'database> Ctx<'database> {
@@ -55,25 +55,27 @@ impl<'database> Ctx<'database> {
     ) -> Option<()> {
         let item = match item {
             Item::ImportStatement(import_statement) => {
-                ModuleItem::ImportStatement(self.lower_import(&import_statement)?)
+                ModuleItemId::ImportStatement(self.lower_import(&import_statement)?)
             },
             Item::FunctionDeclaration(function) => {
-                ModuleItem::Function(self.lower_function(&function)?)
+                ModuleItemId::Function(self.lower_function(&function)?)
             },
-            Item::StructDeclaration(r#struct) => ModuleItem::Struct(self.lower_struct(&r#struct)?),
+            Item::StructDeclaration(r#struct) => {
+                ModuleItemId::Struct(self.lower_struct(&r#struct)?)
+            },
             Item::VariableDeclaration(variable) => {
-                ModuleItem::GlobalVariable(self.lower_global_variable(&variable)?)
+                ModuleItemId::GlobalVariable(self.lower_global_variable(&variable)?)
             },
             Item::ConstantDeclaration(constant) => {
-                ModuleItem::GlobalConstant(self.lower_global_constant(&constant)?)
+                ModuleItemId::GlobalConstant(self.lower_global_constant(&constant)?)
             },
             Item::OverrideDeclaration(override_declaration) => {
-                ModuleItem::Override(self.lower_override(&override_declaration)?)
+                ModuleItemId::Override(self.lower_override(&override_declaration)?)
             },
             Item::TypeAliasDeclaration(type_alias) => {
-                ModuleItem::TypeAlias(self.lower_type_alias(&type_alias)?)
+                ModuleItemId::TypeAlias(self.lower_type_alias(&type_alias)?)
             },
-            Item::AssertStatement(assert_statement) => ModuleItem::GlobalAssertStatement(
+            Item::AssertStatement(assert_statement) => ModuleItemId::GlobalAssertStatement(
                 self.lower_global_assert_statement(&assert_statement)?,
             ),
         };
@@ -84,16 +86,16 @@ impl<'database> Ctx<'database> {
     fn lower_import(
         &mut self,
         item: &syntax::ast::ImportStatement,
-    ) -> Option<ModuleItemId<ImportStatement>> {
+    ) -> Option<ItemTreeAstId<ImportStatement>> {
         let kind = PathKind::from_src(item.relative());
         let tree = Self::lower_import_tree(&item.item()?)?;
         let ast_id = self.source_ast_id_map.ast_id(item);
-        Some(
-            self.tree
-                .imports
-                .alloc(ImportStatement { kind, tree, ast_id })
-                .into(),
-        )
+        let import_statement = ImportStatement { kind, tree };
+        self.tree.big_data.insert(
+            ast_id.upcast(),
+            BigModItem::ImportStatement(import_statement),
+        );
+        Some(ast_id)
     }
 
     fn lower_import_tree(import_tree: &syntax::ast::ImportTree) -> Option<ImportTree> {
@@ -122,66 +124,81 @@ impl<'database> Ctx<'database> {
     fn lower_type_alias(
         &mut self,
         type_alias: &syntax::ast::TypeAliasDeclaration,
-    ) -> Option<ModuleItemId<TypeAlias>> {
+    ) -> Option<ItemTreeAstId<TypeAlias>> {
         let name = type_alias.name()?.text().into();
         let ast_id = self.source_ast_id_map.ast_id(type_alias);
-        Some(
-            self.tree
-                .type_aliases
-                .alloc(TypeAlias { name, ast_id })
-                .into(),
-        )
+        let type_alias = TypeAlias { name };
+        self.tree
+            .small_data
+            .insert(ast_id.upcast(), SmallModItem::TypeAlias(type_alias));
+        Some(ast_id)
     }
 
     fn lower_override(
         &mut self,
         override_declaration: &syntax::ast::OverrideDeclaration,
-    ) -> Option<ModuleItemId<Override>> {
+    ) -> Option<ItemTreeAstId<Override>> {
         let name = override_declaration.name()?.text().into();
         let ast_id = self.source_ast_id_map.ast_id(override_declaration);
-
-        let override_declaration = Override { name, ast_id };
-        Some(self.tree.overrides.alloc(override_declaration).into())
+        let override_declaration = Override { name };
+        self.tree.small_data.insert(
+            ast_id.upcast(),
+            SmallModItem::Override(override_declaration),
+        );
+        Some(ast_id)
     }
 
     fn lower_global_constant(
         &mut self,
         constant: &syntax::ast::ConstantDeclaration,
-    ) -> Option<ModuleItemId<GlobalConstant>> {
+    ) -> Option<ItemTreeAstId<GlobalConstant>> {
         let name = constant.name()?.text().into();
         let ast_id = self.source_ast_id_map.ast_id(constant);
-        let constant = GlobalConstant { name, ast_id };
-        Some(self.tree.global_constants.alloc(constant).into())
+        let constant = GlobalConstant { name };
+        self.tree
+            .small_data
+            .insert(ast_id.upcast(), SmallModItem::GlobalConstant(constant));
+        Some(ast_id)
     }
 
     fn lower_global_variable(
         &mut self,
         variable: &syntax::ast::VariableDeclaration,
-    ) -> Option<ModuleItemId<GlobalVariable>> {
+    ) -> Option<ItemTreeAstId<GlobalVariable>> {
         let name = variable.name()?.text().into();
         let ast_id = self.source_ast_id_map.ast_id(variable);
-        let variable = GlobalVariable { name, ast_id };
-        Some(self.tree.global_variables.alloc(variable).into())
+        let variable = GlobalVariable { name };
+        self.tree
+            .small_data
+            .insert(ast_id.upcast(), SmallModItem::GlobalVariable(variable));
+
+        Some(ast_id)
     }
 
     fn lower_struct(
         &mut self,
         r#struct: &syntax::ast::StructDeclaration,
-    ) -> Option<ModuleItemId<Struct>> {
+    ) -> Option<ItemTreeAstId<Struct>> {
         let name = r#struct.name()?.text().into();
         let ast_id = self.source_ast_id_map.ast_id(r#struct);
-        let r#struct = Struct { name, ast_id };
-        Some(self.tree.structs.alloc(r#struct).into())
+        let r#struct = Struct { name };
+        self.tree
+            .small_data
+            .insert(ast_id.upcast(), SmallModItem::Struct(r#struct));
+        Some(ast_id)
     }
 
     fn lower_function(
         &mut self,
         function: &syntax::ast::FunctionDeclaration,
-    ) -> Option<ModuleItemId<Function>> {
+    ) -> Option<ItemTreeAstId<Function>> {
         let name = function.name()?.text().into();
         let ast_id = self.source_ast_id_map.ast_id(function);
-        let function = Function { name, ast_id };
-        Some(self.tree.functions.alloc(function).into())
+        let function = Function { name };
+        self.tree
+            .small_data
+            .insert(ast_id.upcast(), SmallModItem::Function(function));
+        Some(ast_id)
     }
 
     #[expect(
@@ -191,14 +208,14 @@ impl<'database> Ctx<'database> {
     fn lower_global_assert_statement(
         &mut self,
         assert_statement: &syntax::ast::AssertStatement,
-    ) -> Option<ModuleItemId<GlobalAssertStatement>> {
+    ) -> Option<ItemTreeAstId<GlobalAssertStatement>> {
         let ast_id = self.source_ast_id_map.ast_id(assert_statement);
-        let assert_statement = GlobalAssertStatement { ast_id };
-        Some(
-            self.tree
-                .global_assert_statements
-                .alloc(assert_statement)
-                .into(),
-        )
+        let assert_statement = GlobalAssertStatement {};
+        self.tree.small_data.insert(
+            ast_id.upcast(),
+            SmallModItem::GlobalAssertStatement(assert_statement),
+        );
+
+        Some(ast_id)
     }
 }

--- a/crates/hir_def/src/item_tree/pretty.rs
+++ b/crates/hir_def/src/item_tree/pretty.rs
@@ -4,14 +4,14 @@ use std::fmt::Write as _;
 
 use crate::{
     FileAstId,
-    item_tree::{ImportTree, ItemTree, ModuleItem},
+    item_tree::{ImportTree, ItemTree, ModuleItemId},
     mod_path::PathKind,
 };
 
 #[must_use]
 pub fn pretty_print_item_tree(module: &ItemTree) -> String {
     let mut buffer = String::new();
-    for &item in module.items() {
+    for &item in module.top_level_items() {
         write_pretty_module_item(item, module, &mut buffer);
         buffer.push('\n');
     }
@@ -19,52 +19,52 @@ pub fn pretty_print_item_tree(module: &ItemTree) -> String {
 }
 
 fn write_pretty_module_item(
-    item: ModuleItem,
+    item: ModuleItemId,
     module: &ItemTree,
     buffer: &mut String,
 ) {
     match item {
-        ModuleItem::ImportStatement(id) => {
-            let import_statement = &module[id.index];
-            print_ast_id(buffer, import_statement.ast_id);
+        ModuleItemId::ImportStatement(id) => {
+            let import_statement = &module[id];
+            print_ast_id(buffer, id);
             _ = write!(buffer, "import");
             write_pretty_relative_import(import_statement.kind, buffer);
             write_pretty_import_tree(&import_statement.tree, buffer);
             _ = write!(buffer, ";");
         },
-        ModuleItem::Function(id) => {
-            let function = &module[id.index];
-            print_ast_id(buffer, function.ast_id);
+        ModuleItemId::Function(id) => {
+            let function = &module[id];
+            print_ast_id(buffer, id);
             _ = write!(buffer, "fn {};", function.name.0);
         },
-        ModuleItem::Struct(id) => {
-            let r#struct = &module[id.index];
-            print_ast_id(buffer, r#struct.ast_id);
+        ModuleItemId::Struct(id) => {
+            let r#struct = &module[id];
+            print_ast_id(buffer, id);
             _ = write!(buffer, "struct {} {{ ... }}", r#struct.name.0);
         },
-        ModuleItem::GlobalVariable(id) => {
-            let variable = &module[id.index];
-            print_ast_id(buffer, variable.ast_id);
+        ModuleItemId::GlobalVariable(id) => {
+            let variable = &module[id];
+            print_ast_id(buffer, id);
             _ = write!(buffer, "var {} = _;", &variable.name.0);
         },
-        ModuleItem::GlobalConstant(id) => {
-            let constant = &module[id.index];
-            print_ast_id(buffer, constant.ast_id);
+        ModuleItemId::GlobalConstant(id) => {
+            let constant = &module[id];
+            print_ast_id(buffer, id);
             _ = write!(buffer, "const {} = _;", &constant.name.0);
         },
-        ModuleItem::Override(id) => {
-            let override_declaration = &module[id.index];
-            print_ast_id(buffer, override_declaration.ast_id);
+        ModuleItemId::Override(id) => {
+            let override_declaration = &module[id];
+            print_ast_id(buffer, id);
             _ = write!(buffer, "override {} = _;", &override_declaration.name.0);
         },
-        ModuleItem::TypeAlias(id) => {
-            let type_alias = &module[id.index];
-            print_ast_id(buffer, type_alias.ast_id);
+        ModuleItemId::TypeAlias(id) => {
+            let type_alias = &module[id];
+            print_ast_id(buffer, id);
             _ = write!(buffer, "alias {} = _;", &type_alias.name.0);
         },
-        ModuleItem::GlobalAssertStatement(id) => {
-            let const_assert = &module[id.index];
-            print_ast_id(buffer, const_assert.ast_id);
+        ModuleItemId::GlobalAssertStatement(id) => {
+            let const_assert = &module[id];
+            print_ast_id(buffer, id);
             _ = write!(buffer, "const_assert _;");
         },
     }

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -21,7 +21,7 @@ use base_db::{EditionedFileId, FileRange, TextRange};
 use database::DefDatabase;
 use item_tree::{ItemTreeNode, ModuleItemId};
 use rowan::NodeOrToken;
-use syntax::{AstNode, SyntaxNode, SyntaxToken};
+use syntax::{AstNode, SyntaxNode, SyntaxToken, pointer::AstPointer};
 
 /// `InFile<T>` stores a value of `T` inside a particular file/syntax tree.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -122,28 +122,31 @@ pub fn original_file_range<T: HasTextRange>(
 }
 
 pub trait HasSource {
-    type Value;
+    type Value: AstNode;
     fn source(
         &self,
         database: &dyn DefDatabase,
-    ) -> InFile<Self::Value>;
+    ) -> InFile<Self::Value> {
+        let InFile { file_id, value } = self.ast_ptr(database);
+        InFile::new(
+            file_id,
+            value.to_node(&database.parse_or_resolve(file_id).syntax()),
+        )
+    }
+    fn ast_ptr(
+        &self,
+        database: &dyn DefDatabase,
+    ) -> InFile<AstPointer<Self::Value>>;
 }
 
-impl<N: ItemTreeNode> HasSource for InFile<ModuleItemId<N>> {
-    type Value = N::Source;
+impl<Node: AstNode> HasSource for InFile<FileAstId<Node>> {
+    type Value = Node;
 
-    fn source(
+    fn ast_ptr(
         &self,
         database: &dyn DefDatabase,
-    ) -> InFile<N::Source> {
-        let item_tree = database.item_tree(self.file_id);
+    ) -> InFile<AstPointer<Self::Value>> {
         let ast_id_map = database.ast_id_map(self.file_id);
-        let root = database.parse_or_resolve(self.file_id);
-        let node = N::lookup(&item_tree, self.value.index);
-
-        InFile::new(
-            self.file_id,
-            ast_id_map.get(node.ast_id()).to_node(&root.syntax()),
-        )
+        InFile::new(self.file_id, ast_id_map.get(self.value))
     }
 }

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -1,6 +1,6 @@
 use std::ops::ControlFlow;
 
-use base_db::EditionedFileId;
+use base_db::{EditionedFileId, Intern as _};
 use triomphe::Arc;
 
 use crate::{
@@ -9,10 +9,13 @@ use crate::{
         BindingId,
         scope::{ExprScopes, ScopeId},
     },
-    database::{FunctionId, Location},
+    database::{
+        self, DefDatabase, FunctionId, GlobalConstantId, GlobalVariableId, Location, OverrideId,
+        StructId, TypeAliasId,
+    },
     expression_store::path::Path,
     item_tree::{
-        Function, GlobalConstant, GlobalVariable, ItemTree, ModuleItem, Name, Override, Struct,
+        Function, GlobalConstant, GlobalVariable, ItemTree, ModuleItemId, Name, Override, Struct,
         TypeAlias,
     },
 };
@@ -43,17 +46,17 @@ pub struct ExpressionScope {
 #[derive(Debug)]
 pub enum ResolveKind {
     Local(BindingId),
-    Struct(Location<Struct>),
-    TypeAlias(Location<TypeAlias>),
-    GlobalVariable(Location<GlobalVariable>),
-    GlobalConstant(Location<GlobalConstant>),
-    Override(Location<Override>),
-    Function(Location<Function>),
+    Struct(StructId),
+    TypeAlias(TypeAliasId),
+    GlobalVariable(GlobalVariableId),
+    GlobalConstant(GlobalConstantId),
+    Override(OverrideId),
+    Function(FunctionId),
 }
 
 pub enum ScopeDef {
     Local(BindingId),
-    ModuleItem(EditionedFileId, ModuleItem),
+    ModuleItem(EditionedFileId, ModuleItemId),
 }
 
 #[derive(Clone)]
@@ -128,37 +131,37 @@ impl Resolver {
             Scope::Module(scope) => {
                 scope
                     .module_info
-                    .items()
+                    .top_level_items()
                     .iter()
                     .for_each(|item| match item {
-                        ModuleItem::Function(id) => function(
-                            scope.module_info.get(*id).name.clone(),
+                        ModuleItemId::Function(id) => function(
+                            scope.module_info[*id].name.clone(),
                             ScopeDef::ModuleItem(scope.file_id, *item),
                         ),
-                        ModuleItem::GlobalVariable(id) => function(
-                            scope.module_info.get(*id).name.clone(),
+                        ModuleItemId::GlobalVariable(id) => function(
+                            scope.module_info[*id].name.clone(),
                             ScopeDef::ModuleItem(scope.file_id, *item),
                         ),
-                        ModuleItem::GlobalConstant(id) => function(
-                            scope.module_info.get(*id).name.clone(),
+                        ModuleItemId::GlobalConstant(id) => function(
+                            scope.module_info[*id].name.clone(),
                             ScopeDef::ModuleItem(scope.file_id, *item),
                         ),
-                        ModuleItem::Override(id) => function(
-                            scope.module_info.get(*id).name.clone(),
+                        ModuleItemId::Override(id) => function(
+                            scope.module_info[*id].name.clone(),
                             ScopeDef::ModuleItem(scope.file_id, *item),
                         ),
-                        ModuleItem::Struct(id) => function(
-                            scope.module_info.get(*id).name.clone(),
+                        ModuleItemId::Struct(id) => function(
+                            scope.module_info[*id].name.clone(),
                             ScopeDef::ModuleItem(scope.file_id, *item),
                         ),
-                        ModuleItem::TypeAlias(id) => function(
-                            scope.module_info.get(*id).name.clone(),
+                        ModuleItemId::TypeAlias(id) => function(
+                            scope.module_info[*id].name.clone(),
                             ScopeDef::ModuleItem(scope.file_id, *item),
                         ),
-                        ModuleItem::GlobalAssertStatement(_) => {},
-                        ModuleItem::ImportStatement(id) => {
+                        ModuleItemId::GlobalAssertStatement(_) => {},
+                        ModuleItemId::ImportStatement(id) => {
                             // The leaves of the tree are in scope
-                            scope.module_info.get(*id).expand::<(), _>(|flat_import| {
+                            scope.module_info[*id].expand::<(), _>(|flat_import| {
                                 if let Some(name) = flat_import.leaf_name() {
                                     function(
                                         name.clone(),
@@ -192,6 +195,7 @@ impl Resolver {
     pub fn resolve(
         &self,
         path: &Path,
+        database: &dyn DefDatabase,
     ) -> Option<ResolveKind> {
         let mod_path = path.mod_path();
         let leaf_name = match mod_path.kind() {
@@ -212,58 +216,78 @@ impl Resolver {
                     .resolve_name_in_scope(scope.scope_id, leaf_name)?;
                 Some(ResolveKind::Local(entry.binding))
             },
-            Scope::Module(scope) => scope
-                .module_info
-                .items()
-                .iter()
-                .find_map(|item| match item {
-                    ModuleItem::Struct(id) => {
-                        let r#struct = scope.module_info.get(*id);
-                        (&r#struct.name == leaf_name)
-                            .then(|| ResolveKind::Struct(InFile::new(scope.file_id, *id)))
-                    },
-                    ModuleItem::TypeAlias(id) => {
-                        let type_alias = scope.module_info.get(*id);
-                        (&type_alias.name == leaf_name)
-                            .then(|| ResolveKind::TypeAlias(InFile::new(scope.file_id, *id)))
-                    },
-                    ModuleItem::GlobalVariable(id) => {
-                        let variable = scope.module_info.get(*id);
-                        (&variable.name == leaf_name)
-                            .then(|| ResolveKind::GlobalVariable(Location::new(scope.file_id, *id)))
-                    },
-                    ModuleItem::GlobalConstant(id) => {
-                        let constant = scope.module_info.get(*id);
-                        (&constant.name == leaf_name)
-                            .then(|| ResolveKind::GlobalConstant(Location::new(scope.file_id, *id)))
-                    },
-                    ModuleItem::Override(id) => {
-                        let r#override = scope.module_info.get(*id);
-                        (&r#override.name == leaf_name)
-                            .then(|| ResolveKind::Override(Location::new(scope.file_id, *id)))
-                    },
-                    ModuleItem::Function(id) => {
-                        let function = scope.module_info.get(*id);
-                        (&function.name == leaf_name)
-                            .then(|| ResolveKind::Function(InFile::new(scope.file_id, *id)))
-                    },
-                    ModuleItem::GlobalAssertStatement(_) => None,
-                    ModuleItem::ImportStatement(_id) => None,
-                    // TODO: Support import statements https://github.com/wgsl-analyzer/wgsl-analyzer/issues/632
-                    /*scope
+            Scope::Module(scope) => {
+                scope
                     .module_info
-                    .get(*id)
-                    .expand::<ResolveKind>(|flat_import| {
-                        if flat_import.leaf_name() == Some(leaf_name) {
-                            ControlFlow::Break(ResolveKind::Function(InFile::new(
-                                scope.file_id,
-                                *id,
-                            )))
-                        } else {
-                            ControlFlow::Continue(())
-                        }
-                    }),*/
-                }),
+                    .top_level_items()
+                    .iter()
+                    .find_map(|item| match item {
+                        ModuleItemId::Struct(id) => {
+                            let r#struct = &scope.module_info[*id];
+                            (&r#struct.name == leaf_name).then(|| {
+                                ResolveKind::Struct(
+                                    InFile::new(scope.file_id, *id).intern(database),
+                                )
+                            })
+                        },
+                        ModuleItemId::TypeAlias(id) => {
+                            let type_alias = &scope.module_info[*id];
+                            (&type_alias.name == leaf_name).then(|| {
+                                ResolveKind::TypeAlias(
+                                    InFile::new(scope.file_id, *id).intern(database),
+                                )
+                            })
+                        },
+                        ModuleItemId::GlobalVariable(id) => {
+                            let variable = &scope.module_info[*id];
+                            (&variable.name == leaf_name).then(|| {
+                                ResolveKind::GlobalVariable(
+                                    Location::new(scope.file_id, *id).intern(database),
+                                )
+                            })
+                        },
+                        ModuleItemId::GlobalConstant(id) => {
+                            let constant = &scope.module_info[*id];
+                            (&constant.name == leaf_name).then(|| {
+                                ResolveKind::GlobalConstant(
+                                    Location::new(scope.file_id, *id).intern(database),
+                                )
+                            })
+                        },
+                        ModuleItemId::Override(id) => {
+                            let r#override = &scope.module_info[*id];
+                            (&r#override.name == leaf_name).then(|| {
+                                ResolveKind::Override(
+                                    Location::new(scope.file_id, *id).intern(database),
+                                )
+                            })
+                        },
+                        ModuleItemId::Function(id) => {
+                            let function = &scope.module_info[*id];
+                            (&function.name == leaf_name).then(|| {
+                                ResolveKind::Function(
+                                    InFile::new(scope.file_id, *id).intern(database),
+                                )
+                            })
+                        },
+                        ModuleItemId::GlobalAssertStatement(_) => None,
+                        ModuleItemId::ImportStatement(_id) => None,
+                        // TODO: Support import statements https://github.com/wgsl-analyzer/wgsl-analyzer/issues/632
+                        /*scope
+                        .module_info
+                        .get(*id)
+                        .expand::<ResolveKind>(|flat_import| {
+                            if flat_import.leaf_name() == Some(leaf_name) {
+                                ControlFlow::Break(ResolveKind::Function(InFile::new(
+                                    scope.file_id,
+                                    *id,
+                                )))
+                            } else {
+                                ControlFlow::Continue(())
+                            }
+                        }),*/
+                    })
+            },
             Scope::Builtin => {
                 // TODO: Match against "name.as_str()" and then point at a "builtin" file
                 // See: https://github.com/wgsl-analyzer/wgsl-analyzer/issues/559

--- a/crates/hir_ty/src/database.rs
+++ b/crates/hir_ty/src/database.rs
@@ -186,26 +186,30 @@ fn struct_is_used_in_uniform(
     file_id: EditionedFileId,
 ) -> bool {
     let module_info = database.item_tree(file_id);
-    module_info.items().iter().any(|item| match *item {
-        hir_def::item_tree::ModuleItem::GlobalVariable(declaration) => {
-            let declaration = database.intern_global_variable(InFile::new(file_id, declaration));
-            let inference = database.infer(DefinitionWithBodyId::GlobalVariable(declaration));
-            let type_kind = inference.return_type().kind(database);
+    module_info
+        .top_level_items()
+        .iter()
+        .any(|item| match *item {
+            hir_def::item_tree::ModuleItemId::GlobalVariable(declaration) => {
+                let declaration =
+                    database.intern_global_variable(InFile::new(file_id, declaration));
+                let inference = database.infer(DefinitionWithBodyId::GlobalVariable(declaration));
+                let type_kind = inference.return_type().kind(database);
 
-            if let TypeKind::Reference(crate::ty::Reference { address_space, .. }) = type_kind
-                && !matches!(address_space, AddressSpace::Uniform)
-            {
-                return false;
-            }
+                if let TypeKind::Reference(crate::ty::Reference { address_space, .. }) = type_kind
+                    && !matches!(address_space, AddressSpace::Uniform)
+                {
+                    return false;
+                }
 
-            inference.return_type().contains_struct(database, r#struct)
-        },
-        hir_def::item_tree::ModuleItem::Function(_)
-        | hir_def::item_tree::ModuleItem::Struct(_)
-        | hir_def::item_tree::ModuleItem::GlobalConstant(_)
-        | hir_def::item_tree::ModuleItem::Override(_)
-        | hir_def::item_tree::ModuleItem::GlobalAssertStatement(_)
-        | hir_def::item_tree::ModuleItem::TypeAlias(_)
-        | hir_def::item_tree::ModuleItem::ImportStatement(_) => false,
-    })
+                inference.return_type().contains_struct(database, r#struct)
+            },
+            hir_def::item_tree::ModuleItemId::Function(_)
+            | hir_def::item_tree::ModuleItemId::Struct(_)
+            | hir_def::item_tree::ModuleItemId::GlobalConstant(_)
+            | hir_def::item_tree::ModuleItemId::Override(_)
+            | hir_def::item_tree::ModuleItemId::GlobalAssertStatement(_)
+            | hir_def::item_tree::ModuleItemId::TypeAlias(_)
+            | hir_def::item_tree::ModuleItemId::ImportStatement(_) => false,
+        })
 }

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -2523,39 +2523,25 @@ impl<'database> TypeLoweringContext<'database> {
         path: &Path,
         template_parameters: &[ExpressionId],
     ) -> Result<Lowered, TypeLoweringError> {
-        let resolved_type = self.resolver.resolve(path);
+        let resolved_type = self.resolver.resolve(path, self.database);
 
         if resolved_type.is_some() {
             self.expect_no_template(template_parameters);
         }
 
         match resolved_type {
-            Some(ResolveKind::TypeAlias(location)) => {
-                let id = self.database.intern_type_alias(location);
+            Some(ResolveKind::TypeAlias(id)) => {
                 Ok(Lowered::Type(self.database.type_alias_type(id).0))
             },
-            Some(ResolveKind::Struct(location)) => {
-                let id = self.database.intern_struct(location);
-                Ok(Lowered::Type(
-                    self.database.intern_type(TypeKind::Struct(id)),
-                ))
-            },
-            Some(ResolveKind::Function(location)) => {
-                let id = self.database.intern_function(location);
+            Some(ResolveKind::Struct(id)) => Ok(Lowered::Type(
+                self.database.intern_type(TypeKind::Struct(id)),
+            )),
+            Some(ResolveKind::Function(id)) => {
                 Ok(Lowered::Function(self.database.function_type(id)))
             },
-            Some(ResolveKind::GlobalConstant(location)) => {
-                let id = self.database.intern_global_constant(location);
-                Ok(Lowered::GlobalConstant(id))
-            },
-            Some(ResolveKind::GlobalVariable(location)) => {
-                let id = self.database.intern_global_variable(location);
-                Ok(Lowered::GlobalVariable(id))
-            },
-            Some(ResolveKind::Override(location)) => {
-                let id = self.database.intern_override(location);
-                Ok(Lowered::Override(id))
-            },
+            Some(ResolveKind::GlobalConstant(id)) => Ok(Lowered::GlobalConstant(id)),
+            Some(ResolveKind::GlobalVariable(id)) => Ok(Lowered::GlobalVariable(id)),
+            Some(ResolveKind::Override(id)) => Ok(Lowered::Override(id)),
             Some(ResolveKind::Local(local)) => Ok(Lowered::Local(local)),
             None => self.lower_predeclared(type_container, path, template_parameters),
         }

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -4,14 +4,14 @@ mod builtins;
 mod simple;
 use std::fmt::Write as _;
 
-use base_db::{EditionedFileId, Lookup as _};
+use base_db::{EditionedFileId, Intern, Lookup as _};
 use expect_test::Expect;
 use hir_def::{
     HasSource as _,
     body::{Body, BodySourceMap},
     database::{DefDatabase as _, DefinitionWithBodyId, InternDatabase as _, Location},
     expression_store::SyntheticSyntax,
-    item_tree::ModuleItem,
+    item_tree::ModuleItemId,
 };
 use salsa::Durability;
 use syntax::{AstNode as _, ExtensionsConfig, SyntaxNode};
@@ -180,40 +180,35 @@ fn text_size(
 }
 
 fn module_definitions(
-    db: &TestDatabase,
+    database: &TestDatabase,
     file_id: EditionedFileId,
     item_tree: &Arc<hir_def::item_tree::ItemTree>,
 ) -> Vec<DefinitionWithBodyId> {
     item_tree
-        .items()
+        .top_level_items()
         .iter()
         .filter_map(|item| {
             Some(match item {
-                ModuleItem::Function(id) => {
-                    let loc = Location::new(file_id, *id);
-                    DefinitionWithBodyId::Function(db.intern_function(loc))
+                ModuleItemId::Function(id) => {
+                    DefinitionWithBodyId::Function(Location::new(file_id, *id).intern(database))
                 },
-                ModuleItem::GlobalVariable(id) => {
-                    let loc = Location::new(file_id, *id);
-                    DefinitionWithBodyId::GlobalVariable(db.intern_global_variable(loc))
+                ModuleItemId::GlobalVariable(id) => DefinitionWithBodyId::GlobalVariable(
+                    Location::new(file_id, *id).intern(database),
+                ),
+                ModuleItemId::GlobalConstant(id) => DefinitionWithBodyId::GlobalConstant(
+                    Location::new(file_id, *id).intern(database),
+                ),
+                ModuleItemId::Override(id) => {
+                    DefinitionWithBodyId::Override(Location::new(file_id, *id).intern(database))
                 },
-                ModuleItem::GlobalConstant(id) => {
-                    let loc = Location::new(file_id, *id);
-                    DefinitionWithBodyId::GlobalConstant(db.intern_global_constant(loc))
-                },
-                ModuleItem::Override(id) => {
-                    let loc = Location::new(file_id, *id);
-                    DefinitionWithBodyId::Override(db.intern_override(loc))
-                },
-                ModuleItem::GlobalAssertStatement(id) => {
-                    let loc = Location::new(file_id, *id);
+                ModuleItemId::GlobalAssertStatement(id) => {
                     DefinitionWithBodyId::GlobalAssertStatement(
-                        db.intern_global_assert_statement(loc),
+                        Location::new(file_id, *id).intern(database),
                     )
                 },
-                ModuleItem::TypeAlias(_)
-                | ModuleItem::Struct(_)
-                | ModuleItem::ImportStatement(_) => return None,
+                ModuleItemId::TypeAlias(_)
+                | ModuleItemId::Struct(_)
+                | ModuleItemId::ImportStatement(_) => return None,
             })
         })
         .collect()

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -4,7 +4,7 @@ mod builtins;
 mod simple;
 use std::fmt::Write as _;
 
-use base_db::{EditionedFileId, Intern, Lookup as _};
+use base_db::{EditionedFileId, Intern as _, Lookup as _};
 use expect_test::Expect;
 use hir_def::{
     HasSource as _,

--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -2,7 +2,7 @@ use base_db::{EditionedFileId, FilePosition, TextSize};
 use hir::{HirDatabase as _, Semantics, database::DefDatabase};
 use hir_def::{
     database::{InternDatabase as _, Location},
-    item_tree::ModuleItem,
+    item_tree::ModuleItemId,
     resolver::ScopeDef,
 };
 use hir_ty::{
@@ -110,7 +110,7 @@ pub(crate) fn signature_help(
         .resolver(file_id, syntax)
         .process_all_names(|name, scope_def| {
             if name.as_str().to_owned().contains(&text.to_string())
-                && let ScopeDef::ModuleItem(file_id, ModuleItem::Function(module_item_id)) =
+                && let ScopeDef::ModuleItem(file_id, ModuleItemId::Function(module_item_id)) =
                     scope_def
             {
                 overloads.push(module_item_id);

--- a/crates/ide_completion/src/completions/expression.rs
+++ b/crates/ide_completion/src/completions/expression.rs
@@ -2,7 +2,7 @@ use base_db::EditionedFileId;
 use hir::HirDatabase as _;
 use hir_def::{
     database::{DefDatabase as _, DefinitionWithBodyId, InternDatabase as _, Location},
-    item_tree::{ModuleItem, Name},
+    item_tree::{ModuleItemId, Name},
     resolver::ScopeDef,
 };
 use hir_ty::{
@@ -32,21 +32,22 @@ pub(crate) fn complete_names_in_scope(
             return;
         }
         let kind = match item {
-            ScopeDef::ModuleItem(_, ModuleItem::Function(_)) => CompletionItemKind::Function,
-            ScopeDef::ModuleItem(_, ModuleItem::GlobalVariable(_)) | ScopeDef::Local(_) => {
+            ScopeDef::ModuleItem(_, ModuleItemId::Function(_)) => CompletionItemKind::Function,
+            ScopeDef::ModuleItem(_, ModuleItemId::GlobalVariable(_)) | ScopeDef::Local(_) => {
                 CompletionItemKind::Variable
             },
-            ScopeDef::ModuleItem(_, ModuleItem::GlobalConstant(_) | ModuleItem::Override(_)) => {
-                CompletionItemKind::Constant
-            },
-            ScopeDef::ModuleItem(_, ModuleItem::Struct(_)) => CompletionItemKind::Struct,
-            ScopeDef::ModuleItem(_, ModuleItem::TypeAlias(_)) => CompletionItemKind::TypeAlias,
-            ScopeDef::ModuleItem(_, ModuleItem::ImportStatement(_)) => {
+            ScopeDef::ModuleItem(
+                _,
+                ModuleItemId::GlobalConstant(_) | ModuleItemId::Override(_),
+            ) => CompletionItemKind::Constant,
+            ScopeDef::ModuleItem(_, ModuleItemId::Struct(_)) => CompletionItemKind::Struct,
+            ScopeDef::ModuleItem(_, ModuleItemId::TypeAlias(_)) => CompletionItemKind::TypeAlias,
+            ScopeDef::ModuleItem(_, ModuleItemId::ImportStatement(_)) => {
                 // TODO: Resolve the import statement, and then set the correct CompletionItemKind from there
                 // TODO: https://github.com/wgsl-analyzer/wgsl-analyzer/issues/632
                 CompletionItemKind::Module
             },
-            ScopeDef::ModuleItem(_, ModuleItem::GlobalAssertStatement(_)) => {
+            ScopeDef::ModuleItem(_, ModuleItemId::GlobalAssertStatement(_)) => {
                 return;
             },
         };
@@ -101,10 +102,10 @@ pub(crate) fn complete_names_in_scope(
 fn render_detail(
     context: &CompletionContext<'_>,
     file_id: EditionedFileId,
-    item: ModuleItem,
+    item: ModuleItemId,
 ) -> String {
     match item {
-        ModuleItem::Function(id) => {
+        ModuleItemId::Function(id) => {
             let function_id = context.database.intern_function(Location::new(file_id, id));
             let function_type = context.database.function_type(function_id);
 
@@ -114,11 +115,11 @@ fn render_detail(
                 TypeVerbosity::Compact,
             )
         },
-        ModuleItem::Struct(id) => {
+        ModuleItemId::Struct(id) => {
             let module_info = context.database.item_tree(file_id);
-            format!("struct {}", module_info.get(id).name.as_str())
+            format!("struct {}", module_info[id].name.as_str())
         },
-        ModuleItem::GlobalVariable(id) => {
+        ModuleItemId::GlobalVariable(id) => {
             let variable_id = context
                 .database
                 .intern_global_variable(Location::new(file_id, id));
@@ -129,7 +130,7 @@ fn render_detail(
             let module_info = context.database.item_tree(file_id);
             format!(
                 "var {}: {}",
-                module_info.get(id).name.as_str(),
+                module_info[id].name.as_str(),
                 pretty_type_with_verbosity(
                     context.database,
                     variable_type.return_type(),
@@ -137,7 +138,7 @@ fn render_detail(
                 )
             )
         },
-        ModuleItem::GlobalConstant(id) => {
+        ModuleItemId::GlobalConstant(id) => {
             let constant_id = context
                 .database
                 .intern_global_constant(Location::new(file_id, id));
@@ -148,7 +149,7 @@ fn render_detail(
             let module_info = context.database.item_tree(file_id);
             format!(
                 "const {}: {}",
-                module_info.get(id).name.as_str(),
+                module_info[id].name.as_str(),
                 pretty_type_with_verbosity(
                     context.database,
                     constant_type.return_type(),
@@ -156,7 +157,7 @@ fn render_detail(
                 )
             )
         },
-        ModuleItem::Override(id) => {
+        ModuleItemId::Override(id) => {
             let override_id = context.database.intern_override(Location::new(file_id, id));
             let override_type = context
                 .database
@@ -165,7 +166,7 @@ fn render_detail(
             let module_info = context.database.item_tree(file_id);
             format!(
                 "override {}: {}",
-                module_info.get(id).name.as_str(),
+                module_info[id].name.as_str(),
                 pretty_type_with_verbosity(
                     context.database,
                     override_type.return_type(),
@@ -173,16 +174,16 @@ fn render_detail(
                 )
             )
         },
-        ModuleItem::TypeAlias(id) => {
+        ModuleItemId::TypeAlias(id) => {
             let module_info = context.database.item_tree(file_id);
-            format!("alias {}", module_info.get(id).name.as_str())
+            format!("alias {}", module_info[id].name.as_str())
         },
-        ModuleItem::GlobalAssertStatement(_) => {
+        ModuleItemId::GlobalAssertStatement(_) => {
             // const_asserts don't have a name or binding, and will probably never be autocompleted - or will their
             // details have to be rendered. We implement this anyways to achieve consistency.
             String::from("const_assert ...")
         },
-        ModuleItem::ImportStatement(_) => {
+        ModuleItemId::ImportStatement(_) => {
             // TODO: Support import statements somehow https://github.com/wgsl-analyzer/wgsl-analyzer/issues/632
             String::new()
         },

--- a/crates/test-utils/src/assert_linear.rs
+++ b/crates/test-utils/src/assert_linear.rs
@@ -85,7 +85,7 @@ impl Round {
             let mut num = 0.0;
             let mut denom = 0.0;
             for (x, y) in xy.clone() {
-                num += (x - mean_x) * (y - mean_y);
+                num = (x - mean_x).mul_add(y - mean_y, num);
                 denom += (x - mean_x).powi(2);
             }
             num / denom


### PR DESCRIPTION
# Objective

Remove `ModuleItemId` with a simpler approach

## Solution

Essentially do what https://github.com/rust-lang/rust-analyzer/pull/19982/ does

## Testing

The unit tests still pass

## Showcase

More lines removed than added :D