### PR TITLE
Group codeql-action actions in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -29,6 +29,10 @@ updates:
       - S-Ready-to-Review
     cooldown:
       default-days: 7
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: npm
     directory: /editors/code

--- a/.github/workflows/security-static-analysis.yaml
+++ b/.github/workflows/security-static-analysis.yaml
@@ -44,7 +44,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/security-static-analysis.yaml
+++ b/.github/workflows/security-static-analysis.yaml
@@ -72,7 +72,7 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{matrix.language}}"
 


### PR DESCRIPTION
# Objective

Dependabot can successfully bump these dependencies.
#1291 and #1290 both fails because they need to be together.

## Solution

Create a group.

## Testing

TODO
