### PR TITLE
Add support for region markers

### DIFF
--- a/crates/ide/src/folding_ranges.rs
+++ b/crates/ide/src/folding_ranges.rs
@@ -11,15 +11,33 @@ use syntax::{
     match_ast,
 };
 
-const REGION_STARTS: &[&str] = &["// region:", "//#region", "// #region"];
-const REGION_ENDS: &[&str] = &["// endregion", "//#endregion", "// #endregion"];
-
 fn is_region_start(text: &str) -> bool {
-    REGION_STARTS.iter().any(|marker| text.starts_with(marker))
+    is_region_marker(text, "region")
 }
 
 fn is_region_end(text: &str) -> bool {
-    REGION_ENDS.iter().any(|marker| text.starts_with(marker))
+    is_region_marker(text, "endregion")
+}
+
+fn is_region_marker(
+    text: &str,
+    marker: &str,
+) -> bool {
+    let text = text.trim_start();
+    let text = if let Some(text) = text.strip_prefix("//") {
+        text
+    } else if let Some(text) = text.strip_prefix("/*") {
+        text
+    } else {
+        return false;
+    };
+
+    let text = text.trim_start();
+    let text = text.strip_suffix("*/").map(str::trim_end).unwrap_or(text);
+    let text = text.strip_prefix('#').map(str::trim_start).unwrap_or(text);
+    text.strip_prefix(marker).is_some_and(|rest| {
+        rest.is_empty() || rest.starts_with(':') || rest.starts_with(char::is_whitespace)
+    })
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/ide/src/folding_ranges.rs
+++ b/crates/ide/src/folding_ranges.rs
@@ -11,8 +11,16 @@ use syntax::{
     match_ast,
 };
 
-const REGION_START: &str = "// region:";
-const REGION_END: &str = "// endregion";
+const REGION_STARTS: &[&str] = &["// region:", "//#region", "// #region"];
+const REGION_ENDS: &[&str] = &["// endregion", "//#endregion", "// #endregion"];
+
+fn is_region_start(text: &str) -> bool {
+    REGION_STARTS.iter().any(|marker| text.starts_with(marker))
+}
+
+fn is_region_end(text: &str) -> bool {
+    REGION_ENDS.iter().any(|marker| text.starts_with(marker))
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum FoldKind {
@@ -98,9 +106,9 @@ pub(crate) fn folding_ranges(file: &SourceFile) -> Vec<Fold> {
                         continue;
                     }
                     let text = comment.text().trim_start();
-                    if text.starts_with(REGION_START) {
+                    if is_region_start(text) {
                         region_starts.push(comment.syntax().text_range().start());
-                    } else if text.starts_with(REGION_END) {
+                    } else if is_region_end(text) {
                         if let Some(region) = region_starts.pop() {
                             result.push(Fold {
                                 range: TextRange::new(region, comment.syntax().text_range().end()),
@@ -249,7 +257,7 @@ fn contiguous_range_for_comment(
                 {
                     let text = comment.text().trim_start();
                     // regions are not real comments
-                    if !(text.starts_with(REGION_START) || text.starts_with(REGION_END)) {
+                    if !(is_region_start(text) || is_region_end(text)) {
                         visited.insert(comment.clone());
                         last = comment;
                         continue;

--- a/crates/ide/src/folding_ranges.rs
+++ b/crates/ide/src/folding_ranges.rs
@@ -33,8 +33,8 @@ fn is_region_marker(
     };
 
     let text = text.trim_start();
-    let text = text.strip_suffix("*/").map(str::trim_end).unwrap_or(text);
-    let text = text.strip_prefix('#').map(str::trim_start).unwrap_or(text);
+    let text = text.strip_suffix("*/").map_or(text, str::trim_end);
+    let text = text.strip_prefix('#').map_or(text, str::trim_start);
     text.strip_prefix(marker).is_some_and(|rest| {
         rest.is_empty() || rest.starts_with(':') || rest.starts_with(char::is_whitespace)
     })

--- a/docs/book/src/editor_features.md
+++ b/docs/book/src/editor_features.md
@@ -1,5 +1,19 @@
 # Editor Features
 
+## Folding regions
+
+You can use folding regions with comment syntax such as:
+
+```wgsl
+// region: Setup
+// ...
+// endregion
+
+// #region Update
+// ...
+// #endregion
+```
+
 ## VS Code
 
 ### Color configurations
@@ -49,7 +63,7 @@ This also works for Markdown fenced code blocks:
 We do not expect the WGSL string within the Rust string within this literal
 Markdown document to have WGSL syntax highlighting.
 -->
-<!-- 
+<!--
 ### Semantic style customizations
 
 You can customize the look of different semantic elements in the source code.

--- a/docs/book/src/editor_features.md
+++ b/docs/book/src/editor_features.md
@@ -5,13 +5,9 @@
 You can use folding regions with comment syntax such as:
 
 ```wgsl
-// region: Setup
+// region: Update
 // ...
 // endregion
-
-// #region Update
-// ...
-// #endregion
 ```
 
 ## VS Code

--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -59,8 +59,8 @@
 	},
 	"folding": {
 		"markers": {
-			"start": "^\\s*(?://\\s*#region\\b|/\\*\\s*#region\\b|#ifn?def\\b)",
-			"end": "^\\s*(?://\\s*#endregion\\b|/\\*\\s*#endregion\\b|#endif\\b)"
+			"start": "^\\s*(?://(?:\\s*#region\\b|\\s+region\\b:?)|#ifn?def\\b)",
+			"end": "^\\s*(?://(?:\\s*#endregion\\b|\\s+endregion\\b:?)|#endif\\b)"
 		}
 	}
 }

--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -59,8 +59,8 @@
 	},
 	"folding": {
 		"markers": {
-			"start": "^\\s*#ifn?def\\b",
-			"end": "^\\s*#endif\\b"
+			"start": "^\\s*(?://\\s*#region\\b|/\\*\\s*#region\\b|#ifn?def\\b)",
+			"end": "^\\s*(?://\\s*#endregion\\b|/\\*\\s*#endregion\\b|#endif\\b)"
 		}
 	}
 }

--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -57,10 +57,13 @@
 		"increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$",
 		"decreaseIndentPattern": "^\\s*(\\s*\\/[*].*[*]\\/\\s*)*[})]"
 	},
+	/* Folding range regex is needed here
+	for vscode to display region marker
+	labels in the minimap */
 	"folding": {
 		"markers": {
-			"start": "^\\s*(?://(?:\\s*#region\\b|\\s+region\\b:?)|#ifn?def\\b)",
-			"end": "^\\s*(?://(?:\\s*#endregion\\b|\\s+endregion\\b:?)|#endif\\b)"
+			"start": "^\\s*(?://\\s*#?\\s*region\\b:?\\s*|/\\*\\s*#?\\s*region\\b:?\\s*|#ifn?def\\b)",
+			"end": "^\\s*(?://\\s*#?\\s*endregion\\b:?\\s*|/\\*\\s*#?\\s*endregion\\b:?\\s*\\*/|#endif\\b)"
 		}
 	}
 }

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"icon": "icon.png",
 	"version": "0.13.0-dev",
-	"releaseTag": null,
+	"releaseTag": "nightly",
 	"publisher": "wgsl-analyzer",
 	"type": "commonjs",
 	"repository": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"icon": "icon.png",
 	"version": "0.13.0-dev",
-	"releaseTag": "nightly",
+	"releaseTag": null,
 	"publisher": "wgsl-analyzer",
 	"type": "commonjs",
 	"repository": {


### PR DESCRIPTION
Fixes https://github.com/wgsl-analyzer/wgsl-analyzer/issues/964

# Objective

Adds suport in `.wgsl`/`.wesl` files for region markers via `//#region` `/* #region */`

## Solution

Changed language-configuration.json to support folding markers for
```
//#region xyz
...
//#endregion
``` 
& 
```
/* #region xyz */ 
...
/* #endregion */
``` 

## Testing

- Built the VS Code extension with pnpm.cmd --dir editors/code run build.
- Packaged and manually tested a bundled win32-x64 VSIX in VS Code on Windows.
- Verified Region markers receive proper code folding range and have minimap marker show up with title

Note whilst regions work the same for /* #region xyz */ syntax, the minimap marker label includes the */ e.g. `xyz */` i found no simple way around this but otherwise it works fine

## Showcase

<img width="418" height="100" alt="image" src="https://github.com/user-attachments/assets/91e207b9-c496-42a5-8cbe-1e26da649001" />
<img width="130" height="91" alt="image" src="https://github.com/user-attachments/assets/e9f535e6-9494-4f68-b7f0-3453e9ac3e0d" />

