### PR TITLE
Fix WGSL angle bracket scopes and add inline highlighting support for framework files

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -687,13 +687,24 @@
 				"injectTo": [
 					"source.js",
 					"source.ts",
+					"source.jsx",
+					"source.tsx",
+					"source.svelte",
+					"source.vue",
+					"source.astro",
 					"source.rust"
 				],
 				"scopeName": "source.comment-string.wgsl",
 				"path": "./syntaxes/inline-wgsl.tmLanguage.json",
 				"embeddedLanguages": {
 					"meta.embedded.block.wgsl": "wgsl"
-				}
+				},
+				"unbalancedBracketScopes": [
+					"keyword.operator.arrow.skinny.wgsl",
+					"keyword.operator.comparison.wgsl",
+					"keyword.operator.logical.wgsl",
+					"keyword.operator.assignment.wgsl"
+				]
 			},
 			{
 				"scopeName": "markdown.wgsl.codeblock",
@@ -715,13 +726,24 @@
 				"injectTo": [
 					"source.js",
 					"source.ts",
+					"source.jsx",
+					"source.tsx",
+					"source.svelte",
+					"source.vue",
+					"source.astro",
 					"source.rust"
 				],
 				"scopeName": "source.comment-string.wesl",
 				"path": "./syntaxes/inline-wesl.tmLanguage.json",
 				"embeddedLanguages": {
 					"meta.embedded.block.wesl": "wesl"
-				}
+				},
+				"unbalancedBracketScopes": [
+					"keyword.operator.arrow.skinny.wgsl",
+					"keyword.operator.comparison.wgsl",
+					"keyword.operator.logical.wgsl",
+					"keyword.operator.assignment.wgsl"
+				]
 			},
 			{
 				"scopeName": "markdown.wesl.codeblock",

--- a/editors/code/syntaxes/inline-wesl.tmLanguage.json
+++ b/editors/code/syntaxes/inline-wesl.tmLanguage.json
@@ -1,11 +1,12 @@
 {
 	"scopeName": "source.comment-string.wesl",
-	"fileTypes": ["js", "ts", "rs"],
+	"fileTypes": ["js", "ts", "jsx", "tsx", "svelte", "vue", "astro", "rs"],
 	"injectionSelector": "L:source -comment -string",
 	"patterns": [
 		{
 			"comment": "JavaScript multi-line strings",
 			"begin": "(\\s?/\\*\\s?(?i:wesl)\\s?\\*/\\s*)(`)",
+			"contentName": "meta.embedded.block.wesl",
 			"beginCaptures": {
 				"1": { "name": "entity.name.function.tagged-template.ts" },
 				"2": { "name": "string.template.ts, punctuation.definition.string.template.begin.ts" }
@@ -22,6 +23,7 @@
 		{
 			"comment": "Rust multi-line raw/byte strings",
 			"begin": "(\\s?/\\*\\s?(?i:wesl)\\s?\\*/\\s*)(b?r?)(#*)(\")",
+			"contentName": "meta.embedded.block.wesl",
 			"beginCaptures": {
 				"1": { "name": "entity.name.function.rust" },
 				"2": { "name": "string.quoted.byte.raw.rust" },
@@ -38,6 +40,7 @@
 		{
 			"comment": "Standard strings",
 			"begin": "(\\s?/\\*\\s?(?i:wesl)\\s?\\*/\\s*)(\")",
+			"contentName": "meta.embedded.block.wesl",
 			"beginCaptures": { "1": { "name": "entity.name.function" } },
 			"end": "(\")",
 			"patterns": [{ "include": "source.wesl" }]

--- a/editors/code/syntaxes/inline-wgsl.tmLanguage.json
+++ b/editors/code/syntaxes/inline-wgsl.tmLanguage.json
@@ -1,11 +1,12 @@
 {
 	"scopeName": "source.comment-string.wgsl",
-	"fileTypes": ["js", "ts", "rs"],
+	"fileTypes": ["js", "ts", "jsx", "tsx", "svelte", "vue", "astro", "rs"],
 	"injectionSelector": "L:source -comment -string",
 	"patterns": [
 		{
 			"comment": "JavaScript multi-line strings",
 			"begin": "(\\s?/\\*\\s?(?i:wgsl)\\s?\\*/\\s*)(`)",
+			"contentName": "meta.embedded.block.wgsl",
 			"beginCaptures": {
 				"1": { "name": "entity.name.function.tagged-template.ts" },
 				"2": { "name": "string.template.ts, punctuation.definition.string.template.begin.ts" }
@@ -22,6 +23,7 @@
 		{
 			"comment": "Rust multi-line raw/byte strings",
 			"begin": "(\\s?/\\*\\s?(?i:wgsl)\\s?\\*/\\s*)(b?r?)(#*)(\")",
+			"contentName": "meta.embedded.block.wgsl",
 			"beginCaptures": {
 				"1": { "name": "entity.name.function.rust" },
 				"2": { "name": "string.quoted.byte.raw.rust" },
@@ -38,6 +40,7 @@
 		{
 			"comment": "Standard strings",
 			"begin": "(\\s?/\\*\\s?(?i:wgsl)\\s?\\*/\\s*)(\")",
+			"contentName": "meta.embedded.block.wgsl",
 			"beginCaptures": { "1": { "name": "entity.name.function" } },
 			"end": "(\")",
 			"patterns": [{ "include": "source.wgsl" }]

--- a/editors/code/syntaxes/wgsl.tmLanguage.json
+++ b/editors/code/syntaxes/wgsl.tmLanguage.json
@@ -71,11 +71,13 @@
 				{
 					"comment": "function/method calls with best effort generics",
 					"name": "meta.function.wgsl",
-					"begin": "([_$[:alpha:]][_$[:alnum:]]*)\\s*(<[^|&()]+>)?(\\()",
+					"begin": "([_$[:alpha:]][_$[:alnum:]]*)\\s*(?:(<)([^|&()]+)(>))?(\\()",
 					"beginCaptures": {
 						"1": { "name": "entity.name.function.wgsl" },
-						"2": { "patterns": [{ "include": "#function_arguments" }] },
-						"3": { "name": "punctuation.brackets.round.wgsl" }
+						"2": { "name": "punctuation.brackets.angle.wgsl" },
+						"3": { "patterns": [{ "include": "#function_arguments" }] },
+						"4": { "name": "punctuation.brackets.angle.wgsl" },
+						"5": { "name": "punctuation.brackets.round.wgsl" }
 					},
 					"end": "\\)",
 					"endCaptures": { "0": { "name": "punctuation.brackets.round.wgsl" } },
@@ -114,10 +116,25 @@
 		},
 		"types": {
 			"patterns": [
+				{ "include": "#template_types" },
 				{ "include": "#plain_types" },
 				{ "include": "#memory_views" },
 				{ "include": "#texture_and_sampler_types" }
 			]
+		},
+		"template_types": {
+			"comment": "types with template arguments",
+			"name": "meta.type.template.wgsl",
+			"begin": "\\b(array|atomic|ptr|vec[2-4]|mat[2-4]x[2-4]|texture_storage_(?:1d|2d|2d_array|3d))\\s*(<)",
+			"beginCaptures": {
+				"1": { "name": "storage.type.wgsl" },
+				"2": { "name": "punctuation.brackets.angle.wgsl" }
+			},
+			"end": ">",
+			"endCaptures": {
+				"0": { "name": "punctuation.brackets.angle.wgsl" }
+			},
+			"patterns": [{ "include": "#function_arguments" }]
 		},
 		"plain_types": {
 			"comment": "types: https://www.w3.org/TR/WGSL/#types",
@@ -263,11 +280,6 @@
 					"comment": "square brackets",
 					"name": "punctuation.brackets.square.wgsl",
 					"match": "[\\[\\]]"
-				},
-				{
-					"comment": "angle brackets",
-					"name": "punctuation.brackets.angle.wgsl",
-					"match": "(?<!=)[<>]"
 				}
 			]
 		},
@@ -321,7 +333,7 @@
 				{
 					"comment": "comparison operators",
 					"name": "keyword.operator.comparison.wgsl",
-					"match": "(=(=)?(?!>)|!=|<=|(?<!=)>=)"
+					"match": "(==|!=|<=|>=|<|>)"
 				},
 				{
 					"comment": "math operators",


### PR DESCRIPTION
# Objective

Fix WGSL angle/arrows operators being treated as colorized brackets, and expand inline WGSL/WESL highlighting to common JS framework files such as Svelte, JSX, TSX, Vue, and Astro.

Previously, inline shader highlighting was limited to a hard-coded set of host file types and could not be extended without patching the extension.

## Solution

Expanded inline WGSL/WESL grammar injection targets and file types to include JSX, TSX, Svelte, Vue, and Astro.

Marked inline shader contents as embedded WGSL/WESL so VS Code applies the correct language context.

Changed WGSL angle bracket scoping so `<` and `>` are operators by default, while actual template/type delimiters still receive angle bracket punctuation in template-like contexts.

Previously with vscode and colorized brackets enabled, within template literals `<` and `>` could be highlighted as open brackets

<img width="450" height="586" alt="Screenshot 2026-06-30 002842" src="https://github.com/user-attachments/assets/1d6990bc-2884-4f4f-bd63-b1e4f9a82b40" />

## Testing

- Built the VS Code extension with `pnpm.cmd --dir editors/code run build`.
- Packaged and manually tested a bundled `win32-x64` VSIX in VS Code on Windows.
- Verified inline WGSL highlighting in Svelte template literals.
- Verified WGSL angle/arrows operators are no longer treated as colorized brackets.