### PR TITLE
Add inline highlighting support to .mdx files

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -710,7 +710,8 @@
 				"scopeName": "markdown.wgsl.codeblock",
 				"path": "./syntaxes/inline-wgsl.markdown.tmLanguage.json",
 				"injectTo": [
-					"text.html.markdown"
+					"text.html.markdown",
+					"source.mdx"
 				],
 				"embeddedLanguages": {
 					"meta.embedded.block.wgsl": "wgsl"
@@ -749,7 +750,8 @@
 				"scopeName": "markdown.wesl.codeblock",
 				"path": "./syntaxes/inline-wesl.markdown.tmLanguage.json",
 				"injectTo": [
-					"text.html.markdown"
+					"text.html.markdown",
+					"source.mdx"
 				],
 				"embeddedLanguages": {
 					"meta.embedded.block.wesl": "wesl"

--- a/editors/code/syntaxes/inline-wesl.markdown.tmLanguage.json
+++ b/editors/code/syntaxes/inline-wesl.markdown.tmLanguage.json
@@ -1,7 +1,7 @@
 {
 	"scopeName": "markdown.wesl.codeblock",
-	"fileTypes": ["md"],
-	"injectionSelector": "L:text.html.markdown",
+	"fileTypes": ["md", "mdx"],
+	"injectionSelector": "L:text.html.markdown, L:source.mdx",
 	"patterns": [{ "include": "#fenced_code_block_wesl" }],
 	"repository": {
 		"fenced_code_block_wesl": {

--- a/editors/code/syntaxes/inline-wgsl.markdown.tmLanguage.json
+++ b/editors/code/syntaxes/inline-wgsl.markdown.tmLanguage.json
@@ -1,7 +1,7 @@
 {
 	"scopeName": "markdown.wgsl.codeblock",
-	"fileTypes": ["md"],
-	"injectionSelector": "L:text.html.markdown",
+	"fileTypes": ["md", "mdx"],
+	"injectionSelector": "L:text.html.markdown, L:source.mdx",
 	"patterns": [{ "include": "#fenced_code_block_wgsl" }],
 	"repository": {
 		"fenced_code_block_wgsl": {


### PR DESCRIPTION
# Objective

Currently inline syntax highlighting support for markdown files only supports `.md` files, this PR expands this to also include `.mdx` files.

## Solution

Updates `markdown.tmLanguage.json` files to support `.mdx` files and inject to `source.mdx`

## Testing

- Built the VS Code extension with pnpm.cmd --dir editors/code run build.
- Packaged and manually tested a bundled win32-x64 VSIX in VS Code on Windows.
- Verified wgsl / wesl code blocks now get inline highlighting in `.mdx` files.

## Showcase

<img width="310" height="160" alt="image" src="https://github.com/user-attachments/assets/659ef035-bec9-4377-a16d-4afb3c136214" />
