### PR TITLE
Publish workspace crates to crates.io

### DIFF
--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -9,6 +9,8 @@ on:
     branches:
       - release
 
+permissions: {}
+
 jobs:
   publish:
     if: ${{ github.repository == 'wgsl-analyzer/wgsl-analyzer' || github.event_name == 'workflow_dispatch' }}
@@ -16,9 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # https://github.com/jlumbroso/free-disk-space/blob/main/action.yml
       - name: Free up some disk space

--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -1,0 +1,69 @@
+name: autopublish
+on:
+  workflow_dispatch: # We can add version input when 1.0 is released and scheduled releases are removed
+
+  #   schedule:
+  #     - cron: "0 0 * * *" # midnight UTC
+
+  push:
+    branches:
+      - release
+
+jobs:
+  publish:
+    if: ${{ github.repository == 'wgsl-analyzer/wgsl-analyzer' || github.event_name == 'workflow_dispatch' }}
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # https://github.com/jlumbroso/free-disk-space/blob/main/action.yml
+      - name: Free up some disk space
+        run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup
+
+      - name: Install Rust toolchain
+        run: rustup update --no-self-update stable
+
+      - name: Install cargo-workspaces
+        run: cargo install cargo-workspaces --version "0.3.6" # TODO update to 0.4.2
+
+      - name: Publish Crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          RUN_NUMBER: ${{ github.run_number }}
+        shell: bash
+        run: |
+          git config --global user.email "runner@gha.local"
+          git config --global user.name "GitHub Action"
+          rm Cargo.lock
+          # Rename subcrates with "too generic" names
+          cargo workspaces rename --from base_db wgsl-analyzer-base-db
+          cargo workspaces rename --from edition wgsl-analyzer-edition
+          cargo workspaces rename --from hir wgsl-analyzer-hir
+          cargo workspaces rename --from hir_def wgsl-analyzer-hir-def
+          cargo workspaces rename --from hir_ty wgsl-analyzer-hir-ty
+          cargo workspaces rename --from ide wgsl-analyzer-ide
+          cargo workspaces rename --from ide_completion wgsl-analyzer-ide-completion
+          cargo workspaces rename --from ide-db wgsl-analyzer-ide-db
+          cargo workspaces rename --from ide-diagnostics wgsl-analyzer-ide-diagnostics
+          cargo workspaces rename --from parser wgsl-analyzer-parser
+          cargo workspaces rename --from profile wgsl-analyzer-profile
+          cargo workspaces rename --from project-model wgsl-analyzer-project-model
+          cargo workspaces rename --from syntax wgsl-analyzer-syntax
+          cargo workspaces rename --from test-fixture wgsl-analyzer-test-fixture
+          cargo workspaces rename --from test-utils wgsl-analyzer-test-utils
+          cargo workspaces rename --from toolchain wgsl-analyzer-toolchain
+          cargo workspaces rename --from vfs wgsl-analyzer-vfs
+          cargo workspaces rename --from vfs-notify wgsl-analyzer-vfs-notify
+          cargo workspaces rename --from wgsl_formatter wgsl-formatter
+          # cargo workspaces rename --from wgsl-analyzer wgsl-analyzer
+          # cargo workspaces rename --from wgslfmt wgslfmt
+          cargo workspaces rename --from wgslfmt_dprint wgslfmt-dprint
+          # Remove library crates and xtask from the workspaces so we don't auto-publish them as well
+          sed -i -Ez 's|members = \[[^]]*\]|members = ["crates/*"]|' Cargo.toml
+          cargo workspaces rename wa-ap-%n
+          find crates/wgsl-analyzer -type f -name '*.rs' -exec sed -i 's/wgsl_analyzer/wa_ap_wgsl_analyzer/g' {} +
+          cargo workspaces publish --yes --force '*' --exact --no-git-commit --allow-dirty --skip-published custom 0.0.$($RUN_NUMBER)

--- a/docs/book/src/installation.md
+++ b/docs/book/src/installation.md
@@ -5,4 +5,12 @@ To use `wgsl-analyzer`, you need a `wgsl-analyzer` binary and a text editor that
 If you are [using VS Code](./vs_code.md), the extension bundles a copy of the `wgsl-analyzer` binary.
 For other editors, you will need to [install the binary](./wgsl-analyzer_binary.md) and [configure your editor](./other_editors.md).
 
+## Crates
+
+There is a package named `wa-ap-wgsl-analyzer` available on [crates.io] for people who want to use `wgsl-analyzer` programmatically.
+
+For more details, see [the publish workflow].
+
 [LSP]: <https://microsoft.github.io/language-server-protocol>
+[crates.io]: <https://crates.io/crates/wa-ap-wgsl-analyzer>
+[the publish workflow]: <https://github.com/wgsl-analyzer/wgsl-analyzer/blob/main/.github/workflows/autopublish.yaml>


### PR DESCRIPTION
# Objective

Fixes #1348

## Solution

Port from rust-analyzer's [autopublish workflow](https://github.com/rust-lang/rust-analyzer/blob/master/.github/workflows/autopublish.yaml).

Changes:
- Changed sed command to work with multiline TOML array.
- Changed list of crates for our current workspace.
- Use wa and wgsl instead of ra and rust

## Testing

TODO

## Showcase
