### PR TITLE
add typescript to CodeQL matrix

### DIFF
--- a/.github/workflows/security-static-analysis.yaml
+++ b/.github/workflows/security-static-analysis.yaml
@@ -34,6 +34,8 @@ jobs:
             build-mode: none
           - language: rust
             build-mode: none
+          - language: typescript
+            build-mode: none
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
# Objective

Address a security notice for the repo

## Solution

Add typescript to the matrix for CodeQL. The last scan was February 5 probably before we switched to defining the workflow manually.

## Testing

Tested simply by having it run in this PR.

## Showcase
<img width="2544" height="842" alt="image" src="https://github.com/user-attachments/assets/d1192c48-b50e-4fc6-b2cc-942e250b5815" />
