### PR TITLE
Reject AI slop in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -396,6 +396,7 @@ jobs:
   conclusion:
     needs:
       [
+        no-ai-commits,
         rust,
         # rust-cross,
         markdown,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect slop
         uses: Jondolf/ai-commit-check@888ad1ef25e2e79ddf5fbdaf0247b90b373eea55 # v1.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,17 @@ jobs:
             typescript:
               - 'editors/code/**'
 
+  no-ai-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect slop
+        uses: Jondolf/ai-commit-check@888ad1ef25e2e79ddf5fbdaf0247b90b373eea55 # v1.0.0
+
   rust:
     name: Rust
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# Objective

Prevent AI contributions from being accepted.

## Solution

Use an action that detects commits authored by known agents

## Testing

IDK
