### PR TITLE
pin docker image

### DIFF
--- a/.github/actions/github-release/Dockerfile
+++ b/.github/actions/github-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:24.16-slim@sha256:ca520832af80fa37a57c14077ed0fcdd83b5aefccc356059fdc3a9a05b78ae1f
 
 COPY . /action
 WORKDIR /action

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -44,3 +44,18 @@ updates:
       - S-Ready-to-Review
     cooldown:
       default-days: 7
+
+  - package-ecosystem: docker
+    directory: /.github
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: internal
+    labels:
+      - A-Editor
+      - C-Dependencies
+      - D-Trivial
+      - S-Ready-to-Review
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# Objective

Fix release workflow

## Solution

Same as https://github.com/rust-lang/rust-analyzer/pull/22624
Pin the docker image to a working version and to avoid mysterious regressions in the future.

## Testing

Proof that it builds:
```
 benjamin@pop-os  ~/source/rust-analyzer/.github/actions/github-release   pin-node-docker-image  docker build --platform linux/amd64 -t github-release-test .
[+] Building 6.5s (10/10) FINISHED                                                                                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                    0.1s
 => => transferring dockerfile: 234B                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/node:24.16-slim@sha256:ca520832af80fa37a57c14077ed0fcdd83b5aefccc356059fdc3a9a05b78ae1f                                                                                              0.9s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                       0.1s
 => => transferring context: 2B                                                                                                                                                                                                         0.0s
 => [internal] load build context                                                                                                                                                                                                       0.1s
 => => transferring context: 5.75kB                                                                                                                                                                                                     0.0s
 => [1/4] FROM docker.io/library/node:24.16-slim@sha256:ca520832af80fa37a57c14077ed0fcdd83b5aefccc356059fdc3a9a05b78ae1f                                                                                                                2.2s
 => => resolve docker.io/library/node:24.16-slim@sha256:ca520832af80fa37a57c14077ed0fcdd83b5aefccc356059fdc3a9a05b78ae1f                                                                                                                0.0s
 => => sha256:eaa9c9173c9ef8b20c039dc5bd3443296e12edea2c29f4fd1e54b632308b6ea2 447B / 447B                                                                                                                                              0.1s
 => => sha256:6ffbd68daabf04b8cd244120546fd8ce2dc53088120e9810aa9d27646741e8c0 1.71MB / 1.71MB                                                                                                                                          0.2s
 => => sha256:11ee7a52d8bb061de25e57356acc8c2019ce9d5e04b0e4a1e42a750c682849b3 50.09MB / 50.09MB                                                                                                                                        0.8s
 => => sha256:056cd437495d7fa167e67ad161e02a6b066b4da19b306de2de3a9c7f47825252 3.31kB / 3.31kB                                                                                                                                          0.3s
 => => sha256:b9136609bef0128191aa157637b98dd7b98e52154ca60c18258d65957a01c6d0 28.24MB / 28.24MB                                                                                                                                        0.9s
 => => extracting sha256:b9136609bef0128191aa157637b98dd7b98e52154ca60c18258d65957a01c6d0                                                                                                                                               0.4s
 => => extracting sha256:056cd437495d7fa167e67ad161e02a6b066b4da19b306de2de3a9c7f47825252                                                                                                                                               0.0s
 => => extracting sha256:11ee7a52d8bb061de25e57356acc8c2019ce9d5e04b0e4a1e42a750c682849b3                                                                                                                                               0.5s
 => => extracting sha256:6ffbd68daabf04b8cd244120546fd8ce2dc53088120e9810aa9d27646741e8c0                                                                                                                                               0.0s
 => => extracting sha256:eaa9c9173c9ef8b20c039dc5bd3443296e12edea2c29f4fd1e54b632308b6ea2                                                                                                                                               0.0s
 => [2/4] COPY . /action                                                                                                                                                                                                                0.1s
 => [3/4] WORKDIR /action                                                                                                                                                                                                               0.1s
 => [4/4] RUN npm install --production                                                                                                                                                                                                  1.9s
 => exporting to image                                                                                                                                                                                                                  0.9s
 => => exporting layers                                                                                                                                                                                                                 0.6s
 => => exporting manifest sha256:b2d053fca38fe07a24d3e7b34b00a2ab038d21f10faf290f24cb28e6b5c81509                                                                                                                                       0.0s
 => => exporting config sha256:6e955e246a0278da1e42bc6bc50b76629769b65b5100fd40e10ab3e42bf68f8d                                                                                                                                         0.0s
 => => exporting attestation manifest sha256:ff9f5363b31c416bad3e3ece43ba0ea65aa7f5f206045f7082d8628169c15ecd                                                                                                                           0.0s
 => => exporting manifest list sha256:c8af9b511de2e4d077cca776296ef018c33dd3efeb8bb58b14e425b90800c52d                                                                                                                                  0.0s
 => => naming to docker.io/library/github-release-test:latest                                                                                                                                                                           0.0s
 => => unpacking to docker.io/library/github-release-test:latest                                                                                                                                                                        0.2s
```
