### PR TITLE
Conditional transpilation attributes with flattened scope semantics + global compound statements

### DIFF
--- a/.github/workflows/dependabot-autofix.yaml
+++ b/.github/workflows/dependabot-autofix.yaml
@@ -52,24 +52,37 @@ jobs:
           key: pnpm-${{ runner.os }}-${{ hashFiles('editors/code/pnpm-lock.yaml') }}
           restore-keys: pnpm-${{ runner.os }}-
 
-      - name: Read current @types/vscode version
-        id: types-version
+      - name: Read versions and check if update is needed
+        id: versions
         run: |
-          VERSION=$(node -p "require('./editors/code/package.json').devDependencies?.['@types/vscode']")
-          echo "Found version: $VERSION"
-          CLEANED=$(echo "$VERSION" | sed -E 's/^[^0-9]*//') # remove ^, ~, etc.
-          echo "version=$CLEANED" >> "$GITHUB_OUTPUT"
+          TYPES_VERSION=$(node -p "require('./editors/code/package.json').devDependencies?.['@types/vscode']")
+          TYPES_CLEANED=$(echo "$TYPES_VERSION" | sed -E 's/^[^0-9]*//')
+          echo "types-version=$TYPES_CLEANED" >> "$GITHUB_OUTPUT"
+
+          ENGINES_VERSION=$(node -p "require('./editors/code/package.json').engines?.vscode ?? ''")
+          ENGINES_CLEANED=$(echo "$ENGINES_VERSION" | sed -E 's/^[^0-9]*//')
+          echo "engines-version=$ENGINES_CLEANED" >> "$GITHUB_OUTPUT"
+
+          if [ "$TYPES_CLEANED" = "$ENGINES_CLEANED" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "engines.vscode ($ENGINES_CLEANED) already matches @types/vscode ($TYPES_CLEANED), skipping."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "engines.vscode ($ENGINES_CLEANED) → @types/vscode ($TYPES_CLEANED), will update."
+          fi
 
       - name: Update engines.vscode
+        if: steps.versions.outputs.changed == 'true'
         run: |
           pnpm dlx json -I -f ./editors/code/package.json \
-            -e "this.engines = this.engines || {}; this.engines.vscode = '^${STEPS_TYPES_VERSION_OUTPUTS_VERSION}'"
+            -e "this.engines = this.engines || {}; this.engines.vscode = '^${TYPES_VERSION}'"
           pnpm --dir editors/code install --frozen-lockfile
           pnpm --dir editors/code run format
         env:
-          STEPS_TYPES_VERSION_OUTPUTS_VERSION: ${{ steps.types-version.outputs.version }}
+          TYPES_VERSION: ${{ steps.versions.outputs.types-version }}
 
       - name: Commit and push updated engines.vscode
+        if: steps.versions.outputs.changed == 'true'
         run: |
           if git diff --quiet; then
             echo "No changes to commit."
@@ -79,7 +92,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "chore: align engines.vscode with types/vscode@${STEPS_TYPES_VERSION_OUTPUTS_VERSION}"
+          git commit -m "chore: align engines.vscode with types/vscode@${TYPES_VERSION}"
           git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:${GITHUB_HEAD_REF}
         env:
-          STEPS_TYPES_VERSION_OUTPUTS_VERSION: ${{ steps.types-version.outputs.version }}
+          TYPES_VERSION: ${{ steps.versions.outputs.types-version }}

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -80,74 +80,84 @@ impl<'db> Semantics<'db> {
             .find_map(|syntax| -> Option<ChildContainer> {
                 let item = ast::Item::cast(syntax)?;
                 let is_in_body = is_node_in_body(source, &item);
-
-                let container: ChildContainer = match item {
-                    ast::Item::ImportStatement(import) => {
-                        let definition = self.import_to_def(&InFile::new(file_id, import))?;
-                        ChildContainer::ImportId(definition)
-                    },
-                    ast::Item::FunctionDeclaration(function_declaration) => {
-                        let definition =
-                            self.function_to_def(&InFile::new(file_id, function_declaration))?;
-                        if is_in_body {
-                            DefinitionWithBodyId::Function(definition).into()
-                        } else {
-                            ChildContainer::FunctionId(definition)
-                        }
-                    },
-                    ast::Item::VariableDeclaration(variable_declaration) => {
-                        let definition = self
-                            .global_variable_to_def(&InFile::new(file_id, variable_declaration))?;
-                        if is_in_body {
-                            DefinitionWithBodyId::GlobalVariable(definition).into()
-                        } else {
-                            ChildContainer::GlobalVariableId(definition)
-                        }
-                    },
-                    ast::Item::ConstantDeclaration(constant_declaration) => {
-                        let definition = self
-                            .global_constant_to_def(&InFile::new(file_id, constant_declaration))?;
-                        if is_in_body {
-                            DefinitionWithBodyId::GlobalConstant(definition).into()
-                        } else {
-                            ChildContainer::GlobalConstantId(definition)
-                        }
-                    },
-                    ast::Item::OverrideDeclaration(override_declaration) => {
-                        let definition = self
-                            .global_override_to_def(&InFile::new(file_id, override_declaration))?;
-                        if is_in_body {
-                            DefinitionWithBodyId::Override(definition).into()
-                        } else {
-                            ChildContainer::OverrideId(definition)
-                        }
-                    },
-                    ast::Item::TypeAliasDeclaration(type_alias_declaration) => {
-                        let definition = self.global_type_alias_to_def(&InFile::new(
-                            file_id,
-                            type_alias_declaration,
-                        ))?;
-                        ChildContainer::TypeAliasId(definition)
-                    },
-                    ast::Item::StructDeclaration(struct_declaration) => {
-                        let definition =
-                            self.global_struct_to_def(&InFile::new(file_id, struct_declaration))?;
-                        ChildContainer::StructId(definition)
-                    },
-                    ast::Item::AssertStatement(assert_statement) => {
-                        let definition = self.global_assert_statement_to_def(&InFile::new(
-                            file_id,
-                            assert_statement,
-                        ))?;
-                        if is_in_body {
-                            DefinitionWithBodyId::GlobalAssertStatement(definition).into()
-                        } else {
-                            ChildContainer::GlobalAssertStatementId(definition)
-                        }
-                    },
-                };
+                let container = self.item_to_container(file_id, item, is_in_body)?;
                 Some(container)
             })
+    }
+
+    fn item_to_container(
+        &self,
+        file_id: EditionedFileId,
+        item: ast::Item,
+        is_in_body: bool,
+    ) -> Option<ChildContainer> {
+        let child_container = match item {
+            ast::Item::ImportStatement(import) => {
+                let definition = self.import_to_def(&InFile::new(file_id, import))?;
+                ChildContainer::ImportId(definition)
+            },
+            ast::Item::FunctionDeclaration(function_declaration) => {
+                let definition =
+                    self.function_to_def(&InFile::new(file_id, function_declaration))?;
+                if is_in_body {
+                    DefinitionWithBodyId::Function(definition).into()
+                } else {
+                    ChildContainer::FunctionId(definition)
+                }
+            },
+            ast::Item::VariableDeclaration(variable_declaration) => {
+                let definition =
+                    self.global_variable_to_def(&InFile::new(file_id, variable_declaration))?;
+                if is_in_body {
+                    DefinitionWithBodyId::GlobalVariable(definition).into()
+                } else {
+                    ChildContainer::GlobalVariableId(definition)
+                }
+            },
+            ast::Item::ConstantDeclaration(constant_declaration) => {
+                let definition =
+                    self.global_constant_to_def(&InFile::new(file_id, constant_declaration))?;
+                if is_in_body {
+                    DefinitionWithBodyId::GlobalConstant(definition).into()
+                } else {
+                    ChildContainer::GlobalConstantId(definition)
+                }
+            },
+            ast::Item::OverrideDeclaration(override_declaration) => {
+                let definition =
+                    self.global_override_to_def(&InFile::new(file_id, override_declaration))?;
+                if is_in_body {
+                    DefinitionWithBodyId::Override(definition).into()
+                } else {
+                    ChildContainer::OverrideId(definition)
+                }
+            },
+            ast::Item::TypeAliasDeclaration(type_alias_declaration) => {
+                let definition =
+                    self.global_type_alias_to_def(&InFile::new(file_id, type_alias_declaration))?;
+                ChildContainer::TypeAliasId(definition)
+            },
+            ast::Item::StructDeclaration(struct_declaration) => {
+                let definition =
+                    self.global_struct_to_def(&InFile::new(file_id, struct_declaration))?;
+                ChildContainer::StructId(definition)
+            },
+            ast::Item::AssertStatement(assert_statement) => {
+                let definition =
+                    self.global_assert_statement_to_def(&InFile::new(file_id, assert_statement))?;
+                if is_in_body {
+                    DefinitionWithBodyId::GlobalAssertStatement(definition).into()
+                } else {
+                    ChildContainer::GlobalAssertStatementId(definition)
+                }
+            },
+            ast::Item::GlobalCompoundDeclaration(global_compound_declaration) => {
+                global_compound_declaration
+                    .items()
+                    .find_map(|item| self.item_to_container(file_id, item, is_in_body))?
+            },
+        };
+        Some(child_container)
     }
 
     #[must_use]
@@ -286,49 +296,36 @@ fn is_node_in_body(
     node: &SyntaxNode,
     item: &ast::Item,
 ) -> bool {
+    let child_offset = node.text_range().start();
     match item {
-        ast::Item::FunctionDeclaration(function_declaration) => {
-            let child_offset = node.text_range().start();
-
-            function_declaration
-                .body()
-                .is_some_and(|compound_statement| {
-                    compound_statement
-                        .syntax()
-                        .text_range()
-                        .contains(child_offset)
-                })
-        },
-        ast::Item::VariableDeclaration(variable_declaration) => {
-            let child_offset = node.text_range().start();
-
-            variable_declaration
-                .init()
-                .is_some_and(|expression| expression.syntax().text_range().contains(child_offset))
-        },
-        ast::Item::ConstantDeclaration(constant_declaration) => {
-            let child_offset = node.text_range().start();
-
-            constant_declaration
-                .init()
-                .is_some_and(|expression| expression.syntax().text_range().contains(child_offset))
-        },
-        ast::Item::OverrideDeclaration(override_declaration) => {
-            let child_offset = node.text_range().start();
-
-            override_declaration
-                .init()
-                .is_some_and(|expression| expression.syntax().text_range().contains(child_offset))
-        },
-        ast::Item::AssertStatement(assert_statement) => {
-            let child_offset = node.text_range().start();
-            assert_statement
-                .expression()
-                .is_some_and(|expression| expression.syntax().text_range().contains(child_offset))
-        },
+        ast::Item::FunctionDeclaration(function_declaration) => function_declaration
+            .body()
+            .is_some_and(|compound_statement| {
+                compound_statement
+                    .syntax()
+                    .text_range()
+                    .contains(child_offset)
+            }),
+        ast::Item::VariableDeclaration(variable_declaration) => variable_declaration
+            .init()
+            .is_some_and(|expression| expression.syntax().text_range().contains(child_offset)),
+        ast::Item::ConstantDeclaration(constant_declaration) => constant_declaration
+            .init()
+            .is_some_and(|expression| expression.syntax().text_range().contains(child_offset)),
+        ast::Item::OverrideDeclaration(override_declaration) => override_declaration
+            .init()
+            .is_some_and(|expression| expression.syntax().text_range().contains(child_offset)),
+        ast::Item::AssertStatement(assert_statement) => assert_statement
+            .expression()
+            .is_some_and(|expression| expression.syntax().text_range().contains(child_offset)),
         ast::Item::ImportStatement(_)
         | ast::Item::TypeAliasDeclaration(_)
         | ast::Item::StructDeclaration(_) => false,
+        ast::Item::GlobalCompoundDeclaration(global_compound_declaration) => {
+            global_compound_declaration
+                .items()
+                .any(|item| is_node_in_body(node, &item))
+        },
     }
 }
 

--- a/crates/hir_def/src/ast_id.rs
+++ b/crates/hir_def/src/ast_id.rs
@@ -33,6 +33,7 @@ impl AstIdMap {
             .syntax()
             .children()
             .filter_map(ast::Item::cast)
+            .flat_map(ast::Item::flatten_global_compound_declarations)
             .for_each(|item| {
                 map.alloc(item.syntax());
             });

--- a/crates/hir_def/src/attributes.rs
+++ b/crates/hir_def/src/attributes.rs
@@ -24,13 +24,6 @@ pub struct Attribute {
     pub parameters: Vec<ExpressionId>,
 }
 
-impl Attribute {
-    #[must_use]
-    pub fn is_conditional_compilation(&self) -> bool {
-        matches!(self.name.as_str(), "if" | "elif" | "else")
-    }
-}
-
 // for example, @group(0) @location(0)
 #[derive(PartialEq, Eq, Debug)]
 pub struct AttributeList {

--- a/crates/hir_def/src/attributes.rs
+++ b/crates/hir_def/src/attributes.rs
@@ -24,6 +24,13 @@ pub struct Attribute {
     pub parameters: Vec<ExpressionId>,
 }
 
+impl Attribute {
+    #[must_use]
+    pub fn is_conditional_compilation(&self) -> bool {
+        matches!(self.name.as_str(), "if" | "elif" | "else")
+    }
+}
+
 // for example, @group(0) @location(0)
 #[derive(PartialEq, Eq, Debug)]
 pub struct AttributeList {

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -1,6 +1,8 @@
 use base_db::{EditionedFileId, SourceDatabase};
 use either::Either;
-use syntax::{HasName as _, HasTemplateParameters as _, ast, pointer::AstPointer};
+use syntax::{
+    HasAttributes as _, HasName as _, HasTemplateParameters as _, ast, pointer::AstPointer,
+};
 
 use super::{Binding, BindingId, Body, BodySourceMap, SyntheticSyntax};
 use crate::{
@@ -195,10 +197,22 @@ impl Collector<'_> {
             .statements()
             .filter_map(|statement| self.collect_statement(&statement))
             .collect();
-
         self.body
             .statements
             .alloc(Statement::Compound { statements })
+    }
+
+    fn collect_conditional_compound_statement(
+        &mut self,
+        compound_statement: &ast::CompoundStatement,
+    ) -> StatementId {
+        let statements = compound_statement
+            .statements()
+            .filter_map(|statement| self.collect_statement(&statement))
+            .collect();
+        self.body
+            .statements
+            .alloc(Statement::ConditionalCompound { statements })
     }
 
     #[expect(
@@ -268,6 +282,11 @@ impl Collector<'_> {
                 }
             },
             ast::Statement::CompoundStatement(compound_statement) => {
+                if let Some(mut attributes) = statement.attributes()
+                    && attributes.any(|attribute| attribute.is_conditional_compilation())
+                {
+                    return Some(self.collect_conditional_compound_statement(compound_statement));
+                }
                 return Some(self.collect_compound_statement(compound_statement));
             },
             ast::Statement::ReturnStatement(ret_statement) => {

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -1,6 +1,8 @@
 use base_db::EditionedFileId;
 use either::Either;
-use syntax::{HasName as _, HasTemplateParameters as _, ast, pointer::AstPointer};
+use syntax::{
+    HasAttributes as _, HasName as _, HasTemplateParameters as _, ast, pointer::AstPointer,
+};
 
 use super::{Binding, BindingId, Body, BodySourceMap, SyntheticSyntax};
 use crate::{
@@ -196,10 +198,22 @@ impl Collector<'_> {
             .statements()
             .filter_map(|statement| self.collect_statement(&statement))
             .collect();
-
         self.body
             .statements
             .alloc(Statement::Compound { statements })
+    }
+
+    fn collect_conditional_compound_statement(
+        &mut self,
+        compound_statement: &ast::CompoundStatement,
+    ) -> StatementId {
+        let statements = compound_statement
+            .statements()
+            .filter_map(|statement| self.collect_statement(&statement))
+            .collect();
+        self.body
+            .statements
+            .alloc(Statement::ConditionalCompound { statements })
     }
 
     #[expect(
@@ -269,6 +283,11 @@ impl Collector<'_> {
                 }
             },
             ast::Statement::CompoundStatement(compound_statement) => {
+                if let Some(mut attributes) = statement.attributes()
+                    && attributes.any(|attribute| attribute.is_conditional_compilation())
+                {
+                    return Some(self.collect_conditional_compound_statement(compound_statement));
+                }
                 return Some(self.collect_compound_statement(compound_statement));
             },
             ast::Statement::ReturnStatement(ret_statement) => {

--- a/crates/hir_def/src/body/scope.rs
+++ b/crates/hir_def/src/body/scope.rs
@@ -176,15 +176,17 @@ impl ExprScopes {
     }
 }
 
+#[must_use]
 fn compute_compound_statement_scopes(
     statements: &[StatementId],
     body: &Body,
     scopes: &mut ExprScopes,
     mut scope: ScopeId,
-) {
+) -> ScopeId {
     for statement in statements {
         scope = compute_statement_scopes(*statement, body, scopes, scope);
     }
+    scope
 }
 
 #[expect(clippy::too_many_lines, reason = "Long but simple match")]
@@ -192,7 +194,7 @@ fn compute_statement_scopes(
     statement_id: StatementId,
     body: &Body,
     scopes: &mut ExprScopes,
-    scope: ScopeId,
+    mut scope: ScopeId,
 ) -> ScopeId {
     scopes.set_scope_statement(statement_id, scope);
 
@@ -202,7 +204,10 @@ fn compute_statement_scopes(
         Statement::Compound { statements } => {
             let new_scope = scopes.new_block_scope(scope);
             scopes.set_scope_statement(statement_id, new_scope);
-            compute_compound_statement_scopes(statements, body, scopes, new_scope);
+            scope = compute_compound_statement_scopes(statements, body, scopes, new_scope);
+        },
+        Statement::ConditionalCompound { statements } => {
+            scope = compute_compound_statement_scopes(statements, body, scopes, scope);
         },
         Statement::Variable {
             binding_id,

--- a/crates/hir_def/src/body/scope.rs
+++ b/crates/hir_def/src/body/scope.rs
@@ -194,15 +194,17 @@ impl ExprScopes {
     }
 }
 
+#[must_use]
 fn compute_compound_statement_scopes(
     statements: &[StatementId],
     body: &Body,
     scopes: &mut ExprScopes,
     mut scope: ScopeId,
-) {
+) -> ScopeId {
     for statement in statements {
         scope = compute_statement_scopes(*statement, body, scopes, scope);
     }
+    scope
 }
 
 #[expect(clippy::too_many_lines, reason = "Long but simple match")]
@@ -210,7 +212,7 @@ fn compute_statement_scopes(
     statement_id: StatementId,
     body: &Body,
     scopes: &mut ExprScopes,
-    scope: ScopeId,
+    mut scope: ScopeId,
 ) -> ScopeId {
     scopes.set_scope_statement(statement_id, scope);
 
@@ -220,7 +222,10 @@ fn compute_statement_scopes(
         Statement::Compound { statements } => {
             let new_scope = scopes.new_block_scope(scope);
             scopes.set_scope_statement(statement_id, new_scope);
-            compute_compound_statement_scopes(statements, body, scopes, new_scope);
+            scope = compute_compound_statement_scopes(statements, body, scopes, new_scope);
+        },
+        Statement::ConditionalCompound { statements } => {
+            scope = compute_compound_statement_scopes(statements, body, scopes, scope);
         },
         Statement::Variable {
             binding_id,

--- a/crates/hir_def/src/expression.rs
+++ b/crates/hir_def/src/expression.rs
@@ -70,6 +70,9 @@ pub enum Statement {
     Compound {
         statements: Vec<StatementId>,
     },
+    ConditionalCompound {
+        statements: Vec<StatementId>,
+    },
     Let {
         binding_id: BindingId,
         type_ref: Option<TypeSpecifierId>,

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -52,33 +52,56 @@ impl<'db> Ctx<'db> {
         &mut self,
         item: Item,
     ) -> Option<()> {
-        let item = match item {
+        match item {
             Item::ImportStatement(import_statement) => {
-                ModuleItemId::ImportStatement(self.lower_import(&import_statement)?)
+                let file_ast_id = self.lower_import(&import_statement)?;
+                let item = ModuleItemId::ImportStatement(file_ast_id);
+                self.items.push(item);
             },
             Item::FunctionDeclaration(function) => {
-                ModuleItemId::Function(self.lower_function(&function)?)
+                let file_ast_id = self.lower_function(&function)?;
+                let item = ModuleItemId::Function(file_ast_id);
+                self.items.push(item);
             },
             Item::StructDeclaration(r#struct) => {
-                ModuleItemId::Struct(self.lower_struct(&r#struct)?)
+                let file_ast_id = self.lower_struct(&r#struct)?;
+                let item = ModuleItemId::Struct(file_ast_id);
+                self.items.push(item);
             },
             Item::VariableDeclaration(variable) => {
-                ModuleItemId::GlobalVariable(self.lower_global_variable(&variable)?)
+                let file_ast_id = self.lower_global_variable(&variable)?;
+                let item = ModuleItemId::GlobalVariable(file_ast_id);
+                self.items.push(item);
             },
             Item::ConstantDeclaration(constant) => {
-                ModuleItemId::GlobalConstant(self.lower_global_constant(&constant)?)
+                let file_ast_id = self.lower_global_constant(&constant)?;
+                let item = ModuleItemId::GlobalConstant(file_ast_id);
+                self.items.push(item);
             },
             Item::OverrideDeclaration(override_declaration) => {
-                ModuleItemId::Override(self.lower_override(&override_declaration)?)
+                let file_ast_id = self.lower_override(&override_declaration)?;
+                let item = ModuleItemId::Override(file_ast_id);
+                self.items.push(item);
             },
             Item::TypeAliasDeclaration(type_alias) => {
-                ModuleItemId::TypeAlias(self.lower_type_alias(&type_alias)?)
+                let file_ast_id = self.lower_type_alias(&type_alias)?;
+                let item = ModuleItemId::TypeAlias(file_ast_id);
+                self.items.push(item);
             },
-            Item::AssertStatement(assert_statement) => ModuleItemId::GlobalAssertStatement(
-                self.lower_global_assert_statement(&assert_statement)?,
-            ),
-        };
-        self.items.push(item);
+            Item::AssertStatement(assert_statement) => {
+                let file_ast_id = self.lower_global_assert_statement(&assert_statement)?;
+                let item = ModuleItemId::GlobalAssertStatement(file_ast_id);
+                self.items.push(item);
+            },
+            Item::GlobalCompoundDeclaration(global_compound_declaration) => {
+                for item in global_compound_declaration
+                    .items()
+                    .flat_map(Item::flatten_global_compound_declarations)
+                {
+                    self.lower_item(item);
+                }
+            },
+        }
         Some(())
     }
 

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -609,7 +609,7 @@ impl<'database> InferenceContext<'database> {
         let resolver = self.resolver_for_statement(statement);
 
         match &body.statements[statement] {
-            Statement::Compound { statements } => {
+            Statement::Compound { statements } | Statement::ConditionalCompound { statements } => {
                 for statement in statements {
                     self.infer_statement(*statement, body, return_type);
                 }

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -588,7 +588,7 @@ impl<'db> InferenceContext<'db> {
         let resolver = self.resolver_for_statement(statement);
 
         match &body.statements[statement] {
-            Statement::Compound { statements } => {
+            Statement::Compound { statements } | Statement::ConditionalCompound { statements } => {
                 for statement in statements {
                     self.infer_statement(*statement, body, return_type);
                 }

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -2,6 +2,7 @@
 
 mod big;
 mod builtins;
+mod conditional_compilation;
 mod imports;
 mod incremental;
 mod layout;

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -53,7 +53,12 @@ fn infer(
         InferPrinter::new(&database, file_id).infer_file(&mut buffer);
     }
     buffer.truncate(buffer.trim_end().len());
-    buffer
+    let mut buffer2 = String::new();
+    for line in buffer.lines() {
+        buffer2.push_str(line.trim_end());
+        buffer2.push('\n');
+    }
+    buffer2
 }
 
 struct InferPrinter<'db> {
@@ -414,6 +419,5 @@ fn check_infer(
     expect: Expect,
 ) {
     let mut actual = infer(extensions, wa_fixture);
-    actual.push('\n');
     expect.assert_eq(&actual);
 }

--- a/crates/hir_ty/src/tests/conditional_compilation.rs
+++ b/crates/hir_ty/src/tests/conditional_compilation.rs
@@ -4,57 +4,46 @@ use syntax::ExtensionsConfig;
 use crate::tests::check_infer;
 
 #[test]
-fn module_compound() {
+fn module_compound_if_true() {
     check_infer(
         ExtensionsConfig::default(),
         "
         fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }
         ",
-        expect![[r#"
-
-        "#]],
+        expect![""],
     );
 }
 
 #[test]
-fn module_compound_nested() {
+fn module_compound_if_false() {
     check_infer(
         ExtensionsConfig::default(),
         "
-        @if(true) { fn foo() {} { @if(true) fn bar() {} } @if(true) { fn baz() {} } }
+        fn f() {} @if(false) { const_assert true; fn foo() {} struct bar { x: u32 } }
         ",
-        expect![[r#"
-
-        "#]],
+        expect![""],
     );
 }
 
 #[test]
-fn module_compound_shadow() {
+fn module_compound_if_false_elif_true() {
     check_infer(
         ExtensionsConfig::default(),
         "
-        { const foo: u32 = 0; } const foo: u32 = 1;
+        @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; }
         ",
-        expect![[r#"
-            30..33 'foo': u32
-            41..42 '1': integer
-        "#]],
+        expect![""],
     );
 }
 
 #[test]
-fn function_compound() {
+fn module_compound_if_true_compound_elif_true() {
     check_infer(
         ExtensionsConfig::default(),
         "
-        fn foo() { @if(true) { var x = 0; } x++; }
+        @if(true) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; }
         ",
-        expect![[r#"
-            27..28 'x': ref<function, i32, read_write>
-            31..32 '0': integer
-            36..37 'x': ref<function, i32, read_write>
-        "#]],
+        expect![""],
     );
 }
 
@@ -70,6 +59,311 @@ fn function_compound_nested() {
             31..32 '0': integer
             46..47 'x': ref<function, i32, read_write>
             65..66 'x': ref<function, i32, read_write>
+        "#]],
+    );
+}
+
+#[test]
+fn module_if_false_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; }",
+        expect![[r#"
+            17..20 'foo': u32
+            28..29 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn module_if_true_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; }",
+        expect![[r#"
+            16..19 'foo': u32
+            27..28 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn module_compound_else_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(false) { const foo: u32 = 0; } @elif(false) { const bar: u32 = 0; } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_else_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_noop() {
+    check_infer(ExtensionsConfig::default(), "{ fn foo() {} }", expect![""]);
+}
+
+#[test]
+fn module_compound_nested_noop() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if (true) { fn foo() {} { @if(true) fn bar() {} } }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_nested_if() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) { fn foo() {} @if(true) { fn bar() {} } }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_nested_elif_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_nested_elif_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_nested_else_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) { @if(false) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_nested_else_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) { @if(true) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_shadow() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "{ const foo: u32 = 0; } const foo: u32 = 1;",
+        expect![[r#"
+            30..33 'foo': u32
+            41..42 '1': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_if_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { const_assert true; const x: u32 = 0; } }",
+        expect![[r#"
+            34..38 'true': bool
+            46..47 'x': u32
+            55..56 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_if_false() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(false) { const_assert true; const x: u32 = 0; } }",
+        expect![[r#"
+            35..39 'true': bool
+            47..48 'x': u32
+            56..57 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_if_false_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            28..31 'foo': u32
+            39..40 '0': integer
+            64..67 'bar': u32
+            75..76 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_if_true_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            27..30 'foo': u32
+            38..39 '0': integer
+            63..66 'bar': u32
+            74..75 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_if_false_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            26..29 'foo': u32
+            37..38 '0': integer
+            60..63 'bar': u32
+            71..72 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_if_true_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            25..28 'foo': u32
+            36..37 '0': integer
+            59..62 'bar': u32
+            70..71 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_else_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(false) { const foo: u32 = 0; } @elif(false) { const bar: u32 = 0; } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            28..31 'foo': u32
+            39..40 '0': integer
+            65..68 'bar': u32
+            76..77 '0': integer
+            95..98 'baz': u32
+            106..107 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_else_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            28..31 'foo': u32
+            39..40 '0': integer
+            64..67 'bar': u32
+            75..76 '0': integer
+            94..97 'baz': u32
+            105..106 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_if() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { const foo: u32 = 0; @if(true) { const bar: u32 = 0; } } }",
+        expect![[r#"
+            27..30 'foo': u32
+            38..39 '0': integer
+            59..62 'bar': u32
+            70..71 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_elif_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            38..41 'foo': u32
+            49..50 '0': integer
+            72..75 'bar': u32
+            83..84 '0': integer
+            104..107 'baz': u32
+            115..116 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_elif_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            37..40 'foo': u32
+            48..49 '0': integer
+            71..74 'bar': u32
+            82..83 '0': integer
+            103..106 'baz': u32
+            114..115 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_else_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { @if(false) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            38..41 'foo': u32
+            49..50 '0': integer
+            66..69 'bar': u32
+            77..78 '0': integer
+            98..101 'baz': u32
+            109..110 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_else_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { @if(true) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            37..40 'foo': u32
+            48..49 '0': integer
+            65..68 'bar': u32
+            76..77 '0': integer
+            97..100 'baz': u32
+            108..109 '0': integer
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/conditional_compilation.rs
+++ b/crates/hir_ty/src/tests/conditional_compilation.rs
@@ -11,7 +11,7 @@ fn module_compound() {
         fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }
         ",
         expect![[r#"
-            35..39 'true': bool
+
         "#]],
     );
 }
@@ -37,8 +37,6 @@ fn module_compound_shadow() {
         { const foo: u32 = 0; } const foo: u32 = 1;
         ",
         expect![[r#"
-            8..11 'foo': u32
-            19..20 '0': integer
             30..33 'foo': u32
             41..42 '1': integer
         "#]],
@@ -53,10 +51,12 @@ fn function_compound() {
         fn foo() { @if(true) { var x = 0; } x++; }
         ",
         expect![[r#"
-            8..11 'foo': u32
-            19..20 '0': integer
-            30..33 'foo': u32
-            41..42 '1': integer
+            27..28 'x': ref<function, i32, read_write>
+            31..32 '0': integer
+            36..37 'x': [error]
+            InvalidType { error: TypeLoweringError { container: Expression(Idx::<Expression>(1)), kind: UnresolvedPath { path: Path(ModPath("x")), failed_segment: 0 } } } in Body
+            ExpectedLoweredKind { expression: Idx::<Expression>(1), expected: Variable, actual: Type, path: Path(ModPath("x")) } in Body
+            AssignmentNotAReference { left_side: Idx::<Expression>(1), actual: Type(2400) } in Body
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/conditional_compilation.rs
+++ b/crates/hir_ty/src/tests/conditional_compilation.rs
@@ -4,57 +4,46 @@ use syntax::ExtensionsConfig;
 use crate::tests::check_infer;
 
 #[test]
-fn module_compound() {
+fn module_compound_if_true() {
     check_infer(
         ExtensionsConfig::default(),
         "
         fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }
         ",
-        expect![[r#"
-
-        "#]],
+        expect![""],
     );
 }
 
 #[test]
-fn module_compound_nested() {
+fn module_compound_if_false() {
     check_infer(
         ExtensionsConfig::default(),
         "
-        @if(true) { fn foo() {} { @if(true) fn bar() {} } @if(true) { fn baz() {} } }
+        fn f() {} @if(false) { const_assert true; fn foo() {} struct bar { x: u32 } }
         ",
-        expect![[r#"
-
-        "#]],
+        expect![""],
     );
 }
 
 #[test]
-fn module_compound_shadow() {
+fn module_compound_if_false_elif_true() {
     check_infer(
         ExtensionsConfig::default(),
         "
-        { const foo: u32 = 0; } const foo: u32 = 1;
+        @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; }
         ",
-        expect![[r#"
-            30..33 'foo': u32
-            41..42 '1': integer
-        "#]],
+        expect![""],
     );
 }
 
 #[test]
-fn function_compound() {
+fn module_compound_if_true_compound_elif_true() {
     check_infer(
         ExtensionsConfig::default(),
         "
-        fn foo() { @if(true) { var x = 0; } x++; }
+        @if(true) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; }
         ",
-        expect![[r#"
-            27..28 'x': ref<function, i32, read_write>
-            31..32 '0': integer
-            36..37 'x': ref<function, i32, read_write>
-        "#]],
+        expect![""],
     );
 }
 
@@ -70,6 +59,321 @@ fn function_compound_nested() {
             31..32 '0': integer
             46..47 'x': ref<function, i32, read_write>
             65..66 'x': ref<function, i32, read_write>
+        "#]],
+    );
+}
+
+#[test]
+fn module_if_false_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; }",
+        expect![[r#"
+            17..20 'foo': u32
+            28..29 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn module_if_true_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; }",
+        expect![[r#"
+            16..19 'foo': u32
+            27..28 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn module_compound_else_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(false) { const foo: u32 = 0; } @elif(false) { const bar: u32 = 0; } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_else_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_noop() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "{ fn foo() {} }",
+        expect![[r#"
+
+"#]],
+    );
+}
+
+#[test]
+fn module_compound_nested_noop() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if (true) { fn foo() {} { @if(true) fn bar() {} } }",
+        expect![[r#"
+
+"#]],
+    );
+}
+
+#[test]
+fn module_compound_nested_if() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) { fn foo() {} @if(true) { fn bar() {} } }",
+        expect![[r#"
+
+"#]],
+    );
+}
+
+#[test]
+fn module_compound_nested_elif_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_nested_elif_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_nested_else_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) { @if(false) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_nested_else_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "@if(true) { @if(true) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![""],
+    );
+}
+
+#[test]
+fn module_compound_shadow() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "{ const foo: u32 = 0; } const foo: u32 = 1;",
+        expect![[r#"
+            30..33 'foo': u32
+            41..42 '1': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_if_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { const_assert true; const x: u32 = 0; } }",
+        expect![[r#"
+            34..38 'true': bool
+            46..47 'x': u32
+            55..56 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_if_false() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(false) { const_assert true; const x: u32 = 0; } }",
+        expect![[r#"
+            35..39 'true': bool
+            47..48 'x': u32
+            56..57 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_if_false_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            28..31 'foo': u32
+            39..40 '0': integer
+            64..67 'bar': u32
+            75..76 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_if_true_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            27..30 'foo': u32
+            38..39 '0': integer
+            63..66 'bar': u32
+            74..75 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_if_false_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            26..29 'foo': u32
+            37..38 '0': integer
+            60..63 'bar': u32
+            71..72 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_if_true_compound_elif_true() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            25..28 'foo': u32
+            36..37 '0': integer
+            59..62 'bar': u32
+            70..71 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_else_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(false) { const foo: u32 = 0; } @elif(false) { const bar: u32 = 0; } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            28..31 'foo': u32
+            39..40 '0': integer
+            65..68 'bar': u32
+            76..77 '0': integer
+            95..98 'baz': u32
+            106..107 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_else_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            28..31 'foo': u32
+            39..40 '0': integer
+            64..67 'bar': u32
+            75..76 '0': integer
+            94..97 'baz': u32
+            105..106 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_if() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { const foo: u32 = 0; @if(true) { const bar: u32 = 0; } } }",
+        expect![[r#"
+            27..30 'foo': u32
+            38..39 '0': integer
+            59..62 'bar': u32
+            70..71 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_elif_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            38..41 'foo': u32
+            49..50 '0': integer
+            72..75 'bar': u32
+            83..84 '0': integer
+            104..107 'baz': u32
+            115..116 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_elif_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            37..40 'foo': u32
+            48..49 '0': integer
+            71..74 'bar': u32
+            82..83 '0': integer
+            103..106 'baz': u32
+            114..115 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_else_hit() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { @if(false) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            38..41 'foo': u32
+            49..50 '0': integer
+            66..69 'bar': u32
+            77..78 '0': integer
+            98..101 'baz': u32
+            109..110 '0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_else_skipped() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "fn f() { @if(true) { @if(true) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            37..40 'foo': u32
+            48..49 '0': integer
+            65..68 'bar': u32
+            76..77 '0': integer
+            97..100 'baz': u32
+            108..109 '0': integer
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/conditional_compilation.rs
+++ b/crates/hir_ty/src/tests/conditional_compilation.rs
@@ -10,7 +10,9 @@ fn module_compound_if_true() {
         "
         fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }
         ",
-        expect![""],
+        expect![[r#"
+            35..39 'true': bool
+        "#]],
     );
 }
 
@@ -21,7 +23,9 @@ fn module_compound_if_false() {
         "
         fn f() {} @if(false) { const_assert true; fn foo() {} struct bar { x: u32 } }
         ",
-        expect![""],
+        expect![[r#"
+            36..40 'true': bool
+        "#]],
     );
 }
 
@@ -32,7 +36,12 @@ fn module_compound_if_false_elif_true() {
         "
         @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; }
         ",
-        expect![""],
+        expect![[r#"
+            19..22 'foo': u32
+            30..31 '0': integer
+            55..58 'bar': u32
+            66..67 '0': integer
+        "#]],
     );
 }
 
@@ -43,7 +52,12 @@ fn module_compound_if_true_compound_elif_true() {
         "
         @if(true) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; }
         ",
-        expect![""],
+        expect![[r#"
+            18..21 'foo': u32
+            29..30 '0': integer
+            54..57 'bar': u32
+            65..66 '0': integer
+        "#]],
     );
 }
 
@@ -71,6 +85,8 @@ fn module_if_false_compound_elif_true() {
         expect![[r#"
             17..20 'foo': u32
             28..29 '0': integer
+            51..54 'bar': u32
+            62..63 '0': integer
         "#]],
     );
 }
@@ -83,6 +99,8 @@ fn module_if_true_compound_elif_true() {
         expect![[r#"
             16..19 'foo': u32
             27..28 '0': integer
+            50..53 'bar': u32
+            61..62 '0': integer
         "#]],
     );
 }
@@ -92,7 +110,14 @@ fn module_compound_else_hit() {
     check_infer(
         ExtensionsConfig::default(),
         "@if(false) { const foo: u32 = 0; } @elif(false) { const bar: u32 = 0; } @else { const baz: u32 = 0; }",
-        expect![""],
+        expect![[r#"
+            19..22 'foo': u32
+            30..31 '0': integer
+            56..59 'bar': u32
+            67..68 '0': integer
+            86..89 'baz': u32
+            97..98 '0': integer
+        "#]],
     );
 }
 
@@ -101,7 +126,14 @@ fn module_compound_else_skipped() {
     check_infer(
         ExtensionsConfig::default(),
         "@if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } @else { const baz: u32 = 0; }",
-        expect![""],
+        expect![[r#"
+            19..22 'foo': u32
+            30..31 '0': integer
+            55..58 'bar': u32
+            66..67 '0': integer
+            85..88 'baz': u32
+            96..97 '0': integer
+        "#]],
     );
 }
 
@@ -143,7 +175,14 @@ fn module_compound_nested_elif_hit() {
     check_infer(
         ExtensionsConfig::default(),
         "@if(true) { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
-        expect![""],
+        expect![[r#"
+            29..32 'foo': u32
+            40..41 '0': integer
+            63..66 'bar': u32
+            74..75 '0': integer
+            95..98 'baz': u32
+            106..107 '0': integer
+        "#]],
     );
 }
 
@@ -152,7 +191,14 @@ fn module_compound_nested_elif_skipped() {
     check_infer(
         ExtensionsConfig::default(),
         "@if(true) { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
-        expect![""],
+        expect![[r#"
+            28..31 'foo': u32
+            39..40 '0': integer
+            62..65 'bar': u32
+            73..74 '0': integer
+            94..97 'baz': u32
+            105..106 '0': integer
+        "#]],
     );
 }
 
@@ -161,7 +207,14 @@ fn module_compound_nested_else_hit() {
     check_infer(
         ExtensionsConfig::default(),
         "@if(true) { @if(false) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
-        expect![""],
+        expect![[r#"
+            29..32 'foo': u32
+            40..41 '0': integer
+            57..60 'bar': u32
+            68..69 '0': integer
+            89..92 'baz': u32
+            100..101 '0': integer
+        "#]],
     );
 }
 
@@ -170,7 +223,14 @@ fn module_compound_nested_else_skipped() {
     check_infer(
         ExtensionsConfig::default(),
         "@if(true) { @if(true) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
-        expect![""],
+        expect![[r#"
+            28..31 'foo': u32
+            39..40 '0': integer
+            56..59 'bar': u32
+            67..68 '0': integer
+            88..91 'baz': u32
+            99..100 '0': integer
+        "#]],
     );
 }
 
@@ -180,6 +240,8 @@ fn module_compound_shadow() {
         ExtensionsConfig::default(),
         "{ const foo: u32 = 0; } const foo: u32 = 1;",
         expect![[r#"
+            8..11 'foo': u32
+            19..20 '0': integer
             30..33 'foo': u32
             41..42 '1': integer
         "#]],

--- a/crates/hir_ty/src/tests/conditional_compilation.rs
+++ b/crates/hir_ty/src/tests/conditional_compilation.rs
@@ -53,10 +53,7 @@ fn function_compound() {
         expect![[r#"
             27..28 'x': ref<function, i32, read_write>
             31..32 '0': integer
-            36..37 'x': [error]
-            InvalidType { error: TypeLoweringError { container: Expression(Idx::<Expression>(1)), kind: UnresolvedPath { path: Path(ModPath("x")), failed_segment: 0 } } } in Body
-            ExpectedLoweredKind { expression: Idx::<Expression>(1), expected: Variable, actual: Type, path: Path(ModPath("x")) } in Body
-            AssignmentNotAReference { left_side: Idx::<Expression>(1), actual: Type(2400) } in Body
+            36..37 'x': ref<function, i32, read_write>
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/conditional_compilation.rs
+++ b/crates/hir_ty/src/tests/conditional_compilation.rs
@@ -1,0 +1,78 @@
+use expect_test::expect;
+use syntax::ExtensionsConfig;
+
+use crate::tests::check_infer;
+
+#[test]
+fn module_compound() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+        fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }
+        ",
+        expect![[r#"
+            35..39 'true': bool
+        "#]],
+    );
+}
+
+#[test]
+fn module_compound_nested() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+        @if(true) { fn foo() {} { @if(true) fn bar() {} } @if(true) { fn baz() {} } }
+        ",
+        expect![[r#"
+
+        "#]],
+    );
+}
+
+#[test]
+fn module_compound_shadow() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+        { const foo: u32 = 0; } const foo: u32 = 1;
+        ",
+        expect![[r#"
+            8..11 'foo': u32
+            19..20 '0': integer
+            30..33 'foo': u32
+            41..42 '1': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+        fn foo() { @if(true) { var x = 0; } x++; }
+        ",
+        expect![[r#"
+            8..11 'foo': u32
+            19..20 '0': integer
+            30..33 'foo': u32
+            41..42 '1': integer
+        "#]],
+    );
+}
+
+#[test]
+fn function_compound_nested() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+        fn foo() { @if(true) { var x = 0; { @if(true) x++; } @if(true) { x--; } } }
+        ",
+        expect![[r#"
+            27..28 'x': ref<function, i32, read_write>
+            31..32 '0': integer
+            46..47 'x': ref<function, i32, read_write>
+            65..66 'x': ref<function, i32, read_write>
+        "#]],
+    );
+}

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -2036,3 +2036,19 @@ fn main(@builtin(position) pos: vec4f) -> @location(0) vec4f {
         "#]],
     );
 }
+
+#[test]
+fn override_declaration() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+        override LEVELS: f32 = 4.0;
+        fn foo() -> f32 { return LEVELS; }
+        ",
+        expect![[r#"
+            9..15 'LEVELS': f32
+            23..26 '4.0': float
+            53..59 'LEVELS': f32
+        "#]],
+    );
+}

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -2028,10 +2028,11 @@ fn main(@builtin(position) pos: vec4f) -> @location(0) vec4f {
             81..82 'x': ref<function, f32, read_write>
             122..123 'x': ref<function, i32, read_write>
             126..128 '1i': i32
-            147..163 'vec4(v...x), 1)': vec4<f32>
-            152..159 'vec3(x)': vec3<f32>
-            157..158 'x': ref<function, f32, read_write>
+            147..163 'vec4(v...x), 1)': vec4<i32>
+            152..159 'vec3(x)': vec3<i32>
+            157..158 'x': ref<function, i32, read_write>
             161..162 '1': integer
+            147..163 'vec4(v...x), 1)': expected vec4<f32> but got vec4<i32>
         "#]],
     );
 }

--- a/crates/parser/src/cst_builder.rs
+++ b/crates/parser/src/cst_builder.rs
@@ -144,6 +144,7 @@ impl CstBuilder<'_, '_> {
             | Rule::CompoundAssignmentOperator
             | Rule::ExprTemplateList
             | Rule::GlobalItem
+            | Rule::GlobalCompoundDeclarationItem
             | Rule::IdentOrFunction
             | Rule::LetDeclarationSemi
             | Rule::OverrideDeclarationSemi
@@ -199,6 +200,10 @@ impl CstBuilder<'_, '_> {
             Rule::IfAttr => self.start_node(SyntaxKind::IfAttribute),
             Rule::ElifAttr => self.start_node(SyntaxKind::ElifAttribute),
             Rule::ElseAttr => self.start_node(SyntaxKind::ElseAttribute),
+            // experimental WESL
+            Rule::GlobalCompoundDeclaration => {
+                self.start_node(SyntaxKind::GlobalCompoundDeclaration)
+            },
         }
     }
 

--- a/crates/parser/src/cst_builder.rs
+++ b/crates/parser/src/cst_builder.rs
@@ -202,7 +202,7 @@ impl CstBuilder<'_, '_> {
             Rule::ElseAttr => self.start_node(SyntaxKind::ElseAttribute),
             // experimental WESL
             Rule::GlobalCompoundDeclaration => {
-                self.start_node(SyntaxKind::GlobalCompoundDeclaration)
+                self.start_node(SyntaxKind::GlobalCompoundDeclaration);
             },
         }
     }

--- a/crates/parser/src/syntax_kind.rs
+++ b/crates/parser/src/syntax_kind.rs
@@ -185,6 +185,9 @@ pub enum SyntaxKind {
     /// @else
     ElseAttribute,
 
+    // WESL experiment
+    GlobalCompoundDeclaration,
+
     // Tokens
     /// Source: <https://www.w3.org/TR/WGSL/#blankspace-and-line-breaks>
     #[regex("[\x20\x09\x0A-\x0D\u{0085}\u{200E}\u{200F}\u{2028}\u{2029}]+")]

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -3,6 +3,7 @@
 
 mod attributes;
 mod conditional;
+mod conditional_compilation;
 mod diagnostic;
 mod expression;
 mod imports;

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -2506,7 +2506,7 @@ fn annotation_with_invalid_statement_recover() {
               Error@102..103
                 BraceRight@102..103 "}"
 
-            error at 102..103: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
+            error at 102..103: invalid syntax, expected one of: 'alias', '@', '{', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
     );
 }
 
@@ -2951,7 +2951,7 @@ fn test()
                     TypeSpecifier@14..14
                   BraceRight@14..15 "}"
               Blankspace@15..17 "\n\n"
-              FunctionDeclaration@17..28
+              FunctionDeclaration@17..27
                 Fn@17..19 "fn"
                 Blankspace@19..20 " "
                 Name@20..24
@@ -2960,8 +2960,8 @@ fn test()
                   ParenthesisLeft@24..25 "("
                   ParenthesisRight@25..26 ")"
                 Blankspace@26..27 "\n"
-                Error@27..28
-                  BraceRight@27..28 "}"
+              Error@27..28
+                BraceRight@27..28 "}"
               Semicolon@28..29 ";"
               Blankspace@29..30 "\n"
 

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -2506,7 +2506,7 @@ fn annotation_with_invalid_statement_recover() {
               Error@102..103
                 BraceRight@102..103 "}"
 
-            error at 102..103: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
+            error at 102..103: invalid syntax, expected one of: 'alias', '@', '{', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
     );
 }
 
@@ -3026,7 +3026,7 @@ fn test()
                     TypeSpecifier@14..14
                   BraceRight@14..15 "}"
               Blankspace@15..17 "\n\n"
-              FunctionDeclaration@17..28
+              FunctionDeclaration@17..27
                 Fn@17..19 "fn"
                 Blankspace@19..20 " "
                 Name@20..24
@@ -3035,8 +3035,8 @@ fn test()
                   ParenthesisLeft@24..25 "("
                   ParenthesisRight@25..26 ")"
                 Blankspace@26..27 "\n"
-                Error@27..28
-                  BraceRight@27..28 "}"
+              Error@27..28
+                BraceRight@27..28 "}"
               Semicolon@28..29 ";"
               Blankspace@29..30 "\n"
 

--- a/crates/parser/src/tests/conditional.rs
+++ b/crates/parser/src/tests/conditional.rs
@@ -223,7 +223,7 @@ fn foo(){}
                   BraceRight@44..45 "}"
               Blankspace@45..54 "\n        "
 
-            error at 27..28: invalid syntax, expected one of: 'alias', 'const', 'const_assert', 'diagnostic', 'enable', 'fn', 'import', 'let', 'override', 'requires', 'struct', 'var'"#]],
+            error at 27..28: invalid syntax, expected one of: 'alias', '{', 'const', 'const_assert', 'diagnostic', 'enable', 'fn', 'import', 'let', 'override', 'requires', 'struct', 'var'"#]],
     );
 }
 

--- a/crates/parser/src/tests/conditional_compilation.rs
+++ b/crates/parser/src/tests/conditional_compilation.rs
@@ -1,0 +1,395 @@
+use expect_test::expect;
+
+use crate::tests::check;
+
+#[test]
+fn module_compound() {
+    check(
+        "
+        fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }
+        ",
+        expect![[r#"
+            SourceFile@0..94
+              Blankspace@0..9 "\n        "
+              FunctionDeclaration@9..18
+                Fn@9..11 "fn"
+                Blankspace@11..12 " "
+                Name@12..13
+                  Identifier@12..13 "f"
+                FunctionParameters@13..15
+                  ParenthesisLeft@13..14 "("
+                  ParenthesisRight@14..15 ")"
+                Blankspace@15..16 " "
+                CompoundStatement@16..18
+                  BraceLeft@16..17 "{"
+                  BraceRight@17..18 "}"
+              Blankspace@18..19 " "
+              AttributeList@19..28
+                IfAttribute@19..28
+                  AttributeOperator@19..20 "@"
+                  If@20..22 "if"
+                  ParenthesisLeft@22..23 "("
+                  Literal@23..27
+                    True@23..27 "true"
+                  ParenthesisRight@27..28 ")"
+              Blankspace@28..29 " "
+              Error@29..30
+                BraceLeft@29..30 "{"
+              Blankspace@30..31 " "
+              AssertStatement@31..49
+                ConstantAssert@31..43 "const_assert"
+                Blankspace@43..44 " "
+                Literal@44..48
+                  True@44..48 "true"
+                Semicolon@48..49 ";"
+              Blankspace@49..50 " "
+              FunctionDeclaration@50..61
+                Fn@50..52 "fn"
+                Blankspace@52..53 " "
+                Name@53..56
+                  Identifier@53..56 "foo"
+                FunctionParameters@56..58
+                  ParenthesisLeft@56..57 "("
+                  ParenthesisRight@57..58 ")"
+                Blankspace@58..59 " "
+                CompoundStatement@59..61
+                  BraceLeft@59..60 "{"
+                  BraceRight@60..61 "}"
+              Blankspace@61..62 " "
+              StructDeclaration@62..83
+                Struct@62..68 "struct"
+                Blankspace@68..69 " "
+                Name@69..72
+                  Identifier@69..72 "bar"
+                Blankspace@72..73 " "
+                StructBody@73..83
+                  BraceLeft@73..74 "{"
+                  Blankspace@74..75 " "
+                  StructMember@75..81
+                    Name@75..76
+                      Identifier@75..76 "x"
+                    Colon@76..77 ":"
+                    Blankspace@77..78 " "
+                    TypeSpecifier@78..81
+                      Path@78..81
+                        Identifier@78..81 "u32"
+                  Blankspace@81..82 " "
+                  BraceRight@82..83 "}"
+              Blankspace@83..84 " "
+              Error@84..85
+                BraceRight@84..85 "}"
+              Blankspace@85..94 "\n        "
+
+            error at 29..30: invalid syntax, expected one of: 'alias', 'const', 'const_assert', 'diagnostic', 'enable', 'fn', 'import', 'let', 'override', 'requires', 'struct', 'var'
+            error at 84..85: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
+    );
+}
+
+#[test]
+fn module_compound_nested() {
+    check(
+        "
+        @if(true) { fn foo() {} { @if(true) fn bar() {} } @if(true) { fn baz() {} } }
+        ",
+        expect![[r#"
+            SourceFile@0..95
+              Blankspace@0..9 "\n        "
+              AttributeList@9..18
+                IfAttribute@9..18
+                  AttributeOperator@9..10 "@"
+                  If@10..12 "if"
+                  ParenthesisLeft@12..13 "("
+                  Literal@13..17
+                    True@13..17 "true"
+                  ParenthesisRight@17..18 ")"
+              Blankspace@18..19 " "
+              Error@19..20
+                BraceLeft@19..20 "{"
+              Blankspace@20..21 " "
+              FunctionDeclaration@21..32
+                Fn@21..23 "fn"
+                Blankspace@23..24 " "
+                Name@24..27
+                  Identifier@24..27 "foo"
+                FunctionParameters@27..29
+                  ParenthesisLeft@27..28 "("
+                  ParenthesisRight@28..29 ")"
+                Blankspace@29..30 " "
+                CompoundStatement@30..32
+                  BraceLeft@30..31 "{"
+                  BraceRight@31..32 "}"
+              Blankspace@32..33 " "
+              Error@33..34
+                BraceLeft@33..34 "{"
+              Blankspace@34..35 " "
+              AttributeList@35..44
+                IfAttribute@35..44
+                  AttributeOperator@35..36 "@"
+                  If@36..38 "if"
+                  ParenthesisLeft@38..39 "("
+                  Literal@39..43
+                    True@39..43 "true"
+                  ParenthesisRight@43..44 ")"
+              Blankspace@44..45 " "
+              FunctionDeclaration@45..56
+                Fn@45..47 "fn"
+                Blankspace@47..48 " "
+                Name@48..51
+                  Identifier@48..51 "bar"
+                FunctionParameters@51..53
+                  ParenthesisLeft@51..52 "("
+                  ParenthesisRight@52..53 ")"
+                Blankspace@53..54 " "
+                CompoundStatement@54..56
+                  BraceLeft@54..55 "{"
+                  BraceRight@55..56 "}"
+              Blankspace@56..57 " "
+              Error@57..58
+                BraceRight@57..58 "}"
+              Blankspace@58..59 " "
+              AttributeList@59..68
+                IfAttribute@59..68
+                  AttributeOperator@59..60 "@"
+                  If@60..62 "if"
+                  ParenthesisLeft@62..63 "("
+                  Literal@63..67
+                    True@63..67 "true"
+                  ParenthesisRight@67..68 ")"
+              Blankspace@68..69 " "
+              Error@69..70
+                BraceLeft@69..70 "{"
+              Blankspace@70..71 " "
+              FunctionDeclaration@71..82
+                Fn@71..73 "fn"
+                Blankspace@73..74 " "
+                Name@74..77
+                  Identifier@74..77 "baz"
+                FunctionParameters@77..79
+                  ParenthesisLeft@77..78 "("
+                  ParenthesisRight@78..79 ")"
+                Blankspace@79..80 " "
+                CompoundStatement@80..82
+                  BraceLeft@80..81 "{"
+                  BraceRight@81..82 "}"
+              Blankspace@82..83 " "
+              Error@83..86
+                BraceRight@83..84 "}"
+                Blankspace@84..85 " "
+                BraceRight@85..86 "}"
+              Blankspace@86..95 "\n        "
+
+            error at 19..20: invalid syntax, expected one of: 'alias', 'const', 'const_assert', 'diagnostic', 'enable', 'fn', 'import', 'let', 'override', 'requires', 'struct', 'var'
+            error at 33..34: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'
+            error at 57..58: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'
+            error at 69..70: invalid syntax, expected one of: 'alias', 'const', 'const_assert', 'diagnostic', 'enable', 'fn', 'import', 'let', 'override', 'requires', 'struct', 'var'
+            error at 83..84: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
+    );
+}
+
+#[test]
+fn module_compound_shadow() {
+    check(
+        "
+        { const foo: u32 = 0; } const foo: u32 = 1;
+        ",
+        expect![[r#"
+            SourceFile@0..61
+              Blankspace@0..9 "\n        "
+              Error@9..10
+                BraceLeft@9..10 "{"
+              Blankspace@10..11 " "
+              ConstantDeclaration@11..30
+                Const@11..16 "const"
+                Blankspace@16..17 " "
+                Name@17..20
+                  Identifier@17..20 "foo"
+                Colon@20..21 ":"
+                Blankspace@21..22 " "
+                TypeSpecifier@22..25
+                  Path@22..25
+                    Identifier@22..25 "u32"
+                Blankspace@25..26 " "
+                Equal@26..27 "="
+                Blankspace@27..28 " "
+                Literal@28..29
+                  IntLiteral@28..29 "0"
+                Semicolon@29..30 ";"
+              Blankspace@30..31 " "
+              Error@31..32
+                BraceRight@31..32 "}"
+              Blankspace@32..33 " "
+              ConstantDeclaration@33..52
+                Const@33..38 "const"
+                Blankspace@38..39 " "
+                Name@39..42
+                  Identifier@39..42 "foo"
+                Colon@42..43 ":"
+                Blankspace@43..44 " "
+                TypeSpecifier@44..47
+                  Path@44..47
+                    Identifier@44..47 "u32"
+                Blankspace@47..48 " "
+                Equal@48..49 "="
+                Blankspace@49..50 " "
+                Literal@50..51
+                  IntLiteral@50..51 "1"
+                Semicolon@51..52 ";"
+              Blankspace@52..61 "\n        "
+
+            error at 9..10: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'
+            error at 31..32: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
+    );
+}
+
+#[test]
+fn function_compound() {
+    check(
+        "
+        fn foo() { @if(true) { var x = 0; } x++; }
+        ",
+        expect![[r#"
+            SourceFile@0..60
+              Blankspace@0..9 "\n        "
+              FunctionDeclaration@9..51
+                Fn@9..11 "fn"
+                Blankspace@11..12 " "
+                Name@12..15
+                  Identifier@12..15 "foo"
+                FunctionParameters@15..17
+                  ParenthesisLeft@15..16 "("
+                  ParenthesisRight@16..17 ")"
+                Blankspace@17..18 " "
+                CompoundStatement@18..51
+                  BraceLeft@18..19 "{"
+                  Blankspace@19..20 " "
+                  AttributeList@20..29
+                    IfAttribute@20..29
+                      AttributeOperator@20..21 "@"
+                      If@21..23 "if"
+                      ParenthesisLeft@23..24 "("
+                      Literal@24..28
+                        True@24..28 "true"
+                      ParenthesisRight@28..29 ")"
+                  Blankspace@29..30 " "
+                  CompoundStatement@30..44
+                    BraceLeft@30..31 "{"
+                    Blankspace@31..32 " "
+                    VariableDeclaration@32..42
+                      Var@32..35 "var"
+                      Blankspace@35..36 " "
+                      Name@36..37
+                        Identifier@36..37 "x"
+                      Blankspace@37..38 " "
+                      Equal@38..39 "="
+                      Blankspace@39..40 " "
+                      Literal@40..41
+                        IntLiteral@40..41 "0"
+                      Semicolon@41..42 ";"
+                    Blankspace@42..43 " "
+                    BraceRight@43..44 "}"
+                  Blankspace@44..45 " "
+                  IncrementDecrementStatement@45..49
+                    IdentExpression@45..46
+                      Path@45..46
+                        Identifier@45..46 "x"
+                    PlusPlus@46..48 "++"
+                    Semicolon@48..49 ";"
+                  Blankspace@49..50 " "
+                  BraceRight@50..51 "}"
+              Blankspace@51..60 "\n        ""#]],
+    );
+}
+
+#[test]
+fn function_compound_nested() {
+    check(
+        "
+        fn foo() { @if(true) { var x = 0; { @if(true) x++; } @if(true) { x--; } } }
+        ",
+        expect![[r#"
+            SourceFile@0..93
+              Blankspace@0..9 "\n        "
+              FunctionDeclaration@9..84
+                Fn@9..11 "fn"
+                Blankspace@11..12 " "
+                Name@12..15
+                  Identifier@12..15 "foo"
+                FunctionParameters@15..17
+                  ParenthesisLeft@15..16 "("
+                  ParenthesisRight@16..17 ")"
+                Blankspace@17..18 " "
+                CompoundStatement@18..84
+                  BraceLeft@18..19 "{"
+                  Blankspace@19..20 " "
+                  AttributeList@20..29
+                    IfAttribute@20..29
+                      AttributeOperator@20..21 "@"
+                      If@21..23 "if"
+                      ParenthesisLeft@23..24 "("
+                      Literal@24..28
+                        True@24..28 "true"
+                      ParenthesisRight@28..29 ")"
+                  Blankspace@29..30 " "
+                  CompoundStatement@30..82
+                    BraceLeft@30..31 "{"
+                    Blankspace@31..32 " "
+                    VariableDeclaration@32..42
+                      Var@32..35 "var"
+                      Blankspace@35..36 " "
+                      Name@36..37
+                        Identifier@36..37 "x"
+                      Blankspace@37..38 " "
+                      Equal@38..39 "="
+                      Blankspace@39..40 " "
+                      Literal@40..41
+                        IntLiteral@40..41 "0"
+                      Semicolon@41..42 ";"
+                    Blankspace@42..43 " "
+                    CompoundStatement@43..61
+                      BraceLeft@43..44 "{"
+                      Blankspace@44..45 " "
+                      AttributeList@45..54
+                        IfAttribute@45..54
+                          AttributeOperator@45..46 "@"
+                          If@46..48 "if"
+                          ParenthesisLeft@48..49 "("
+                          Literal@49..53
+                            True@49..53 "true"
+                          ParenthesisRight@53..54 ")"
+                      Blankspace@54..55 " "
+                      IncrementDecrementStatement@55..59
+                        IdentExpression@55..56
+                          Path@55..56
+                            Identifier@55..56 "x"
+                        PlusPlus@56..58 "++"
+                        Semicolon@58..59 ";"
+                      Blankspace@59..60 " "
+                      BraceRight@60..61 "}"
+                    Blankspace@61..62 " "
+                    AttributeList@62..71
+                      IfAttribute@62..71
+                        AttributeOperator@62..63 "@"
+                        If@63..65 "if"
+                        ParenthesisLeft@65..66 "("
+                        Literal@66..70
+                          True@66..70 "true"
+                        ParenthesisRight@70..71 ")"
+                    Blankspace@71..72 " "
+                    CompoundStatement@72..80
+                      BraceLeft@72..73 "{"
+                      Blankspace@73..74 " "
+                      IncrementDecrementStatement@74..78
+                        IdentExpression@74..75
+                          Path@74..75
+                            Identifier@74..75 "x"
+                        MinusMinus@75..77 "--"
+                        Semicolon@77..78 ";"
+                      Blankspace@78..79 " "
+                      BraceRight@79..80 "}"
+                    Blankspace@80..81 " "
+                    BraceRight@81..82 "}"
+                  Blankspace@82..83 " "
+                  BraceRight@83..84 "}"
+              Blankspace@84..93 "\n        ""#]],
+    );
+}

--- a/crates/parser/src/tests/conditional_compilation.rs
+++ b/crates/parser/src/tests/conditional_compilation.rs
@@ -33,55 +33,51 @@ fn module_compound() {
                     True@23..27 "true"
                   ParenthesisRight@27..28 ")"
               Blankspace@28..29 " "
-              Error@29..30
+              GlobalCompoundDeclaration@29..85
                 BraceLeft@29..30 "{"
-              Blankspace@30..31 " "
-              AssertStatement@31..49
-                ConstantAssert@31..43 "const_assert"
-                Blankspace@43..44 " "
-                Literal@44..48
-                  True@44..48 "true"
-                Semicolon@48..49 ";"
-              Blankspace@49..50 " "
-              FunctionDeclaration@50..61
-                Fn@50..52 "fn"
-                Blankspace@52..53 " "
-                Name@53..56
-                  Identifier@53..56 "foo"
-                FunctionParameters@56..58
-                  ParenthesisLeft@56..57 "("
-                  ParenthesisRight@57..58 ")"
-                Blankspace@58..59 " "
-                CompoundStatement@59..61
-                  BraceLeft@59..60 "{"
-                  BraceRight@60..61 "}"
-              Blankspace@61..62 " "
-              StructDeclaration@62..83
-                Struct@62..68 "struct"
-                Blankspace@68..69 " "
-                Name@69..72
-                  Identifier@69..72 "bar"
-                Blankspace@72..73 " "
-                StructBody@73..83
-                  BraceLeft@73..74 "{"
-                  Blankspace@74..75 " "
-                  StructMember@75..81
-                    Name@75..76
-                      Identifier@75..76 "x"
-                    Colon@76..77 ":"
-                    Blankspace@77..78 " "
-                    TypeSpecifier@78..81
-                      Path@78..81
-                        Identifier@78..81 "u32"
-                  Blankspace@81..82 " "
-                  BraceRight@82..83 "}"
-              Blankspace@83..84 " "
-              Error@84..85
+                Blankspace@30..31 " "
+                AssertStatement@31..49
+                  ConstantAssert@31..43 "const_assert"
+                  Blankspace@43..44 " "
+                  Literal@44..48
+                    True@44..48 "true"
+                  Semicolon@48..49 ";"
+                Blankspace@49..50 " "
+                FunctionDeclaration@50..61
+                  Fn@50..52 "fn"
+                  Blankspace@52..53 " "
+                  Name@53..56
+                    Identifier@53..56 "foo"
+                  FunctionParameters@56..58
+                    ParenthesisLeft@56..57 "("
+                    ParenthesisRight@57..58 ")"
+                  Blankspace@58..59 " "
+                  CompoundStatement@59..61
+                    BraceLeft@59..60 "{"
+                    BraceRight@60..61 "}"
+                Blankspace@61..62 " "
+                StructDeclaration@62..83
+                  Struct@62..68 "struct"
+                  Blankspace@68..69 " "
+                  Name@69..72
+                    Identifier@69..72 "bar"
+                  Blankspace@72..73 " "
+                  StructBody@73..83
+                    BraceLeft@73..74 "{"
+                    Blankspace@74..75 " "
+                    StructMember@75..81
+                      Name@75..76
+                        Identifier@75..76 "x"
+                      Colon@76..77 ":"
+                      Blankspace@77..78 " "
+                      TypeSpecifier@78..81
+                        Path@78..81
+                          Identifier@78..81 "u32"
+                    Blankspace@81..82 " "
+                    BraceRight@82..83 "}"
+                Blankspace@83..84 " "
                 BraceRight@84..85 "}"
-              Blankspace@85..94 "\n        "
-
-            error at 29..30: invalid syntax, expected one of: 'alias', 'const', 'const_assert', 'diagnostic', 'enable', 'fn', 'import', 'let', 'override', 'requires', 'struct', 'var'
-            error at 84..85: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
+              Blankspace@85..94 "\n        ""#]],
     );
 }
 
@@ -103,86 +99,78 @@ fn module_compound_nested() {
                     True@13..17 "true"
                   ParenthesisRight@17..18 ")"
               Blankspace@18..19 " "
-              Error@19..20
+              GlobalCompoundDeclaration@19..86
                 BraceLeft@19..20 "{"
-              Blankspace@20..21 " "
-              FunctionDeclaration@21..32
-                Fn@21..23 "fn"
-                Blankspace@23..24 " "
-                Name@24..27
-                  Identifier@24..27 "foo"
-                FunctionParameters@27..29
-                  ParenthesisLeft@27..28 "("
-                  ParenthesisRight@28..29 ")"
-                Blankspace@29..30 " "
-                CompoundStatement@30..32
-                  BraceLeft@30..31 "{"
-                  BraceRight@31..32 "}"
-              Blankspace@32..33 " "
-              Error@33..34
-                BraceLeft@33..34 "{"
-              Blankspace@34..35 " "
-              AttributeList@35..44
-                IfAttribute@35..44
-                  AttributeOperator@35..36 "@"
-                  If@36..38 "if"
-                  ParenthesisLeft@38..39 "("
-                  Literal@39..43
-                    True@39..43 "true"
-                  ParenthesisRight@43..44 ")"
-              Blankspace@44..45 " "
-              FunctionDeclaration@45..56
-                Fn@45..47 "fn"
-                Blankspace@47..48 " "
-                Name@48..51
-                  Identifier@48..51 "bar"
-                FunctionParameters@51..53
-                  ParenthesisLeft@51..52 "("
-                  ParenthesisRight@52..53 ")"
-                Blankspace@53..54 " "
-                CompoundStatement@54..56
-                  BraceLeft@54..55 "{"
-                  BraceRight@55..56 "}"
-              Blankspace@56..57 " "
-              Error@57..58
-                BraceRight@57..58 "}"
-              Blankspace@58..59 " "
-              AttributeList@59..68
-                IfAttribute@59..68
-                  AttributeOperator@59..60 "@"
-                  If@60..62 "if"
-                  ParenthesisLeft@62..63 "("
-                  Literal@63..67
-                    True@63..67 "true"
-                  ParenthesisRight@67..68 ")"
-              Blankspace@68..69 " "
-              Error@69..70
-                BraceLeft@69..70 "{"
-              Blankspace@70..71 " "
-              FunctionDeclaration@71..82
-                Fn@71..73 "fn"
-                Blankspace@73..74 " "
-                Name@74..77
-                  Identifier@74..77 "baz"
-                FunctionParameters@77..79
-                  ParenthesisLeft@77..78 "("
-                  ParenthesisRight@78..79 ")"
-                Blankspace@79..80 " "
-                CompoundStatement@80..82
-                  BraceLeft@80..81 "{"
-                  BraceRight@81..82 "}"
-              Blankspace@82..83 " "
-              Error@83..86
-                BraceRight@83..84 "}"
+                Blankspace@20..21 " "
+                FunctionDeclaration@21..32
+                  Fn@21..23 "fn"
+                  Blankspace@23..24 " "
+                  Name@24..27
+                    Identifier@24..27 "foo"
+                  FunctionParameters@27..29
+                    ParenthesisLeft@27..28 "("
+                    ParenthesisRight@28..29 ")"
+                  Blankspace@29..30 " "
+                  CompoundStatement@30..32
+                    BraceLeft@30..31 "{"
+                    BraceRight@31..32 "}"
+                Blankspace@32..33 " "
+                GlobalCompoundDeclaration@33..58
+                  BraceLeft@33..34 "{"
+                  Blankspace@34..35 " "
+                  AttributeList@35..44
+                    IfAttribute@35..44
+                      AttributeOperator@35..36 "@"
+                      If@36..38 "if"
+                      ParenthesisLeft@38..39 "("
+                      Literal@39..43
+                        True@39..43 "true"
+                      ParenthesisRight@43..44 ")"
+                  Blankspace@44..45 " "
+                  FunctionDeclaration@45..56
+                    Fn@45..47 "fn"
+                    Blankspace@47..48 " "
+                    Name@48..51
+                      Identifier@48..51 "bar"
+                    FunctionParameters@51..53
+                      ParenthesisLeft@51..52 "("
+                      ParenthesisRight@52..53 ")"
+                    Blankspace@53..54 " "
+                    CompoundStatement@54..56
+                      BraceLeft@54..55 "{"
+                      BraceRight@55..56 "}"
+                  Blankspace@56..57 " "
+                  BraceRight@57..58 "}"
+                Blankspace@58..59 " "
+                AttributeList@59..68
+                  IfAttribute@59..68
+                    AttributeOperator@59..60 "@"
+                    If@60..62 "if"
+                    ParenthesisLeft@62..63 "("
+                    Literal@63..67
+                      True@63..67 "true"
+                    ParenthesisRight@67..68 ")"
+                Blankspace@68..69 " "
+                GlobalCompoundDeclaration@69..84
+                  BraceLeft@69..70 "{"
+                  Blankspace@70..71 " "
+                  FunctionDeclaration@71..82
+                    Fn@71..73 "fn"
+                    Blankspace@73..74 " "
+                    Name@74..77
+                      Identifier@74..77 "baz"
+                    FunctionParameters@77..79
+                      ParenthesisLeft@77..78 "("
+                      ParenthesisRight@78..79 ")"
+                    Blankspace@79..80 " "
+                    CompoundStatement@80..82
+                      BraceLeft@80..81 "{"
+                      BraceRight@81..82 "}"
+                  Blankspace@82..83 " "
+                  BraceRight@83..84 "}"
                 Blankspace@84..85 " "
                 BraceRight@85..86 "}"
-              Blankspace@86..95 "\n        "
-
-            error at 19..20: invalid syntax, expected one of: 'alias', 'const', 'const_assert', 'diagnostic', 'enable', 'fn', 'import', 'let', 'override', 'requires', 'struct', 'var'
-            error at 33..34: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'
-            error at 57..58: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'
-            error at 69..70: invalid syntax, expected one of: 'alias', 'const', 'const_assert', 'diagnostic', 'enable', 'fn', 'import', 'let', 'override', 'requires', 'struct', 'var'
-            error at 83..84: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
+              Blankspace@86..95 "\n        ""#]],
     );
 }
 
@@ -195,27 +183,26 @@ fn module_compound_shadow() {
         expect![[r#"
             SourceFile@0..61
               Blankspace@0..9 "\n        "
-              Error@9..10
+              GlobalCompoundDeclaration@9..32
                 BraceLeft@9..10 "{"
-              Blankspace@10..11 " "
-              ConstantDeclaration@11..30
-                Const@11..16 "const"
-                Blankspace@16..17 " "
-                Name@17..20
-                  Identifier@17..20 "foo"
-                Colon@20..21 ":"
-                Blankspace@21..22 " "
-                TypeSpecifier@22..25
-                  Path@22..25
-                    Identifier@22..25 "u32"
-                Blankspace@25..26 " "
-                Equal@26..27 "="
-                Blankspace@27..28 " "
-                Literal@28..29
-                  IntLiteral@28..29 "0"
-                Semicolon@29..30 ";"
-              Blankspace@30..31 " "
-              Error@31..32
+                Blankspace@10..11 " "
+                ConstantDeclaration@11..30
+                  Const@11..16 "const"
+                  Blankspace@16..17 " "
+                  Name@17..20
+                    Identifier@17..20 "foo"
+                  Colon@20..21 ":"
+                  Blankspace@21..22 " "
+                  TypeSpecifier@22..25
+                    Path@22..25
+                      Identifier@22..25 "u32"
+                  Blankspace@25..26 " "
+                  Equal@26..27 "="
+                  Blankspace@27..28 " "
+                  Literal@28..29
+                    IntLiteral@28..29 "0"
+                  Semicolon@29..30 ";"
+                Blankspace@30..31 " "
                 BraceRight@31..32 "}"
               Blankspace@32..33 " "
               ConstantDeclaration@33..52
@@ -234,10 +221,7 @@ fn module_compound_shadow() {
                 Literal@50..51
                   IntLiteral@50..51 "1"
                 Semicolon@51..52 ";"
-              Blankspace@52..61 "\n        "
-
-            error at 9..10: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'
-            error at 31..32: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
+              Blankspace@52..61 "\n        ""#]],
     );
 }
 

--- a/crates/parser/src/tests/conditional_compilation.rs
+++ b/crates/parser/src/tests/conditional_compilation.rs
@@ -3,7 +3,7 @@ use expect_test::expect;
 use crate::tests::check;
 
 #[test]
-fn module_compound() {
+fn module_compound_if_true() {
     check(
         "
         fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }
@@ -82,13 +82,167 @@ fn module_compound() {
 }
 
 #[test]
-fn module_compound_nested() {
+fn module_compound_if_false() {
     check(
         "
-        @if(true) { fn foo() {} { @if(true) fn bar() {} } @if(true) { fn baz() {} } }
+        fn f() {} @if(false) { const_assert true; fn foo() {} struct bar { x: u32 } }
         ",
         expect![[r#"
             SourceFile@0..95
+              Blankspace@0..9 "\n        "
+              FunctionDeclaration@9..18
+                Fn@9..11 "fn"
+                Blankspace@11..12 " "
+                Name@12..13
+                  Identifier@12..13 "f"
+                FunctionParameters@13..15
+                  ParenthesisLeft@13..14 "("
+                  ParenthesisRight@14..15 ")"
+                Blankspace@15..16 " "
+                CompoundStatement@16..18
+                  BraceLeft@16..17 "{"
+                  BraceRight@17..18 "}"
+              Blankspace@18..19 " "
+              AttributeList@19..29
+                IfAttribute@19..29
+                  AttributeOperator@19..20 "@"
+                  If@20..22 "if"
+                  ParenthesisLeft@22..23 "("
+                  Literal@23..28
+                    False@23..28 "false"
+                  ParenthesisRight@28..29 ")"
+              Blankspace@29..30 " "
+              GlobalCompoundDeclaration@30..86
+                BraceLeft@30..31 "{"
+                Blankspace@31..32 " "
+                AssertStatement@32..50
+                  ConstantAssert@32..44 "const_assert"
+                  Blankspace@44..45 " "
+                  Literal@45..49
+                    True@45..49 "true"
+                  Semicolon@49..50 ";"
+                Blankspace@50..51 " "
+                FunctionDeclaration@51..62
+                  Fn@51..53 "fn"
+                  Blankspace@53..54 " "
+                  Name@54..57
+                    Identifier@54..57 "foo"
+                  FunctionParameters@57..59
+                    ParenthesisLeft@57..58 "("
+                    ParenthesisRight@58..59 ")"
+                  Blankspace@59..60 " "
+                  CompoundStatement@60..62
+                    BraceLeft@60..61 "{"
+                    BraceRight@61..62 "}"
+                Blankspace@62..63 " "
+                StructDeclaration@63..84
+                  Struct@63..69 "struct"
+                  Blankspace@69..70 " "
+                  Name@70..73
+                    Identifier@70..73 "bar"
+                  Blankspace@73..74 " "
+                  StructBody@74..84
+                    BraceLeft@74..75 "{"
+                    Blankspace@75..76 " "
+                    StructMember@76..82
+                      Name@76..77
+                        Identifier@76..77 "x"
+                      Colon@77..78 ":"
+                      Blankspace@78..79 " "
+                      TypeSpecifier@79..82
+                        Path@79..82
+                          Identifier@79..82 "u32"
+                    Blankspace@82..83 " "
+                    BraceRight@83..84 "}"
+                Blankspace@84..85 " "
+                BraceRight@85..86 "}"
+              Blankspace@86..95 "\n        ""#]],
+    );
+}
+
+#[test]
+fn module_compound_if_false_elif_true() {
+    check(
+        "
+        @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; }
+        ",
+        expect![[r#"
+            SourceFile@0..88
+              Blankspace@0..9 "\n        "
+              AttributeList@9..19
+                IfAttribute@9..19
+                  AttributeOperator@9..10 "@"
+                  If@10..12 "if"
+                  ParenthesisLeft@12..13 "("
+                  Literal@13..18
+                    False@13..18 "false"
+                  ParenthesisRight@18..19 ")"
+              Blankspace@19..20 " "
+              GlobalCompoundDeclaration@20..43
+                BraceLeft@20..21 "{"
+                Blankspace@21..22 " "
+                ConstantDeclaration@22..41
+                  Const@22..27 "const"
+                  Blankspace@27..28 " "
+                  Name@28..31
+                    Identifier@28..31 "foo"
+                  Colon@31..32 ":"
+                  Blankspace@32..33 " "
+                  TypeSpecifier@33..36
+                    Path@33..36
+                      Identifier@33..36 "u32"
+                  Blankspace@36..37 " "
+                  Equal@37..38 "="
+                  Blankspace@38..39 " "
+                  Literal@39..40
+                    IntLiteral@39..40 "0"
+                  Semicolon@40..41 ";"
+                Blankspace@41..42 " "
+                BraceRight@42..43 "}"
+              Blankspace@43..44 " "
+              AttributeList@44..55
+                OtherAttribute@44..55
+                  AttributeOperator@44..45 "@"
+                  Identifier@45..49 "elif"
+                  Arguments@49..55
+                    ParenthesisLeft@49..50 "("
+                    Literal@50..54
+                      True@50..54 "true"
+                    ParenthesisRight@54..55 ")"
+              Blankspace@55..56 " "
+              GlobalCompoundDeclaration@56..79
+                BraceLeft@56..57 "{"
+                Blankspace@57..58 " "
+                ConstantDeclaration@58..77
+                  Const@58..63 "const"
+                  Blankspace@63..64 " "
+                  Name@64..67
+                    Identifier@64..67 "bar"
+                  Colon@67..68 ":"
+                  Blankspace@68..69 " "
+                  TypeSpecifier@69..72
+                    Path@69..72
+                      Identifier@69..72 "u32"
+                  Blankspace@72..73 " "
+                  Equal@73..74 "="
+                  Blankspace@74..75 " "
+                  Literal@75..76
+                    IntLiteral@75..76 "0"
+                  Semicolon@76..77 ";"
+                Blankspace@77..78 " "
+                BraceRight@78..79 "}"
+              Blankspace@79..88 "\n        ""#]],
+    );
+}
+
+#[test]
+fn module_compound_if_true_compound_elif_true() {
+    check(
+        "
+        @if(true) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; }
+        ",
+        expect![[r#"
+            SourceFile@0..87
               Blankspace@0..9 "\n        "
               AttributeList@9..18
                 IfAttribute@9..18
@@ -99,188 +253,60 @@ fn module_compound_nested() {
                     True@13..17 "true"
                   ParenthesisRight@17..18 ")"
               Blankspace@18..19 " "
-              GlobalCompoundDeclaration@19..86
+              GlobalCompoundDeclaration@19..42
                 BraceLeft@19..20 "{"
                 Blankspace@20..21 " "
-                FunctionDeclaration@21..32
-                  Fn@21..23 "fn"
-                  Blankspace@23..24 " "
-                  Name@24..27
-                    Identifier@24..27 "foo"
-                  FunctionParameters@27..29
-                    ParenthesisLeft@27..28 "("
-                    ParenthesisRight@28..29 ")"
-                  Blankspace@29..30 " "
-                  CompoundStatement@30..32
-                    BraceLeft@30..31 "{"
-                    BraceRight@31..32 "}"
-                Blankspace@32..33 " "
-                GlobalCompoundDeclaration@33..58
-                  BraceLeft@33..34 "{"
-                  Blankspace@34..35 " "
-                  AttributeList@35..44
-                    IfAttribute@35..44
-                      AttributeOperator@35..36 "@"
-                      If@36..38 "if"
-                      ParenthesisLeft@38..39 "("
-                      Literal@39..43
-                        True@39..43 "true"
-                      ParenthesisRight@43..44 ")"
-                  Blankspace@44..45 " "
-                  FunctionDeclaration@45..56
-                    Fn@45..47 "fn"
-                    Blankspace@47..48 " "
-                    Name@48..51
-                      Identifier@48..51 "bar"
-                    FunctionParameters@51..53
-                      ParenthesisLeft@51..52 "("
-                      ParenthesisRight@52..53 ")"
-                    Blankspace@53..54 " "
-                    CompoundStatement@54..56
-                      BraceLeft@54..55 "{"
-                      BraceRight@55..56 "}"
-                  Blankspace@56..57 " "
-                  BraceRight@57..58 "}"
-                Blankspace@58..59 " "
-                AttributeList@59..68
-                  IfAttribute@59..68
-                    AttributeOperator@59..60 "@"
-                    If@60..62 "if"
-                    ParenthesisLeft@62..63 "("
-                    Literal@63..67
-                      True@63..67 "true"
-                    ParenthesisRight@67..68 ")"
-                Blankspace@68..69 " "
-                GlobalCompoundDeclaration@69..84
-                  BraceLeft@69..70 "{"
-                  Blankspace@70..71 " "
-                  FunctionDeclaration@71..82
-                    Fn@71..73 "fn"
-                    Blankspace@73..74 " "
-                    Name@74..77
-                      Identifier@74..77 "baz"
-                    FunctionParameters@77..79
-                      ParenthesisLeft@77..78 "("
-                      ParenthesisRight@78..79 ")"
-                    Blankspace@79..80 " "
-                    CompoundStatement@80..82
-                      BraceLeft@80..81 "{"
-                      BraceRight@81..82 "}"
-                  Blankspace@82..83 " "
-                  BraceRight@83..84 "}"
-                Blankspace@84..85 " "
-                BraceRight@85..86 "}"
-              Blankspace@86..95 "\n        ""#]],
-    );
-}
-
-#[test]
-fn module_compound_shadow() {
-    check(
-        "
-        { const foo: u32 = 0; } const foo: u32 = 1;
-        ",
-        expect![[r#"
-            SourceFile@0..61
-              Blankspace@0..9 "\n        "
-              GlobalCompoundDeclaration@9..32
-                BraceLeft@9..10 "{"
-                Blankspace@10..11 " "
-                ConstantDeclaration@11..30
-                  Const@11..16 "const"
-                  Blankspace@16..17 " "
-                  Name@17..20
-                    Identifier@17..20 "foo"
-                  Colon@20..21 ":"
-                  Blankspace@21..22 " "
-                  TypeSpecifier@22..25
-                    Path@22..25
-                      Identifier@22..25 "u32"
-                  Blankspace@25..26 " "
-                  Equal@26..27 "="
-                  Blankspace@27..28 " "
-                  Literal@28..29
-                    IntLiteral@28..29 "0"
-                  Semicolon@29..30 ";"
-                Blankspace@30..31 " "
-                BraceRight@31..32 "}"
-              Blankspace@32..33 " "
-              ConstantDeclaration@33..52
-                Const@33..38 "const"
-                Blankspace@38..39 " "
-                Name@39..42
-                  Identifier@39..42 "foo"
-                Colon@42..43 ":"
-                Blankspace@43..44 " "
-                TypeSpecifier@44..47
-                  Path@44..47
-                    Identifier@44..47 "u32"
-                Blankspace@47..48 " "
-                Equal@48..49 "="
-                Blankspace@49..50 " "
-                Literal@50..51
-                  IntLiteral@50..51 "1"
-                Semicolon@51..52 ";"
-              Blankspace@52..61 "\n        ""#]],
-    );
-}
-
-#[test]
-fn function_compound() {
-    check(
-        "
-        fn foo() { @if(true) { var x = 0; } x++; }
-        ",
-        expect![[r#"
-            SourceFile@0..60
-              Blankspace@0..9 "\n        "
-              FunctionDeclaration@9..51
-                Fn@9..11 "fn"
-                Blankspace@11..12 " "
-                Name@12..15
-                  Identifier@12..15 "foo"
-                FunctionParameters@15..17
-                  ParenthesisLeft@15..16 "("
-                  ParenthesisRight@16..17 ")"
-                Blankspace@17..18 " "
-                CompoundStatement@18..51
-                  BraceLeft@18..19 "{"
-                  Blankspace@19..20 " "
-                  AttributeList@20..29
-                    IfAttribute@20..29
-                      AttributeOperator@20..21 "@"
-                      If@21..23 "if"
-                      ParenthesisLeft@23..24 "("
-                      Literal@24..28
-                        True@24..28 "true"
-                      ParenthesisRight@28..29 ")"
-                  Blankspace@29..30 " "
-                  CompoundStatement@30..44
-                    BraceLeft@30..31 "{"
-                    Blankspace@31..32 " "
-                    VariableDeclaration@32..42
-                      Var@32..35 "var"
-                      Blankspace@35..36 " "
-                      Name@36..37
-                        Identifier@36..37 "x"
-                      Blankspace@37..38 " "
-                      Equal@38..39 "="
-                      Blankspace@39..40 " "
-                      Literal@40..41
-                        IntLiteral@40..41 "0"
-                      Semicolon@41..42 ";"
-                    Blankspace@42..43 " "
-                    BraceRight@43..44 "}"
-                  Blankspace@44..45 " "
-                  IncrementDecrementStatement@45..49
-                    IdentExpression@45..46
-                      Path@45..46
-                        Identifier@45..46 "x"
-                    PlusPlus@46..48 "++"
-                    Semicolon@48..49 ";"
-                  Blankspace@49..50 " "
-                  BraceRight@50..51 "}"
-              Blankspace@51..60 "\n        ""#]],
+                ConstantDeclaration@21..40
+                  Const@21..26 "const"
+                  Blankspace@26..27 " "
+                  Name@27..30
+                    Identifier@27..30 "foo"
+                  Colon@30..31 ":"
+                  Blankspace@31..32 " "
+                  TypeSpecifier@32..35
+                    Path@32..35
+                      Identifier@32..35 "u32"
+                  Blankspace@35..36 " "
+                  Equal@36..37 "="
+                  Blankspace@37..38 " "
+                  Literal@38..39
+                    IntLiteral@38..39 "0"
+                  Semicolon@39..40 ";"
+                Blankspace@40..41 " "
+                BraceRight@41..42 "}"
+              Blankspace@42..43 " "
+              AttributeList@43..54
+                OtherAttribute@43..54
+                  AttributeOperator@43..44 "@"
+                  Identifier@44..48 "elif"
+                  Arguments@48..54
+                    ParenthesisLeft@48..49 "("
+                    Literal@49..53
+                      True@49..53 "true"
+                    ParenthesisRight@53..54 ")"
+              Blankspace@54..55 " "
+              GlobalCompoundDeclaration@55..78
+                BraceLeft@55..56 "{"
+                Blankspace@56..57 " "
+                ConstantDeclaration@57..76
+                  Const@57..62 "const"
+                  Blankspace@62..63 " "
+                  Name@63..66
+                    Identifier@63..66 "bar"
+                  Colon@66..67 ":"
+                  Blankspace@67..68 " "
+                  TypeSpecifier@68..71
+                    Path@68..71
+                      Identifier@68..71 "u32"
+                  Blankspace@71..72 " "
+                  Equal@72..73 "="
+                  Blankspace@73..74 " "
+                  Literal@74..75
+                    IntLiteral@74..75 "0"
+                  Semicolon@75..76 ";"
+                Blankspace@76..77 " "
+                BraceRight@77..78 "}"
+              Blankspace@78..87 "\n        ""#]],
     );
 }
 
@@ -375,5 +401,2178 @@ fn function_compound_nested() {
                   Blankspace@82..83 " "
                   BraceRight@83..84 "}"
               Blankspace@84..93 "\n        ""#]],
+    );
+}
+
+#[test]
+fn module_if_false_compound_elif_true() {
+    check(
+        "@if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; }",
+        expect![[r#"
+            SourceFile@0..66
+              AttributeList@0..10
+                IfAttribute@0..10
+                  AttributeOperator@0..1 "@"
+                  If@1..3 "if"
+                  ParenthesisLeft@3..4 "("
+                  Literal@4..9
+                    False@4..9 "false"
+                  ParenthesisRight@9..10 ")"
+              Blankspace@10..11 " "
+              ConstantDeclaration@11..30
+                Const@11..16 "const"
+                Blankspace@16..17 " "
+                Name@17..20
+                  Identifier@17..20 "foo"
+                Colon@20..21 ":"
+                Blankspace@21..22 " "
+                TypeSpecifier@22..25
+                  Path@22..25
+                    Identifier@22..25 "u32"
+                Blankspace@25..26 " "
+                Equal@26..27 "="
+                Blankspace@27..28 " "
+                Literal@28..29
+                  IntLiteral@28..29 "0"
+                Semicolon@29..30 ";"
+              Blankspace@30..31 " "
+              AttributeList@31..42
+                OtherAttribute@31..42
+                  AttributeOperator@31..32 "@"
+                  Identifier@32..36 "elif"
+                  Arguments@36..42
+                    ParenthesisLeft@36..37 "("
+                    Literal@37..41
+                      True@37..41 "true"
+                    ParenthesisRight@41..42 ")"
+              Blankspace@42..43 " "
+              GlobalCompoundDeclaration@43..66
+                BraceLeft@43..44 "{"
+                Blankspace@44..45 " "
+                ConstantDeclaration@45..64
+                  Const@45..50 "const"
+                  Blankspace@50..51 " "
+                  Name@51..54
+                    Identifier@51..54 "bar"
+                  Colon@54..55 ":"
+                  Blankspace@55..56 " "
+                  TypeSpecifier@56..59
+                    Path@56..59
+                      Identifier@56..59 "u32"
+                  Blankspace@59..60 " "
+                  Equal@60..61 "="
+                  Blankspace@61..62 " "
+                  Literal@62..63
+                    IntLiteral@62..63 "0"
+                  Semicolon@63..64 ";"
+                Blankspace@64..65 " "
+                BraceRight@65..66 "}""#]],
+    );
+}
+
+#[test]
+fn module_if_true_compound_elif_true() {
+    check(
+        "@if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; }",
+        expect![[r#"
+            SourceFile@0..65
+              AttributeList@0..9
+                IfAttribute@0..9
+                  AttributeOperator@0..1 "@"
+                  If@1..3 "if"
+                  ParenthesisLeft@3..4 "("
+                  Literal@4..8
+                    True@4..8 "true"
+                  ParenthesisRight@8..9 ")"
+              Blankspace@9..10 " "
+              ConstantDeclaration@10..29
+                Const@10..15 "const"
+                Blankspace@15..16 " "
+                Name@16..19
+                  Identifier@16..19 "foo"
+                Colon@19..20 ":"
+                Blankspace@20..21 " "
+                TypeSpecifier@21..24
+                  Path@21..24
+                    Identifier@21..24 "u32"
+                Blankspace@24..25 " "
+                Equal@25..26 "="
+                Blankspace@26..27 " "
+                Literal@27..28
+                  IntLiteral@27..28 "0"
+                Semicolon@28..29 ";"
+              Blankspace@29..30 " "
+              AttributeList@30..41
+                OtherAttribute@30..41
+                  AttributeOperator@30..31 "@"
+                  Identifier@31..35 "elif"
+                  Arguments@35..41
+                    ParenthesisLeft@35..36 "("
+                    Literal@36..40
+                      True@36..40 "true"
+                    ParenthesisRight@40..41 ")"
+              Blankspace@41..42 " "
+              GlobalCompoundDeclaration@42..65
+                BraceLeft@42..43 "{"
+                Blankspace@43..44 " "
+                ConstantDeclaration@44..63
+                  Const@44..49 "const"
+                  Blankspace@49..50 " "
+                  Name@50..53
+                    Identifier@50..53 "bar"
+                  Colon@53..54 ":"
+                  Blankspace@54..55 " "
+                  TypeSpecifier@55..58
+                    Path@55..58
+                      Identifier@55..58 "u32"
+                  Blankspace@58..59 " "
+                  Equal@59..60 "="
+                  Blankspace@60..61 " "
+                  Literal@61..62
+                    IntLiteral@61..62 "0"
+                  Semicolon@62..63 ";"
+                Blankspace@63..64 " "
+                BraceRight@64..65 "}""#]],
+    );
+}
+
+#[test]
+fn module_compound_else_hit() {
+    check(
+        "@if(false) { const foo: u32 = 0; } @elif(false) { const bar: u32 = 0; } @else { const baz: u32 = 0; }",
+        expect![[r#"
+            SourceFile@0..101
+              AttributeList@0..10
+                IfAttribute@0..10
+                  AttributeOperator@0..1 "@"
+                  If@1..3 "if"
+                  ParenthesisLeft@3..4 "("
+                  Literal@4..9
+                    False@4..9 "false"
+                  ParenthesisRight@9..10 ")"
+              Blankspace@10..11 " "
+              GlobalCompoundDeclaration@11..34
+                BraceLeft@11..12 "{"
+                Blankspace@12..13 " "
+                ConstantDeclaration@13..32
+                  Const@13..18 "const"
+                  Blankspace@18..19 " "
+                  Name@19..22
+                    Identifier@19..22 "foo"
+                  Colon@22..23 ":"
+                  Blankspace@23..24 " "
+                  TypeSpecifier@24..27
+                    Path@24..27
+                      Identifier@24..27 "u32"
+                  Blankspace@27..28 " "
+                  Equal@28..29 "="
+                  Blankspace@29..30 " "
+                  Literal@30..31
+                    IntLiteral@30..31 "0"
+                  Semicolon@31..32 ";"
+                Blankspace@32..33 " "
+                BraceRight@33..34 "}"
+              Blankspace@34..35 " "
+              AttributeList@35..47
+                OtherAttribute@35..47
+                  AttributeOperator@35..36 "@"
+                  Identifier@36..40 "elif"
+                  Arguments@40..47
+                    ParenthesisLeft@40..41 "("
+                    Literal@41..46
+                      False@41..46 "false"
+                    ParenthesisRight@46..47 ")"
+              Blankspace@47..48 " "
+              GlobalCompoundDeclaration@48..71
+                BraceLeft@48..49 "{"
+                Blankspace@49..50 " "
+                ConstantDeclaration@50..69
+                  Const@50..55 "const"
+                  Blankspace@55..56 " "
+                  Name@56..59
+                    Identifier@56..59 "bar"
+                  Colon@59..60 ":"
+                  Blankspace@60..61 " "
+                  TypeSpecifier@61..64
+                    Path@61..64
+                      Identifier@61..64 "u32"
+                  Blankspace@64..65 " "
+                  Equal@65..66 "="
+                  Blankspace@66..67 " "
+                  Literal@67..68
+                    IntLiteral@67..68 "0"
+                  Semicolon@68..69 ";"
+                Blankspace@69..70 " "
+                BraceRight@70..71 "}"
+              Blankspace@71..72 " "
+              AttributeList@72..77
+                ElseAttribute@72..77
+                  AttributeOperator@72..73 "@"
+                  Else@73..77 "else"
+              Blankspace@77..78 " "
+              GlobalCompoundDeclaration@78..101
+                BraceLeft@78..79 "{"
+                Blankspace@79..80 " "
+                ConstantDeclaration@80..99
+                  Const@80..85 "const"
+                  Blankspace@85..86 " "
+                  Name@86..89
+                    Identifier@86..89 "baz"
+                  Colon@89..90 ":"
+                  Blankspace@90..91 " "
+                  TypeSpecifier@91..94
+                    Path@91..94
+                      Identifier@91..94 "u32"
+                  Blankspace@94..95 " "
+                  Equal@95..96 "="
+                  Blankspace@96..97 " "
+                  Literal@97..98
+                    IntLiteral@97..98 "0"
+                  Semicolon@98..99 ";"
+                Blankspace@99..100 " "
+                BraceRight@100..101 "}""#]],
+    );
+}
+
+#[test]
+fn module_compound_else_skipped() {
+    check(
+        "@if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } @else { const baz: u32 = 0; }",
+        expect![[r#"
+            SourceFile@0..100
+              AttributeList@0..10
+                IfAttribute@0..10
+                  AttributeOperator@0..1 "@"
+                  If@1..3 "if"
+                  ParenthesisLeft@3..4 "("
+                  Literal@4..9
+                    False@4..9 "false"
+                  ParenthesisRight@9..10 ")"
+              Blankspace@10..11 " "
+              GlobalCompoundDeclaration@11..34
+                BraceLeft@11..12 "{"
+                Blankspace@12..13 " "
+                ConstantDeclaration@13..32
+                  Const@13..18 "const"
+                  Blankspace@18..19 " "
+                  Name@19..22
+                    Identifier@19..22 "foo"
+                  Colon@22..23 ":"
+                  Blankspace@23..24 " "
+                  TypeSpecifier@24..27
+                    Path@24..27
+                      Identifier@24..27 "u32"
+                  Blankspace@27..28 " "
+                  Equal@28..29 "="
+                  Blankspace@29..30 " "
+                  Literal@30..31
+                    IntLiteral@30..31 "0"
+                  Semicolon@31..32 ";"
+                Blankspace@32..33 " "
+                BraceRight@33..34 "}"
+              Blankspace@34..35 " "
+              AttributeList@35..46
+                OtherAttribute@35..46
+                  AttributeOperator@35..36 "@"
+                  Identifier@36..40 "elif"
+                  Arguments@40..46
+                    ParenthesisLeft@40..41 "("
+                    Literal@41..45
+                      True@41..45 "true"
+                    ParenthesisRight@45..46 ")"
+              Blankspace@46..47 " "
+              GlobalCompoundDeclaration@47..70
+                BraceLeft@47..48 "{"
+                Blankspace@48..49 " "
+                ConstantDeclaration@49..68
+                  Const@49..54 "const"
+                  Blankspace@54..55 " "
+                  Name@55..58
+                    Identifier@55..58 "bar"
+                  Colon@58..59 ":"
+                  Blankspace@59..60 " "
+                  TypeSpecifier@60..63
+                    Path@60..63
+                      Identifier@60..63 "u32"
+                  Blankspace@63..64 " "
+                  Equal@64..65 "="
+                  Blankspace@65..66 " "
+                  Literal@66..67
+                    IntLiteral@66..67 "0"
+                  Semicolon@67..68 ";"
+                Blankspace@68..69 " "
+                BraceRight@69..70 "}"
+              Blankspace@70..71 " "
+              AttributeList@71..76
+                ElseAttribute@71..76
+                  AttributeOperator@71..72 "@"
+                  Else@72..76 "else"
+              Blankspace@76..77 " "
+              GlobalCompoundDeclaration@77..100
+                BraceLeft@77..78 "{"
+                Blankspace@78..79 " "
+                ConstantDeclaration@79..98
+                  Const@79..84 "const"
+                  Blankspace@84..85 " "
+                  Name@85..88
+                    Identifier@85..88 "baz"
+                  Colon@88..89 ":"
+                  Blankspace@89..90 " "
+                  TypeSpecifier@90..93
+                    Path@90..93
+                      Identifier@90..93 "u32"
+                  Blankspace@93..94 " "
+                  Equal@94..95 "="
+                  Blankspace@95..96 " "
+                  Literal@96..97
+                    IntLiteral@96..97 "0"
+                  Semicolon@97..98 ";"
+                Blankspace@98..99 " "
+                BraceRight@99..100 "}""#]],
+    );
+}
+
+#[test]
+fn module_compound_noop() {
+    check("{ fn foo() {} }", expect![[r#"
+        SourceFile@0..15
+          GlobalCompoundDeclaration@0..15
+            BraceLeft@0..1 "{"
+            Blankspace@1..2 " "
+            FunctionDeclaration@2..13
+              Fn@2..4 "fn"
+              Blankspace@4..5 " "
+              Name@5..8
+                Identifier@5..8 "foo"
+              FunctionParameters@8..10
+                ParenthesisLeft@8..9 "("
+                ParenthesisRight@9..10 ")"
+              Blankspace@10..11 " "
+              CompoundStatement@11..13
+                BraceLeft@11..12 "{"
+                BraceRight@12..13 "}"
+            Blankspace@13..14 " "
+            BraceRight@14..15 "}""#]]);
+}
+
+#[test]
+fn module_compound_nested_noop() {
+    check(
+        "@if (true) { fn foo() {} { @if(true) fn bar() {} } }",
+        expect![[r#"
+            SourceFile@0..52
+              AttributeList@0..10
+                IfAttribute@0..10
+                  AttributeOperator@0..1 "@"
+                  If@1..3 "if"
+                  Blankspace@3..4 " "
+                  ParenthesisLeft@4..5 "("
+                  Literal@5..9
+                    True@5..9 "true"
+                  ParenthesisRight@9..10 ")"
+              Blankspace@10..11 " "
+              GlobalCompoundDeclaration@11..52
+                BraceLeft@11..12 "{"
+                Blankspace@12..13 " "
+                FunctionDeclaration@13..24
+                  Fn@13..15 "fn"
+                  Blankspace@15..16 " "
+                  Name@16..19
+                    Identifier@16..19 "foo"
+                  FunctionParameters@19..21
+                    ParenthesisLeft@19..20 "("
+                    ParenthesisRight@20..21 ")"
+                  Blankspace@21..22 " "
+                  CompoundStatement@22..24
+                    BraceLeft@22..23 "{"
+                    BraceRight@23..24 "}"
+                Blankspace@24..25 " "
+                GlobalCompoundDeclaration@25..50
+                  BraceLeft@25..26 "{"
+                  Blankspace@26..27 " "
+                  AttributeList@27..36
+                    IfAttribute@27..36
+                      AttributeOperator@27..28 "@"
+                      If@28..30 "if"
+                      ParenthesisLeft@30..31 "("
+                      Literal@31..35
+                        True@31..35 "true"
+                      ParenthesisRight@35..36 ")"
+                  Blankspace@36..37 " "
+                  FunctionDeclaration@37..48
+                    Fn@37..39 "fn"
+                    Blankspace@39..40 " "
+                    Name@40..43
+                      Identifier@40..43 "bar"
+                    FunctionParameters@43..45
+                      ParenthesisLeft@43..44 "("
+                      ParenthesisRight@44..45 ")"
+                    Blankspace@45..46 " "
+                    CompoundStatement@46..48
+                      BraceLeft@46..47 "{"
+                      BraceRight@47..48 "}"
+                  Blankspace@48..49 " "
+                  BraceRight@49..50 "}"
+                Blankspace@50..51 " "
+                BraceRight@51..52 "}""#]],
+    );
+}
+
+#[test]
+fn module_compound_nested_if() {
+    check(
+        "@if(true) { fn foo() {} @if(true) { fn bar() {} } }",
+        expect![[r#"
+            SourceFile@0..51
+              AttributeList@0..9
+                IfAttribute@0..9
+                  AttributeOperator@0..1 "@"
+                  If@1..3 "if"
+                  ParenthesisLeft@3..4 "("
+                  Literal@4..8
+                    True@4..8 "true"
+                  ParenthesisRight@8..9 ")"
+              Blankspace@9..10 " "
+              GlobalCompoundDeclaration@10..51
+                BraceLeft@10..11 "{"
+                Blankspace@11..12 " "
+                FunctionDeclaration@12..23
+                  Fn@12..14 "fn"
+                  Blankspace@14..15 " "
+                  Name@15..18
+                    Identifier@15..18 "foo"
+                  FunctionParameters@18..20
+                    ParenthesisLeft@18..19 "("
+                    ParenthesisRight@19..20 ")"
+                  Blankspace@20..21 " "
+                  CompoundStatement@21..23
+                    BraceLeft@21..22 "{"
+                    BraceRight@22..23 "}"
+                Blankspace@23..24 " "
+                AttributeList@24..33
+                  IfAttribute@24..33
+                    AttributeOperator@24..25 "@"
+                    If@25..27 "if"
+                    ParenthesisLeft@27..28 "("
+                    Literal@28..32
+                      True@28..32 "true"
+                    ParenthesisRight@32..33 ")"
+                Blankspace@33..34 " "
+                GlobalCompoundDeclaration@34..49
+                  BraceLeft@34..35 "{"
+                  Blankspace@35..36 " "
+                  FunctionDeclaration@36..47
+                    Fn@36..38 "fn"
+                    Blankspace@38..39 " "
+                    Name@39..42
+                      Identifier@39..42 "bar"
+                    FunctionParameters@42..44
+                      ParenthesisLeft@42..43 "("
+                      ParenthesisRight@43..44 ")"
+                    Blankspace@44..45 " "
+                    CompoundStatement@45..47
+                      BraceLeft@45..46 "{"
+                      BraceRight@46..47 "}"
+                  Blankspace@47..48 " "
+                  BraceRight@48..49 "}"
+                Blankspace@49..50 " "
+                BraceRight@50..51 "}""#]],
+    );
+}
+
+#[test]
+fn module_compound_nested_elif_hit() {
+    check(
+        "@if(true) { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![[r#"
+            SourceFile@0..110
+              AttributeList@0..9
+                IfAttribute@0..9
+                  AttributeOperator@0..1 "@"
+                  If@1..3 "if"
+                  ParenthesisLeft@3..4 "("
+                  Literal@4..8
+                    True@4..8 "true"
+                  ParenthesisRight@8..9 ")"
+              Blankspace@9..10 " "
+              GlobalCompoundDeclaration@10..80
+                BraceLeft@10..11 "{"
+                Blankspace@11..12 " "
+                AttributeList@12..22
+                  IfAttribute@12..22
+                    AttributeOperator@12..13 "@"
+                    If@13..15 "if"
+                    ParenthesisLeft@15..16 "("
+                    Literal@16..21
+                      False@16..21 "false"
+                    ParenthesisRight@21..22 ")"
+                Blankspace@22..23 " "
+                ConstantDeclaration@23..42
+                  Const@23..28 "const"
+                  Blankspace@28..29 " "
+                  Name@29..32
+                    Identifier@29..32 "foo"
+                  Colon@32..33 ":"
+                  Blankspace@33..34 " "
+                  TypeSpecifier@34..37
+                    Path@34..37
+                      Identifier@34..37 "u32"
+                  Blankspace@37..38 " "
+                  Equal@38..39 "="
+                  Blankspace@39..40 " "
+                  Literal@40..41
+                    IntLiteral@40..41 "0"
+                  Semicolon@41..42 ";"
+                Blankspace@42..43 " "
+                AttributeList@43..54
+                  OtherAttribute@43..54
+                    AttributeOperator@43..44 "@"
+                    Identifier@44..48 "elif"
+                    Arguments@48..54
+                      ParenthesisLeft@48..49 "("
+                      Literal@49..53
+                        True@49..53 "true"
+                      ParenthesisRight@53..54 ")"
+                Blankspace@54..55 " "
+                GlobalCompoundDeclaration@55..78
+                  BraceLeft@55..56 "{"
+                  Blankspace@56..57 " "
+                  ConstantDeclaration@57..76
+                    Const@57..62 "const"
+                    Blankspace@62..63 " "
+                    Name@63..66
+                      Identifier@63..66 "bar"
+                    Colon@66..67 ":"
+                    Blankspace@67..68 " "
+                    TypeSpecifier@68..71
+                      Path@68..71
+                        Identifier@68..71 "u32"
+                    Blankspace@71..72 " "
+                    Equal@72..73 "="
+                    Blankspace@73..74 " "
+                    Literal@74..75
+                      IntLiteral@74..75 "0"
+                    Semicolon@75..76 ";"
+                  Blankspace@76..77 " "
+                  BraceRight@77..78 "}"
+                Blankspace@78..79 " "
+                BraceRight@79..80 "}"
+              Blankspace@80..81 " "
+              AttributeList@81..86
+                ElseAttribute@81..86
+                  AttributeOperator@81..82 "@"
+                  Else@82..86 "else"
+              Blankspace@86..87 " "
+              GlobalCompoundDeclaration@87..110
+                BraceLeft@87..88 "{"
+                Blankspace@88..89 " "
+                ConstantDeclaration@89..108
+                  Const@89..94 "const"
+                  Blankspace@94..95 " "
+                  Name@95..98
+                    Identifier@95..98 "baz"
+                  Colon@98..99 ":"
+                  Blankspace@99..100 " "
+                  TypeSpecifier@100..103
+                    Path@100..103
+                      Identifier@100..103 "u32"
+                  Blankspace@103..104 " "
+                  Equal@104..105 "="
+                  Blankspace@105..106 " "
+                  Literal@106..107
+                    IntLiteral@106..107 "0"
+                  Semicolon@107..108 ";"
+                Blankspace@108..109 " "
+                BraceRight@109..110 "}""#]],
+    );
+}
+
+#[test]
+fn module_compound_nested_elif_skipped() {
+    check(
+        "@if(true) { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![[r#"
+            SourceFile@0..109
+              AttributeList@0..9
+                IfAttribute@0..9
+                  AttributeOperator@0..1 "@"
+                  If@1..3 "if"
+                  ParenthesisLeft@3..4 "("
+                  Literal@4..8
+                    True@4..8 "true"
+                  ParenthesisRight@8..9 ")"
+              Blankspace@9..10 " "
+              GlobalCompoundDeclaration@10..79
+                BraceLeft@10..11 "{"
+                Blankspace@11..12 " "
+                AttributeList@12..21
+                  IfAttribute@12..21
+                    AttributeOperator@12..13 "@"
+                    If@13..15 "if"
+                    ParenthesisLeft@15..16 "("
+                    Literal@16..20
+                      True@16..20 "true"
+                    ParenthesisRight@20..21 ")"
+                Blankspace@21..22 " "
+                ConstantDeclaration@22..41
+                  Const@22..27 "const"
+                  Blankspace@27..28 " "
+                  Name@28..31
+                    Identifier@28..31 "foo"
+                  Colon@31..32 ":"
+                  Blankspace@32..33 " "
+                  TypeSpecifier@33..36
+                    Path@33..36
+                      Identifier@33..36 "u32"
+                  Blankspace@36..37 " "
+                  Equal@37..38 "="
+                  Blankspace@38..39 " "
+                  Literal@39..40
+                    IntLiteral@39..40 "0"
+                  Semicolon@40..41 ";"
+                Blankspace@41..42 " "
+                AttributeList@42..53
+                  OtherAttribute@42..53
+                    AttributeOperator@42..43 "@"
+                    Identifier@43..47 "elif"
+                    Arguments@47..53
+                      ParenthesisLeft@47..48 "("
+                      Literal@48..52
+                        True@48..52 "true"
+                      ParenthesisRight@52..53 ")"
+                Blankspace@53..54 " "
+                GlobalCompoundDeclaration@54..77
+                  BraceLeft@54..55 "{"
+                  Blankspace@55..56 " "
+                  ConstantDeclaration@56..75
+                    Const@56..61 "const"
+                    Blankspace@61..62 " "
+                    Name@62..65
+                      Identifier@62..65 "bar"
+                    Colon@65..66 ":"
+                    Blankspace@66..67 " "
+                    TypeSpecifier@67..70
+                      Path@67..70
+                        Identifier@67..70 "u32"
+                    Blankspace@70..71 " "
+                    Equal@71..72 "="
+                    Blankspace@72..73 " "
+                    Literal@73..74
+                      IntLiteral@73..74 "0"
+                    Semicolon@74..75 ";"
+                  Blankspace@75..76 " "
+                  BraceRight@76..77 "}"
+                Blankspace@77..78 " "
+                BraceRight@78..79 "}"
+              Blankspace@79..80 " "
+              AttributeList@80..85
+                ElseAttribute@80..85
+                  AttributeOperator@80..81 "@"
+                  Else@81..85 "else"
+              Blankspace@85..86 " "
+              GlobalCompoundDeclaration@86..109
+                BraceLeft@86..87 "{"
+                Blankspace@87..88 " "
+                ConstantDeclaration@88..107
+                  Const@88..93 "const"
+                  Blankspace@93..94 " "
+                  Name@94..97
+                    Identifier@94..97 "baz"
+                  Colon@97..98 ":"
+                  Blankspace@98..99 " "
+                  TypeSpecifier@99..102
+                    Path@99..102
+                      Identifier@99..102 "u32"
+                  Blankspace@102..103 " "
+                  Equal@103..104 "="
+                  Blankspace@104..105 " "
+                  Literal@105..106
+                    IntLiteral@105..106 "0"
+                  Semicolon@106..107 ";"
+                Blankspace@107..108 " "
+                BraceRight@108..109 "}""#]],
+    );
+}
+
+#[test]
+fn module_compound_nested_else_hit() {
+    check(
+        "@if(true) { @if(false) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![[r#"
+            SourceFile@0..104
+              AttributeList@0..9
+                IfAttribute@0..9
+                  AttributeOperator@0..1 "@"
+                  If@1..3 "if"
+                  ParenthesisLeft@3..4 "("
+                  Literal@4..8
+                    True@4..8 "true"
+                  ParenthesisRight@8..9 ")"
+              Blankspace@9..10 " "
+              GlobalCompoundDeclaration@10..74
+                BraceLeft@10..11 "{"
+                Blankspace@11..12 " "
+                AttributeList@12..22
+                  IfAttribute@12..22
+                    AttributeOperator@12..13 "@"
+                    If@13..15 "if"
+                    ParenthesisLeft@15..16 "("
+                    Literal@16..21
+                      False@16..21 "false"
+                    ParenthesisRight@21..22 ")"
+                Blankspace@22..23 " "
+                ConstantDeclaration@23..42
+                  Const@23..28 "const"
+                  Blankspace@28..29 " "
+                  Name@29..32
+                    Identifier@29..32 "foo"
+                  Colon@32..33 ":"
+                  Blankspace@33..34 " "
+                  TypeSpecifier@34..37
+                    Path@34..37
+                      Identifier@34..37 "u32"
+                  Blankspace@37..38 " "
+                  Equal@38..39 "="
+                  Blankspace@39..40 " "
+                  Literal@40..41
+                    IntLiteral@40..41 "0"
+                  Semicolon@41..42 ";"
+                Blankspace@42..43 " "
+                AttributeList@43..48
+                  ElseAttribute@43..48
+                    AttributeOperator@43..44 "@"
+                    Else@44..48 "else"
+                Blankspace@48..49 " "
+                GlobalCompoundDeclaration@49..72
+                  BraceLeft@49..50 "{"
+                  Blankspace@50..51 " "
+                  ConstantDeclaration@51..70
+                    Const@51..56 "const"
+                    Blankspace@56..57 " "
+                    Name@57..60
+                      Identifier@57..60 "bar"
+                    Colon@60..61 ":"
+                    Blankspace@61..62 " "
+                    TypeSpecifier@62..65
+                      Path@62..65
+                        Identifier@62..65 "u32"
+                    Blankspace@65..66 " "
+                    Equal@66..67 "="
+                    Blankspace@67..68 " "
+                    Literal@68..69
+                      IntLiteral@68..69 "0"
+                    Semicolon@69..70 ";"
+                  Blankspace@70..71 " "
+                  BraceRight@71..72 "}"
+                Blankspace@72..73 " "
+                BraceRight@73..74 "}"
+              Blankspace@74..75 " "
+              AttributeList@75..80
+                ElseAttribute@75..80
+                  AttributeOperator@75..76 "@"
+                  Else@76..80 "else"
+              Blankspace@80..81 " "
+              GlobalCompoundDeclaration@81..104
+                BraceLeft@81..82 "{"
+                Blankspace@82..83 " "
+                ConstantDeclaration@83..102
+                  Const@83..88 "const"
+                  Blankspace@88..89 " "
+                  Name@89..92
+                    Identifier@89..92 "baz"
+                  Colon@92..93 ":"
+                  Blankspace@93..94 " "
+                  TypeSpecifier@94..97
+                    Path@94..97
+                      Identifier@94..97 "u32"
+                  Blankspace@97..98 " "
+                  Equal@98..99 "="
+                  Blankspace@99..100 " "
+                  Literal@100..101
+                    IntLiteral@100..101 "0"
+                  Semicolon@101..102 ";"
+                Blankspace@102..103 " "
+                BraceRight@103..104 "}""#]],
+    );
+}
+
+#[test]
+fn module_compound_nested_else_skipped() {
+    check(
+        "@if(true) { @if(true) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; }",
+        expect![[r#"
+            SourceFile@0..103
+              AttributeList@0..9
+                IfAttribute@0..9
+                  AttributeOperator@0..1 "@"
+                  If@1..3 "if"
+                  ParenthesisLeft@3..4 "("
+                  Literal@4..8
+                    True@4..8 "true"
+                  ParenthesisRight@8..9 ")"
+              Blankspace@9..10 " "
+              GlobalCompoundDeclaration@10..73
+                BraceLeft@10..11 "{"
+                Blankspace@11..12 " "
+                AttributeList@12..21
+                  IfAttribute@12..21
+                    AttributeOperator@12..13 "@"
+                    If@13..15 "if"
+                    ParenthesisLeft@15..16 "("
+                    Literal@16..20
+                      True@16..20 "true"
+                    ParenthesisRight@20..21 ")"
+                Blankspace@21..22 " "
+                ConstantDeclaration@22..41
+                  Const@22..27 "const"
+                  Blankspace@27..28 " "
+                  Name@28..31
+                    Identifier@28..31 "foo"
+                  Colon@31..32 ":"
+                  Blankspace@32..33 " "
+                  TypeSpecifier@33..36
+                    Path@33..36
+                      Identifier@33..36 "u32"
+                  Blankspace@36..37 " "
+                  Equal@37..38 "="
+                  Blankspace@38..39 " "
+                  Literal@39..40
+                    IntLiteral@39..40 "0"
+                  Semicolon@40..41 ";"
+                Blankspace@41..42 " "
+                AttributeList@42..47
+                  ElseAttribute@42..47
+                    AttributeOperator@42..43 "@"
+                    Else@43..47 "else"
+                Blankspace@47..48 " "
+                GlobalCompoundDeclaration@48..71
+                  BraceLeft@48..49 "{"
+                  Blankspace@49..50 " "
+                  ConstantDeclaration@50..69
+                    Const@50..55 "const"
+                    Blankspace@55..56 " "
+                    Name@56..59
+                      Identifier@56..59 "bar"
+                    Colon@59..60 ":"
+                    Blankspace@60..61 " "
+                    TypeSpecifier@61..64
+                      Path@61..64
+                        Identifier@61..64 "u32"
+                    Blankspace@64..65 " "
+                    Equal@65..66 "="
+                    Blankspace@66..67 " "
+                    Literal@67..68
+                      IntLiteral@67..68 "0"
+                    Semicolon@68..69 ";"
+                  Blankspace@69..70 " "
+                  BraceRight@70..71 "}"
+                Blankspace@71..72 " "
+                BraceRight@72..73 "}"
+              Blankspace@73..74 " "
+              AttributeList@74..79
+                ElseAttribute@74..79
+                  AttributeOperator@74..75 "@"
+                  Else@75..79 "else"
+              Blankspace@79..80 " "
+              GlobalCompoundDeclaration@80..103
+                BraceLeft@80..81 "{"
+                Blankspace@81..82 " "
+                ConstantDeclaration@82..101
+                  Const@82..87 "const"
+                  Blankspace@87..88 " "
+                  Name@88..91
+                    Identifier@88..91 "baz"
+                  Colon@91..92 ":"
+                  Blankspace@92..93 " "
+                  TypeSpecifier@93..96
+                    Path@93..96
+                      Identifier@93..96 "u32"
+                  Blankspace@96..97 " "
+                  Equal@97..98 "="
+                  Blankspace@98..99 " "
+                  Literal@99..100
+                    IntLiteral@99..100 "0"
+                  Semicolon@100..101 ";"
+                Blankspace@101..102 " "
+                BraceRight@102..103 "}""#]],
+    );
+}
+
+#[test]
+fn module_compound_shadow() {
+    check(
+        "{ const foo: u32 = 0; } const foo: u32 = 1;",
+        expect![[r#"
+            SourceFile@0..43
+              GlobalCompoundDeclaration@0..23
+                BraceLeft@0..1 "{"
+                Blankspace@1..2 " "
+                ConstantDeclaration@2..21
+                  Const@2..7 "const"
+                  Blankspace@7..8 " "
+                  Name@8..11
+                    Identifier@8..11 "foo"
+                  Colon@11..12 ":"
+                  Blankspace@12..13 " "
+                  TypeSpecifier@13..16
+                    Path@13..16
+                      Identifier@13..16 "u32"
+                  Blankspace@16..17 " "
+                  Equal@17..18 "="
+                  Blankspace@18..19 " "
+                  Literal@19..20
+                    IntLiteral@19..20 "0"
+                  Semicolon@20..21 ";"
+                Blankspace@21..22 " "
+                BraceRight@22..23 "}"
+              Blankspace@23..24 " "
+              ConstantDeclaration@24..43
+                Const@24..29 "const"
+                Blankspace@29..30 " "
+                Name@30..33
+                  Identifier@30..33 "foo"
+                Colon@33..34 ":"
+                Blankspace@34..35 " "
+                TypeSpecifier@35..38
+                  Path@35..38
+                    Identifier@35..38 "u32"
+                Blankspace@38..39 " "
+                Equal@39..40 "="
+                Blankspace@40..41 " "
+                Literal@41..42
+                  IntLiteral@41..42 "1"
+                Semicolon@42..43 ";""#]],
+    );
+}
+
+#[test]
+fn function_compound_if_true() {
+    check(
+        "fn f() { @if(true) { const_assert true; const x: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..61
+              FunctionDeclaration@0..61
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..61
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..18
+                    IfAttribute@9..18
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..17
+                        True@13..17 "true"
+                      ParenthesisRight@17..18 ")"
+                  Blankspace@18..19 " "
+                  CompoundStatement@19..59
+                    BraceLeft@19..20 "{"
+                    Blankspace@20..21 " "
+                    AssertStatement@21..39
+                      ConstantAssert@21..33 "const_assert"
+                      Blankspace@33..34 " "
+                      Literal@34..38
+                        True@34..38 "true"
+                      Semicolon@38..39 ";"
+                    Blankspace@39..40 " "
+                    ConstantDeclaration@40..57
+                      Const@40..45 "const"
+                      Blankspace@45..46 " "
+                      Name@46..47
+                        Identifier@46..47 "x"
+                      Colon@47..48 ":"
+                      Blankspace@48..49 " "
+                      TypeSpecifier@49..52
+                        Path@49..52
+                          Identifier@49..52 "u32"
+                      Blankspace@52..53 " "
+                      Equal@53..54 "="
+                      Blankspace@54..55 " "
+                      Literal@55..56
+                        IntLiteral@55..56 "0"
+                      Semicolon@56..57 ";"
+                    Blankspace@57..58 " "
+                    BraceRight@58..59 "}"
+                  Blankspace@59..60 " "
+                  BraceRight@60..61 "}""#]],
+    );
+}
+
+#[test]
+fn function_compound_if_false() {
+    check(
+        "fn f() { @if(false) { const_assert true; const x: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..62
+              FunctionDeclaration@0..62
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..62
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..19
+                    IfAttribute@9..19
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..18
+                        False@13..18 "false"
+                      ParenthesisRight@18..19 ")"
+                  Blankspace@19..20 " "
+                  CompoundStatement@20..60
+                    BraceLeft@20..21 "{"
+                    Blankspace@21..22 " "
+                    AssertStatement@22..40
+                      ConstantAssert@22..34 "const_assert"
+                      Blankspace@34..35 " "
+                      Literal@35..39
+                        True@35..39 "true"
+                      Semicolon@39..40 ";"
+                    Blankspace@40..41 " "
+                    ConstantDeclaration@41..58
+                      Const@41..46 "const"
+                      Blankspace@46..47 " "
+                      Name@47..48
+                        Identifier@47..48 "x"
+                      Colon@48..49 ":"
+                      Blankspace@49..50 " "
+                      TypeSpecifier@50..53
+                        Path@50..53
+                          Identifier@50..53 "u32"
+                      Blankspace@53..54 " "
+                      Equal@54..55 "="
+                      Blankspace@55..56 " "
+                      Literal@56..57
+                        IntLiteral@56..57 "0"
+                      Semicolon@57..58 ";"
+                    Blankspace@58..59 " "
+                    BraceRight@59..60 "}"
+                  Blankspace@60..61 " "
+                  BraceRight@61..62 "}""#]],
+    );
+}
+
+#[test]
+fn function_compound_if_false_compound_elif_true() {
+    check(
+        "fn f() { @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..81
+              FunctionDeclaration@0..81
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..81
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..19
+                    IfAttribute@9..19
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..18
+                        False@13..18 "false"
+                      ParenthesisRight@18..19 ")"
+                  Blankspace@19..20 " "
+                  CompoundStatement@20..43
+                    BraceLeft@20..21 "{"
+                    Blankspace@21..22 " "
+                    ConstantDeclaration@22..41
+                      Const@22..27 "const"
+                      Blankspace@27..28 " "
+                      Name@28..31
+                        Identifier@28..31 "foo"
+                      Colon@31..32 ":"
+                      Blankspace@32..33 " "
+                      TypeSpecifier@33..36
+                        Path@33..36
+                          Identifier@33..36 "u32"
+                      Blankspace@36..37 " "
+                      Equal@37..38 "="
+                      Blankspace@38..39 " "
+                      Literal@39..40
+                        IntLiteral@39..40 "0"
+                      Semicolon@40..41 ";"
+                    Blankspace@41..42 " "
+                    BraceRight@42..43 "}"
+                  Blankspace@43..44 " "
+                  AttributeList@44..55
+                    OtherAttribute@44..55
+                      AttributeOperator@44..45 "@"
+                      Identifier@45..49 "elif"
+                      Arguments@49..55
+                        ParenthesisLeft@49..50 "("
+                        Literal@50..54
+                          True@50..54 "true"
+                        ParenthesisRight@54..55 ")"
+                  Blankspace@55..56 " "
+                  CompoundStatement@56..79
+                    BraceLeft@56..57 "{"
+                    Blankspace@57..58 " "
+                    ConstantDeclaration@58..77
+                      Const@58..63 "const"
+                      Blankspace@63..64 " "
+                      Name@64..67
+                        Identifier@64..67 "bar"
+                      Colon@67..68 ":"
+                      Blankspace@68..69 " "
+                      TypeSpecifier@69..72
+                        Path@69..72
+                          Identifier@69..72 "u32"
+                      Blankspace@72..73 " "
+                      Equal@73..74 "="
+                      Blankspace@74..75 " "
+                      Literal@75..76
+                        IntLiteral@75..76 "0"
+                      Semicolon@76..77 ";"
+                    Blankspace@77..78 " "
+                    BraceRight@78..79 "}"
+                  Blankspace@79..80 " "
+                  BraceRight@80..81 "}""#]],
+    );
+}
+
+#[test]
+fn function_compound_if_true_compound_elif_true() {
+    check(
+        "fn f() { @if(true) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..80
+              FunctionDeclaration@0..80
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..80
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..18
+                    IfAttribute@9..18
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..17
+                        True@13..17 "true"
+                      ParenthesisRight@17..18 ")"
+                  Blankspace@18..19 " "
+                  CompoundStatement@19..42
+                    BraceLeft@19..20 "{"
+                    Blankspace@20..21 " "
+                    ConstantDeclaration@21..40
+                      Const@21..26 "const"
+                      Blankspace@26..27 " "
+                      Name@27..30
+                        Identifier@27..30 "foo"
+                      Colon@30..31 ":"
+                      Blankspace@31..32 " "
+                      TypeSpecifier@32..35
+                        Path@32..35
+                          Identifier@32..35 "u32"
+                      Blankspace@35..36 " "
+                      Equal@36..37 "="
+                      Blankspace@37..38 " "
+                      Literal@38..39
+                        IntLiteral@38..39 "0"
+                      Semicolon@39..40 ";"
+                    Blankspace@40..41 " "
+                    BraceRight@41..42 "}"
+                  Blankspace@42..43 " "
+                  AttributeList@43..54
+                    OtherAttribute@43..54
+                      AttributeOperator@43..44 "@"
+                      Identifier@44..48 "elif"
+                      Arguments@48..54
+                        ParenthesisLeft@48..49 "("
+                        Literal@49..53
+                          True@49..53 "true"
+                        ParenthesisRight@53..54 ")"
+                  Blankspace@54..55 " "
+                  CompoundStatement@55..78
+                    BraceLeft@55..56 "{"
+                    Blankspace@56..57 " "
+                    ConstantDeclaration@57..76
+                      Const@57..62 "const"
+                      Blankspace@62..63 " "
+                      Name@63..66
+                        Identifier@63..66 "bar"
+                      Colon@66..67 ":"
+                      Blankspace@67..68 " "
+                      TypeSpecifier@68..71
+                        Path@68..71
+                          Identifier@68..71 "u32"
+                      Blankspace@71..72 " "
+                      Equal@72..73 "="
+                      Blankspace@73..74 " "
+                      Literal@74..75
+                        IntLiteral@74..75 "0"
+                      Semicolon@75..76 ";"
+                    Blankspace@76..77 " "
+                    BraceRight@77..78 "}"
+                  Blankspace@78..79 " "
+                  BraceRight@79..80 "}""#]],
+    );
+}
+
+#[test]
+fn function_if_false_compound_elif_true() {
+    check(
+        "fn f() { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..77
+              FunctionDeclaration@0..77
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..77
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..19
+                    IfAttribute@9..19
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..18
+                        False@13..18 "false"
+                      ParenthesisRight@18..19 ")"
+                  Blankspace@19..20 " "
+                  ConstantDeclaration@20..39
+                    Const@20..25 "const"
+                    Blankspace@25..26 " "
+                    Name@26..29
+                      Identifier@26..29 "foo"
+                    Colon@29..30 ":"
+                    Blankspace@30..31 " "
+                    TypeSpecifier@31..34
+                      Path@31..34
+                        Identifier@31..34 "u32"
+                    Blankspace@34..35 " "
+                    Equal@35..36 "="
+                    Blankspace@36..37 " "
+                    Literal@37..38
+                      IntLiteral@37..38 "0"
+                    Semicolon@38..39 ";"
+                  Blankspace@39..40 " "
+                  AttributeList@40..51
+                    OtherAttribute@40..51
+                      AttributeOperator@40..41 "@"
+                      Identifier@41..45 "elif"
+                      Arguments@45..51
+                        ParenthesisLeft@45..46 "("
+                        Literal@46..50
+                          True@46..50 "true"
+                        ParenthesisRight@50..51 ")"
+                  Blankspace@51..52 " "
+                  CompoundStatement@52..75
+                    BraceLeft@52..53 "{"
+                    Blankspace@53..54 " "
+                    ConstantDeclaration@54..73
+                      Const@54..59 "const"
+                      Blankspace@59..60 " "
+                      Name@60..63
+                        Identifier@60..63 "bar"
+                      Colon@63..64 ":"
+                      Blankspace@64..65 " "
+                      TypeSpecifier@65..68
+                        Path@65..68
+                          Identifier@65..68 "u32"
+                      Blankspace@68..69 " "
+                      Equal@69..70 "="
+                      Blankspace@70..71 " "
+                      Literal@71..72
+                        IntLiteral@71..72 "0"
+                      Semicolon@72..73 ";"
+                    Blankspace@73..74 " "
+                    BraceRight@74..75 "}"
+                  Blankspace@75..76 " "
+                  BraceRight@76..77 "}""#]],
+    );
+}
+
+#[test]
+fn function_if_true_compound_elif_true() {
+    check(
+        "fn f() { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..76
+              FunctionDeclaration@0..76
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..76
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..18
+                    IfAttribute@9..18
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..17
+                        True@13..17 "true"
+                      ParenthesisRight@17..18 ")"
+                  Blankspace@18..19 " "
+                  ConstantDeclaration@19..38
+                    Const@19..24 "const"
+                    Blankspace@24..25 " "
+                    Name@25..28
+                      Identifier@25..28 "foo"
+                    Colon@28..29 ":"
+                    Blankspace@29..30 " "
+                    TypeSpecifier@30..33
+                      Path@30..33
+                        Identifier@30..33 "u32"
+                    Blankspace@33..34 " "
+                    Equal@34..35 "="
+                    Blankspace@35..36 " "
+                    Literal@36..37
+                      IntLiteral@36..37 "0"
+                    Semicolon@37..38 ";"
+                  Blankspace@38..39 " "
+                  AttributeList@39..50
+                    OtherAttribute@39..50
+                      AttributeOperator@39..40 "@"
+                      Identifier@40..44 "elif"
+                      Arguments@44..50
+                        ParenthesisLeft@44..45 "("
+                        Literal@45..49
+                          True@45..49 "true"
+                        ParenthesisRight@49..50 ")"
+                  Blankspace@50..51 " "
+                  CompoundStatement@51..74
+                    BraceLeft@51..52 "{"
+                    Blankspace@52..53 " "
+                    ConstantDeclaration@53..72
+                      Const@53..58 "const"
+                      Blankspace@58..59 " "
+                      Name@59..62
+                        Identifier@59..62 "bar"
+                      Colon@62..63 ":"
+                      Blankspace@63..64 " "
+                      TypeSpecifier@64..67
+                        Path@64..67
+                          Identifier@64..67 "u32"
+                      Blankspace@67..68 " "
+                      Equal@68..69 "="
+                      Blankspace@69..70 " "
+                      Literal@70..71
+                        IntLiteral@70..71 "0"
+                      Semicolon@71..72 ";"
+                    Blankspace@72..73 " "
+                    BraceRight@73..74 "}"
+                  Blankspace@74..75 " "
+                  BraceRight@75..76 "}""#]],
+    );
+}
+
+#[test]
+fn function_compound_else_hit() {
+    check(
+        "fn f() { @if(false) { const foo: u32 = 0; } @elif(false) { const bar: u32 = 0; } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..112
+              FunctionDeclaration@0..112
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..112
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..19
+                    IfAttribute@9..19
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..18
+                        False@13..18 "false"
+                      ParenthesisRight@18..19 ")"
+                  Blankspace@19..20 " "
+                  CompoundStatement@20..43
+                    BraceLeft@20..21 "{"
+                    Blankspace@21..22 " "
+                    ConstantDeclaration@22..41
+                      Const@22..27 "const"
+                      Blankspace@27..28 " "
+                      Name@28..31
+                        Identifier@28..31 "foo"
+                      Colon@31..32 ":"
+                      Blankspace@32..33 " "
+                      TypeSpecifier@33..36
+                        Path@33..36
+                          Identifier@33..36 "u32"
+                      Blankspace@36..37 " "
+                      Equal@37..38 "="
+                      Blankspace@38..39 " "
+                      Literal@39..40
+                        IntLiteral@39..40 "0"
+                      Semicolon@40..41 ";"
+                    Blankspace@41..42 " "
+                    BraceRight@42..43 "}"
+                  Blankspace@43..44 " "
+                  AttributeList@44..56
+                    OtherAttribute@44..56
+                      AttributeOperator@44..45 "@"
+                      Identifier@45..49 "elif"
+                      Arguments@49..56
+                        ParenthesisLeft@49..50 "("
+                        Literal@50..55
+                          False@50..55 "false"
+                        ParenthesisRight@55..56 ")"
+                  Blankspace@56..57 " "
+                  CompoundStatement@57..80
+                    BraceLeft@57..58 "{"
+                    Blankspace@58..59 " "
+                    ConstantDeclaration@59..78
+                      Const@59..64 "const"
+                      Blankspace@64..65 " "
+                      Name@65..68
+                        Identifier@65..68 "bar"
+                      Colon@68..69 ":"
+                      Blankspace@69..70 " "
+                      TypeSpecifier@70..73
+                        Path@70..73
+                          Identifier@70..73 "u32"
+                      Blankspace@73..74 " "
+                      Equal@74..75 "="
+                      Blankspace@75..76 " "
+                      Literal@76..77
+                        IntLiteral@76..77 "0"
+                      Semicolon@77..78 ";"
+                    Blankspace@78..79 " "
+                    BraceRight@79..80 "}"
+                  Blankspace@80..81 " "
+                  AttributeList@81..86
+                    ElseAttribute@81..86
+                      AttributeOperator@81..82 "@"
+                      Else@82..86 "else"
+                  Blankspace@86..87 " "
+                  CompoundStatement@87..110
+                    BraceLeft@87..88 "{"
+                    Blankspace@88..89 " "
+                    ConstantDeclaration@89..108
+                      Const@89..94 "const"
+                      Blankspace@94..95 " "
+                      Name@95..98
+                        Identifier@95..98 "baz"
+                      Colon@98..99 ":"
+                      Blankspace@99..100 " "
+                      TypeSpecifier@100..103
+                        Path@100..103
+                          Identifier@100..103 "u32"
+                      Blankspace@103..104 " "
+                      Equal@104..105 "="
+                      Blankspace@105..106 " "
+                      Literal@106..107
+                        IntLiteral@106..107 "0"
+                      Semicolon@107..108 ";"
+                    Blankspace@108..109 " "
+                    BraceRight@109..110 "}"
+                  Blankspace@110..111 " "
+                  BraceRight@111..112 "}""#]],
+    );
+}
+
+#[test]
+fn function_compound_else_skipped() {
+    check(
+        "fn f() { @if(false) { const foo: u32 = 0; } @elif(true) { const bar: u32 = 0; } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..111
+              FunctionDeclaration@0..111
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..111
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..19
+                    IfAttribute@9..19
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..18
+                        False@13..18 "false"
+                      ParenthesisRight@18..19 ")"
+                  Blankspace@19..20 " "
+                  CompoundStatement@20..43
+                    BraceLeft@20..21 "{"
+                    Blankspace@21..22 " "
+                    ConstantDeclaration@22..41
+                      Const@22..27 "const"
+                      Blankspace@27..28 " "
+                      Name@28..31
+                        Identifier@28..31 "foo"
+                      Colon@31..32 ":"
+                      Blankspace@32..33 " "
+                      TypeSpecifier@33..36
+                        Path@33..36
+                          Identifier@33..36 "u32"
+                      Blankspace@36..37 " "
+                      Equal@37..38 "="
+                      Blankspace@38..39 " "
+                      Literal@39..40
+                        IntLiteral@39..40 "0"
+                      Semicolon@40..41 ";"
+                    Blankspace@41..42 " "
+                    BraceRight@42..43 "}"
+                  Blankspace@43..44 " "
+                  AttributeList@44..55
+                    OtherAttribute@44..55
+                      AttributeOperator@44..45 "@"
+                      Identifier@45..49 "elif"
+                      Arguments@49..55
+                        ParenthesisLeft@49..50 "("
+                        Literal@50..54
+                          True@50..54 "true"
+                        ParenthesisRight@54..55 ")"
+                  Blankspace@55..56 " "
+                  CompoundStatement@56..79
+                    BraceLeft@56..57 "{"
+                    Blankspace@57..58 " "
+                    ConstantDeclaration@58..77
+                      Const@58..63 "const"
+                      Blankspace@63..64 " "
+                      Name@64..67
+                        Identifier@64..67 "bar"
+                      Colon@67..68 ":"
+                      Blankspace@68..69 " "
+                      TypeSpecifier@69..72
+                        Path@69..72
+                          Identifier@69..72 "u32"
+                      Blankspace@72..73 " "
+                      Equal@73..74 "="
+                      Blankspace@74..75 " "
+                      Literal@75..76
+                        IntLiteral@75..76 "0"
+                      Semicolon@76..77 ";"
+                    Blankspace@77..78 " "
+                    BraceRight@78..79 "}"
+                  Blankspace@79..80 " "
+                  AttributeList@80..85
+                    ElseAttribute@80..85
+                      AttributeOperator@80..81 "@"
+                      Else@81..85 "else"
+                  Blankspace@85..86 " "
+                  CompoundStatement@86..109
+                    BraceLeft@86..87 "{"
+                    Blankspace@87..88 " "
+                    ConstantDeclaration@88..107
+                      Const@88..93 "const"
+                      Blankspace@93..94 " "
+                      Name@94..97
+                        Identifier@94..97 "baz"
+                      Colon@97..98 ":"
+                      Blankspace@98..99 " "
+                      TypeSpecifier@99..102
+                        Path@99..102
+                          Identifier@99..102 "u32"
+                      Blankspace@102..103 " "
+                      Equal@103..104 "="
+                      Blankspace@104..105 " "
+                      Literal@105..106
+                        IntLiteral@105..106 "0"
+                      Semicolon@106..107 ";"
+                    Blankspace@107..108 " "
+                    BraceRight@108..109 "}"
+                  Blankspace@109..110 " "
+                  BraceRight@110..111 "}""#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_if() {
+    check(
+        "fn f() { @if(true) { const foo: u32 = 0; @if(true) { const bar: u32 = 0; } } }",
+        expect![[r#"
+            SourceFile@0..78
+              FunctionDeclaration@0..78
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..78
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..18
+                    IfAttribute@9..18
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..17
+                        True@13..17 "true"
+                      ParenthesisRight@17..18 ")"
+                  Blankspace@18..19 " "
+                  CompoundStatement@19..76
+                    BraceLeft@19..20 "{"
+                    Blankspace@20..21 " "
+                    ConstantDeclaration@21..40
+                      Const@21..26 "const"
+                      Blankspace@26..27 " "
+                      Name@27..30
+                        Identifier@27..30 "foo"
+                      Colon@30..31 ":"
+                      Blankspace@31..32 " "
+                      TypeSpecifier@32..35
+                        Path@32..35
+                          Identifier@32..35 "u32"
+                      Blankspace@35..36 " "
+                      Equal@36..37 "="
+                      Blankspace@37..38 " "
+                      Literal@38..39
+                        IntLiteral@38..39 "0"
+                      Semicolon@39..40 ";"
+                    Blankspace@40..41 " "
+                    AttributeList@41..50
+                      IfAttribute@41..50
+                        AttributeOperator@41..42 "@"
+                        If@42..44 "if"
+                        ParenthesisLeft@44..45 "("
+                        Literal@45..49
+                          True@45..49 "true"
+                        ParenthesisRight@49..50 ")"
+                    Blankspace@50..51 " "
+                    CompoundStatement@51..74
+                      BraceLeft@51..52 "{"
+                      Blankspace@52..53 " "
+                      ConstantDeclaration@53..72
+                        Const@53..58 "const"
+                        Blankspace@58..59 " "
+                        Name@59..62
+                          Identifier@59..62 "bar"
+                        Colon@62..63 ":"
+                        Blankspace@63..64 " "
+                        TypeSpecifier@64..67
+                          Path@64..67
+                            Identifier@64..67 "u32"
+                        Blankspace@67..68 " "
+                        Equal@68..69 "="
+                        Blankspace@69..70 " "
+                        Literal@70..71
+                          IntLiteral@70..71 "0"
+                        Semicolon@71..72 ";"
+                      Blankspace@72..73 " "
+                      BraceRight@73..74 "}"
+                    Blankspace@74..75 " "
+                    BraceRight@75..76 "}"
+                  Blankspace@76..77 " "
+                  BraceRight@77..78 "}""#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_elif_hit() {
+    check(
+        "fn f() { @if(true) { @if(false) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..121
+              FunctionDeclaration@0..121
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..121
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..18
+                    IfAttribute@9..18
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..17
+                        True@13..17 "true"
+                      ParenthesisRight@17..18 ")"
+                  Blankspace@18..19 " "
+                  CompoundStatement@19..89
+                    BraceLeft@19..20 "{"
+                    Blankspace@20..21 " "
+                    AttributeList@21..31
+                      IfAttribute@21..31
+                        AttributeOperator@21..22 "@"
+                        If@22..24 "if"
+                        ParenthesisLeft@24..25 "("
+                        Literal@25..30
+                          False@25..30 "false"
+                        ParenthesisRight@30..31 ")"
+                    Blankspace@31..32 " "
+                    ConstantDeclaration@32..51
+                      Const@32..37 "const"
+                      Blankspace@37..38 " "
+                      Name@38..41
+                        Identifier@38..41 "foo"
+                      Colon@41..42 ":"
+                      Blankspace@42..43 " "
+                      TypeSpecifier@43..46
+                        Path@43..46
+                          Identifier@43..46 "u32"
+                      Blankspace@46..47 " "
+                      Equal@47..48 "="
+                      Blankspace@48..49 " "
+                      Literal@49..50
+                        IntLiteral@49..50 "0"
+                      Semicolon@50..51 ";"
+                    Blankspace@51..52 " "
+                    AttributeList@52..63
+                      OtherAttribute@52..63
+                        AttributeOperator@52..53 "@"
+                        Identifier@53..57 "elif"
+                        Arguments@57..63
+                          ParenthesisLeft@57..58 "("
+                          Literal@58..62
+                            True@58..62 "true"
+                          ParenthesisRight@62..63 ")"
+                    Blankspace@63..64 " "
+                    CompoundStatement@64..87
+                      BraceLeft@64..65 "{"
+                      Blankspace@65..66 " "
+                      ConstantDeclaration@66..85
+                        Const@66..71 "const"
+                        Blankspace@71..72 " "
+                        Name@72..75
+                          Identifier@72..75 "bar"
+                        Colon@75..76 ":"
+                        Blankspace@76..77 " "
+                        TypeSpecifier@77..80
+                          Path@77..80
+                            Identifier@77..80 "u32"
+                        Blankspace@80..81 " "
+                        Equal@81..82 "="
+                        Blankspace@82..83 " "
+                        Literal@83..84
+                          IntLiteral@83..84 "0"
+                        Semicolon@84..85 ";"
+                      Blankspace@85..86 " "
+                      BraceRight@86..87 "}"
+                    Blankspace@87..88 " "
+                    BraceRight@88..89 "}"
+                  Blankspace@89..90 " "
+                  AttributeList@90..95
+                    ElseAttribute@90..95
+                      AttributeOperator@90..91 "@"
+                      Else@91..95 "else"
+                  Blankspace@95..96 " "
+                  CompoundStatement@96..119
+                    BraceLeft@96..97 "{"
+                    Blankspace@97..98 " "
+                    ConstantDeclaration@98..117
+                      Const@98..103 "const"
+                      Blankspace@103..104 " "
+                      Name@104..107
+                        Identifier@104..107 "baz"
+                      Colon@107..108 ":"
+                      Blankspace@108..109 " "
+                      TypeSpecifier@109..112
+                        Path@109..112
+                          Identifier@109..112 "u32"
+                      Blankspace@112..113 " "
+                      Equal@113..114 "="
+                      Blankspace@114..115 " "
+                      Literal@115..116
+                        IntLiteral@115..116 "0"
+                      Semicolon@116..117 ";"
+                    Blankspace@117..118 " "
+                    BraceRight@118..119 "}"
+                  Blankspace@119..120 " "
+                  BraceRight@120..121 "}""#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_elif_skipped() {
+    check(
+        "fn f() { @if(true) { @if(true) const foo: u32 = 0; @elif(true) { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..120
+              FunctionDeclaration@0..120
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..120
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..18
+                    IfAttribute@9..18
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..17
+                        True@13..17 "true"
+                      ParenthesisRight@17..18 ")"
+                  Blankspace@18..19 " "
+                  CompoundStatement@19..88
+                    BraceLeft@19..20 "{"
+                    Blankspace@20..21 " "
+                    AttributeList@21..30
+                      IfAttribute@21..30
+                        AttributeOperator@21..22 "@"
+                        If@22..24 "if"
+                        ParenthesisLeft@24..25 "("
+                        Literal@25..29
+                          True@25..29 "true"
+                        ParenthesisRight@29..30 ")"
+                    Blankspace@30..31 " "
+                    ConstantDeclaration@31..50
+                      Const@31..36 "const"
+                      Blankspace@36..37 " "
+                      Name@37..40
+                        Identifier@37..40 "foo"
+                      Colon@40..41 ":"
+                      Blankspace@41..42 " "
+                      TypeSpecifier@42..45
+                        Path@42..45
+                          Identifier@42..45 "u32"
+                      Blankspace@45..46 " "
+                      Equal@46..47 "="
+                      Blankspace@47..48 " "
+                      Literal@48..49
+                        IntLiteral@48..49 "0"
+                      Semicolon@49..50 ";"
+                    Blankspace@50..51 " "
+                    AttributeList@51..62
+                      OtherAttribute@51..62
+                        AttributeOperator@51..52 "@"
+                        Identifier@52..56 "elif"
+                        Arguments@56..62
+                          ParenthesisLeft@56..57 "("
+                          Literal@57..61
+                            True@57..61 "true"
+                          ParenthesisRight@61..62 ")"
+                    Blankspace@62..63 " "
+                    CompoundStatement@63..86
+                      BraceLeft@63..64 "{"
+                      Blankspace@64..65 " "
+                      ConstantDeclaration@65..84
+                        Const@65..70 "const"
+                        Blankspace@70..71 " "
+                        Name@71..74
+                          Identifier@71..74 "bar"
+                        Colon@74..75 ":"
+                        Blankspace@75..76 " "
+                        TypeSpecifier@76..79
+                          Path@76..79
+                            Identifier@76..79 "u32"
+                        Blankspace@79..80 " "
+                        Equal@80..81 "="
+                        Blankspace@81..82 " "
+                        Literal@82..83
+                          IntLiteral@82..83 "0"
+                        Semicolon@83..84 ";"
+                      Blankspace@84..85 " "
+                      BraceRight@85..86 "}"
+                    Blankspace@86..87 " "
+                    BraceRight@87..88 "}"
+                  Blankspace@88..89 " "
+                  AttributeList@89..94
+                    ElseAttribute@89..94
+                      AttributeOperator@89..90 "@"
+                      Else@90..94 "else"
+                  Blankspace@94..95 " "
+                  CompoundStatement@95..118
+                    BraceLeft@95..96 "{"
+                    Blankspace@96..97 " "
+                    ConstantDeclaration@97..116
+                      Const@97..102 "const"
+                      Blankspace@102..103 " "
+                      Name@103..106
+                        Identifier@103..106 "baz"
+                      Colon@106..107 ":"
+                      Blankspace@107..108 " "
+                      TypeSpecifier@108..111
+                        Path@108..111
+                          Identifier@108..111 "u32"
+                      Blankspace@111..112 " "
+                      Equal@112..113 "="
+                      Blankspace@113..114 " "
+                      Literal@114..115
+                        IntLiteral@114..115 "0"
+                      Semicolon@115..116 ";"
+                    Blankspace@116..117 " "
+                    BraceRight@117..118 "}"
+                  Blankspace@118..119 " "
+                  BraceRight@119..120 "}""#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_else_hit() {
+    check(
+        "fn f() { @if(true) { @if(false) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..115
+              FunctionDeclaration@0..115
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..115
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..18
+                    IfAttribute@9..18
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..17
+                        True@13..17 "true"
+                      ParenthesisRight@17..18 ")"
+                  Blankspace@18..19 " "
+                  CompoundStatement@19..83
+                    BraceLeft@19..20 "{"
+                    Blankspace@20..21 " "
+                    AttributeList@21..31
+                      IfAttribute@21..31
+                        AttributeOperator@21..22 "@"
+                        If@22..24 "if"
+                        ParenthesisLeft@24..25 "("
+                        Literal@25..30
+                          False@25..30 "false"
+                        ParenthesisRight@30..31 ")"
+                    Blankspace@31..32 " "
+                    ConstantDeclaration@32..51
+                      Const@32..37 "const"
+                      Blankspace@37..38 " "
+                      Name@38..41
+                        Identifier@38..41 "foo"
+                      Colon@41..42 ":"
+                      Blankspace@42..43 " "
+                      TypeSpecifier@43..46
+                        Path@43..46
+                          Identifier@43..46 "u32"
+                      Blankspace@46..47 " "
+                      Equal@47..48 "="
+                      Blankspace@48..49 " "
+                      Literal@49..50
+                        IntLiteral@49..50 "0"
+                      Semicolon@50..51 ";"
+                    Blankspace@51..52 " "
+                    AttributeList@52..57
+                      ElseAttribute@52..57
+                        AttributeOperator@52..53 "@"
+                        Else@53..57 "else"
+                    Blankspace@57..58 " "
+                    CompoundStatement@58..81
+                      BraceLeft@58..59 "{"
+                      Blankspace@59..60 " "
+                      ConstantDeclaration@60..79
+                        Const@60..65 "const"
+                        Blankspace@65..66 " "
+                        Name@66..69
+                          Identifier@66..69 "bar"
+                        Colon@69..70 ":"
+                        Blankspace@70..71 " "
+                        TypeSpecifier@71..74
+                          Path@71..74
+                            Identifier@71..74 "u32"
+                        Blankspace@74..75 " "
+                        Equal@75..76 "="
+                        Blankspace@76..77 " "
+                        Literal@77..78
+                          IntLiteral@77..78 "0"
+                        Semicolon@78..79 ";"
+                      Blankspace@79..80 " "
+                      BraceRight@80..81 "}"
+                    Blankspace@81..82 " "
+                    BraceRight@82..83 "}"
+                  Blankspace@83..84 " "
+                  AttributeList@84..89
+                    ElseAttribute@84..89
+                      AttributeOperator@84..85 "@"
+                      Else@85..89 "else"
+                  Blankspace@89..90 " "
+                  CompoundStatement@90..113
+                    BraceLeft@90..91 "{"
+                    Blankspace@91..92 " "
+                    ConstantDeclaration@92..111
+                      Const@92..97 "const"
+                      Blankspace@97..98 " "
+                      Name@98..101
+                        Identifier@98..101 "baz"
+                      Colon@101..102 ":"
+                      Blankspace@102..103 " "
+                      TypeSpecifier@103..106
+                        Path@103..106
+                          Identifier@103..106 "u32"
+                      Blankspace@106..107 " "
+                      Equal@107..108 "="
+                      Blankspace@108..109 " "
+                      Literal@109..110
+                        IntLiteral@109..110 "0"
+                      Semicolon@110..111 ";"
+                    Blankspace@111..112 " "
+                    BraceRight@112..113 "}"
+                  Blankspace@113..114 " "
+                  BraceRight@114..115 "}""#]],
+    );
+}
+
+#[test]
+fn function_compound_nested_else_skipped() {
+    check(
+        "fn f() { @if(true) { @if(true) const foo: u32 = 0; @else { const bar: u32 = 0; } } @else { const baz: u32 = 0; } }",
+        expect![[r#"
+            SourceFile@0..114
+              FunctionDeclaration@0..114
+                Fn@0..2 "fn"
+                Blankspace@2..3 " "
+                Name@3..4
+                  Identifier@3..4 "f"
+                FunctionParameters@4..6
+                  ParenthesisLeft@4..5 "("
+                  ParenthesisRight@5..6 ")"
+                Blankspace@6..7 " "
+                CompoundStatement@7..114
+                  BraceLeft@7..8 "{"
+                  Blankspace@8..9 " "
+                  AttributeList@9..18
+                    IfAttribute@9..18
+                      AttributeOperator@9..10 "@"
+                      If@10..12 "if"
+                      ParenthesisLeft@12..13 "("
+                      Literal@13..17
+                        True@13..17 "true"
+                      ParenthesisRight@17..18 ")"
+                  Blankspace@18..19 " "
+                  CompoundStatement@19..82
+                    BraceLeft@19..20 "{"
+                    Blankspace@20..21 " "
+                    AttributeList@21..30
+                      IfAttribute@21..30
+                        AttributeOperator@21..22 "@"
+                        If@22..24 "if"
+                        ParenthesisLeft@24..25 "("
+                        Literal@25..29
+                          True@25..29 "true"
+                        ParenthesisRight@29..30 ")"
+                    Blankspace@30..31 " "
+                    ConstantDeclaration@31..50
+                      Const@31..36 "const"
+                      Blankspace@36..37 " "
+                      Name@37..40
+                        Identifier@37..40 "foo"
+                      Colon@40..41 ":"
+                      Blankspace@41..42 " "
+                      TypeSpecifier@42..45
+                        Path@42..45
+                          Identifier@42..45 "u32"
+                      Blankspace@45..46 " "
+                      Equal@46..47 "="
+                      Blankspace@47..48 " "
+                      Literal@48..49
+                        IntLiteral@48..49 "0"
+                      Semicolon@49..50 ";"
+                    Blankspace@50..51 " "
+                    AttributeList@51..56
+                      ElseAttribute@51..56
+                        AttributeOperator@51..52 "@"
+                        Else@52..56 "else"
+                    Blankspace@56..57 " "
+                    CompoundStatement@57..80
+                      BraceLeft@57..58 "{"
+                      Blankspace@58..59 " "
+                      ConstantDeclaration@59..78
+                        Const@59..64 "const"
+                        Blankspace@64..65 " "
+                        Name@65..68
+                          Identifier@65..68 "bar"
+                        Colon@68..69 ":"
+                        Blankspace@69..70 " "
+                        TypeSpecifier@70..73
+                          Path@70..73
+                            Identifier@70..73 "u32"
+                        Blankspace@73..74 " "
+                        Equal@74..75 "="
+                        Blankspace@75..76 " "
+                        Literal@76..77
+                          IntLiteral@76..77 "0"
+                        Semicolon@77..78 ";"
+                      Blankspace@78..79 " "
+                      BraceRight@79..80 "}"
+                    Blankspace@80..81 " "
+                    BraceRight@81..82 "}"
+                  Blankspace@82..83 " "
+                  AttributeList@83..88
+                    ElseAttribute@83..88
+                      AttributeOperator@83..84 "@"
+                      Else@84..88 "else"
+                  Blankspace@88..89 " "
+                  CompoundStatement@89..112
+                    BraceLeft@89..90 "{"
+                    Blankspace@90..91 " "
+                    ConstantDeclaration@91..110
+                      Const@91..96 "const"
+                      Blankspace@96..97 " "
+                      Name@97..100
+                        Identifier@97..100 "baz"
+                      Colon@100..101 ":"
+                      Blankspace@101..102 " "
+                      TypeSpecifier@102..105
+                        Path@102..105
+                          Identifier@102..105 "u32"
+                      Blankspace@105..106 " "
+                      Equal@106..107 "="
+                      Blankspace@107..108 " "
+                      Literal@108..109
+                        IntLiteral@108..109 "0"
+                      Semicolon@109..110 ";"
+                    Blankspace@110..111 " "
+                    BraceRight@111..112 "}"
+                  Blankspace@112..113 " "
+                  BraceRight@113..114 "}""#]],
     );
 }

--- a/crates/parser/src/tests/conditional_compilation.rs
+++ b/crates/parser/src/tests/conditional_compilation.rs
@@ -3,92 +3,13 @@ use expect_test::expect;
 use crate::tests::check;
 
 #[test]
-fn module_compound() {
-    check(
-        "
-        fn f() {} @if(true) { const_assert true; fn foo() {} struct bar { x: u32 } }
-        ",
-        expect![[r#"
-            SourceFile@0..94
-              Blankspace@0..9 "\n        "
-              FunctionDeclaration@9..18
-                Fn@9..11 "fn"
-                Blankspace@11..12 " "
-                Name@12..13
-                  Identifier@12..13 "f"
-                FunctionParameters@13..15
-                  ParenthesisLeft@13..14 "("
-                  ParenthesisRight@14..15 ")"
-                Blankspace@15..16 " "
-                CompoundStatement@16..18
-                  BraceLeft@16..17 "{"
-                  BraceRight@17..18 "}"
-              Blankspace@18..19 " "
-              AttributeList@19..28
-                IfAttribute@19..28
-                  AttributeOperator@19..20 "@"
-                  If@20..22 "if"
-                  ParenthesisLeft@22..23 "("
-                  Literal@23..27
-                    True@23..27 "true"
-                  ParenthesisRight@27..28 ")"
-              Blankspace@28..29 " "
-              GlobalCompoundDeclaration@29..85
-                BraceLeft@29..30 "{"
-                Blankspace@30..31 " "
-                AssertStatement@31..49
-                  ConstantAssert@31..43 "const_assert"
-                  Blankspace@43..44 " "
-                  Literal@44..48
-                    True@44..48 "true"
-                  Semicolon@48..49 ";"
-                Blankspace@49..50 " "
-                FunctionDeclaration@50..61
-                  Fn@50..52 "fn"
-                  Blankspace@52..53 " "
-                  Name@53..56
-                    Identifier@53..56 "foo"
-                  FunctionParameters@56..58
-                    ParenthesisLeft@56..57 "("
-                    ParenthesisRight@57..58 ")"
-                  Blankspace@58..59 " "
-                  CompoundStatement@59..61
-                    BraceLeft@59..60 "{"
-                    BraceRight@60..61 "}"
-                Blankspace@61..62 " "
-                StructDeclaration@62..83
-                  Struct@62..68 "struct"
-                  Blankspace@68..69 " "
-                  Name@69..72
-                    Identifier@69..72 "bar"
-                  Blankspace@72..73 " "
-                  StructBody@73..83
-                    BraceLeft@73..74 "{"
-                    Blankspace@74..75 " "
-                    StructMember@75..81
-                      Name@75..76
-                        Identifier@75..76 "x"
-                      Colon@76..77 ":"
-                      Blankspace@77..78 " "
-                      TypeSpecifier@78..81
-                        Path@78..81
-                          Identifier@78..81 "u32"
-                    Blankspace@81..82 " "
-                    BraceRight@82..83 "}"
-                Blankspace@83..84 " "
-                BraceRight@84..85 "}"
-              Blankspace@85..94 "\n        ""#]],
-    );
-}
-
-#[test]
 fn module_compound_nested() {
     check(
         "
-        @if(true) { fn foo() {} { @if(true) fn bar() {} } @if(true) { fn baz() {} } }
+        @if(true) { { } }
         ",
         expect![[r#"
-            SourceFile@0..95
+            SourceFile@0..35
               Blankspace@0..9 "\n        "
               AttributeList@9..18
                 IfAttribute@9..18
@@ -99,188 +20,16 @@ fn module_compound_nested() {
                     True@13..17 "true"
                   ParenthesisRight@17..18 ")"
               Blankspace@18..19 " "
-              GlobalCompoundDeclaration@19..86
+              GlobalCompoundDeclaration@19..26
                 BraceLeft@19..20 "{"
                 Blankspace@20..21 " "
-                FunctionDeclaration@21..32
-                  Fn@21..23 "fn"
-                  Blankspace@23..24 " "
-                  Name@24..27
-                    Identifier@24..27 "foo"
-                  FunctionParameters@27..29
-                    ParenthesisLeft@27..28 "("
-                    ParenthesisRight@28..29 ")"
-                  Blankspace@29..30 " "
-                  CompoundStatement@30..32
-                    BraceLeft@30..31 "{"
-                    BraceRight@31..32 "}"
-                Blankspace@32..33 " "
-                GlobalCompoundDeclaration@33..58
-                  BraceLeft@33..34 "{"
-                  Blankspace@34..35 " "
-                  AttributeList@35..44
-                    IfAttribute@35..44
-                      AttributeOperator@35..36 "@"
-                      If@36..38 "if"
-                      ParenthesisLeft@38..39 "("
-                      Literal@39..43
-                        True@39..43 "true"
-                      ParenthesisRight@43..44 ")"
-                  Blankspace@44..45 " "
-                  FunctionDeclaration@45..56
-                    Fn@45..47 "fn"
-                    Blankspace@47..48 " "
-                    Name@48..51
-                      Identifier@48..51 "bar"
-                    FunctionParameters@51..53
-                      ParenthesisLeft@51..52 "("
-                      ParenthesisRight@52..53 ")"
-                    Blankspace@53..54 " "
-                    CompoundStatement@54..56
-                      BraceLeft@54..55 "{"
-                      BraceRight@55..56 "}"
-                  Blankspace@56..57 " "
-                  BraceRight@57..58 "}"
-                Blankspace@58..59 " "
-                AttributeList@59..68
-                  IfAttribute@59..68
-                    AttributeOperator@59..60 "@"
-                    If@60..62 "if"
-                    ParenthesisLeft@62..63 "("
-                    Literal@63..67
-                      True@63..67 "true"
-                    ParenthesisRight@67..68 ")"
-                Blankspace@68..69 " "
-                GlobalCompoundDeclaration@69..84
-                  BraceLeft@69..70 "{"
-                  Blankspace@70..71 " "
-                  FunctionDeclaration@71..82
-                    Fn@71..73 "fn"
-                    Blankspace@73..74 " "
-                    Name@74..77
-                      Identifier@74..77 "baz"
-                    FunctionParameters@77..79
-                      ParenthesisLeft@77..78 "("
-                      ParenthesisRight@78..79 ")"
-                    Blankspace@79..80 " "
-                    CompoundStatement@80..82
-                      BraceLeft@80..81 "{"
-                      BraceRight@81..82 "}"
-                  Blankspace@82..83 " "
-                  BraceRight@83..84 "}"
-                Blankspace@84..85 " "
-                BraceRight@85..86 "}"
-              Blankspace@86..95 "\n        ""#]],
-    );
-}
-
-#[test]
-fn module_compound_shadow() {
-    check(
-        "
-        { const foo: u32 = 0; } const foo: u32 = 1;
-        ",
-        expect![[r#"
-            SourceFile@0..61
-              Blankspace@0..9 "\n        "
-              GlobalCompoundDeclaration@9..32
-                BraceLeft@9..10 "{"
-                Blankspace@10..11 " "
-                ConstantDeclaration@11..30
-                  Const@11..16 "const"
-                  Blankspace@16..17 " "
-                  Name@17..20
-                    Identifier@17..20 "foo"
-                  Colon@20..21 ":"
-                  Blankspace@21..22 " "
-                  TypeSpecifier@22..25
-                    Path@22..25
-                      Identifier@22..25 "u32"
-                  Blankspace@25..26 " "
-                  Equal@26..27 "="
-                  Blankspace@27..28 " "
-                  Literal@28..29
-                    IntLiteral@28..29 "0"
-                  Semicolon@29..30 ";"
-                Blankspace@30..31 " "
-                BraceRight@31..32 "}"
-              Blankspace@32..33 " "
-              ConstantDeclaration@33..52
-                Const@33..38 "const"
-                Blankspace@38..39 " "
-                Name@39..42
-                  Identifier@39..42 "foo"
-                Colon@42..43 ":"
-                Blankspace@43..44 " "
-                TypeSpecifier@44..47
-                  Path@44..47
-                    Identifier@44..47 "u32"
-                Blankspace@47..48 " "
-                Equal@48..49 "="
-                Blankspace@49..50 " "
-                Literal@50..51
-                  IntLiteral@50..51 "1"
-                Semicolon@51..52 ";"
-              Blankspace@52..61 "\n        ""#]],
-    );
-}
-
-#[test]
-fn function_compound() {
-    check(
-        "
-        fn foo() { @if(true) { var x = 0; } x++; }
-        ",
-        expect![[r#"
-            SourceFile@0..60
-              Blankspace@0..9 "\n        "
-              FunctionDeclaration@9..51
-                Fn@9..11 "fn"
-                Blankspace@11..12 " "
-                Name@12..15
-                  Identifier@12..15 "foo"
-                FunctionParameters@15..17
-                  ParenthesisLeft@15..16 "("
-                  ParenthesisRight@16..17 ")"
-                Blankspace@17..18 " "
-                CompoundStatement@18..51
-                  BraceLeft@18..19 "{"
-                  Blankspace@19..20 " "
-                  AttributeList@20..29
-                    IfAttribute@20..29
-                      AttributeOperator@20..21 "@"
-                      If@21..23 "if"
-                      ParenthesisLeft@23..24 "("
-                      Literal@24..28
-                        True@24..28 "true"
-                      ParenthesisRight@28..29 ")"
-                  Blankspace@29..30 " "
-                  CompoundStatement@30..44
-                    BraceLeft@30..31 "{"
-                    Blankspace@31..32 " "
-                    VariableDeclaration@32..42
-                      Var@32..35 "var"
-                      Blankspace@35..36 " "
-                      Name@36..37
-                        Identifier@36..37 "x"
-                      Blankspace@37..38 " "
-                      Equal@38..39 "="
-                      Blankspace@39..40 " "
-                      Literal@40..41
-                        IntLiteral@40..41 "0"
-                      Semicolon@41..42 ";"
-                    Blankspace@42..43 " "
-                    BraceRight@43..44 "}"
-                  Blankspace@44..45 " "
-                  IncrementDecrementStatement@45..49
-                    IdentExpression@45..46
-                      Path@45..46
-                        Identifier@45..46 "x"
-                    PlusPlus@46..48 "++"
-                    Semicolon@48..49 ";"
-                  Blankspace@49..50 " "
-                  BraceRight@50..51 "}"
-              Blankspace@51..60 "\n        ""#]],
+                GlobalCompoundDeclaration@21..24
+                  BraceLeft@21..22 "{"
+                  Blankspace@22..23 " "
+                  BraceRight@23..24 "}"
+                Blankspace@24..25 " "
+                BraceRight@25..26 "}"
+              Blankspace@26..35 "\n        ""#]],
     );
 }
 
@@ -288,12 +37,12 @@ fn function_compound() {
 fn function_compound_nested() {
     check(
         "
-        fn foo() { @if(true) { var x = 0; { @if(true) x++; } @if(true) { x--; } } }
+        fn foo() { @if(true) { { var x = 0; } } }
         ",
         expect![[r#"
-            SourceFile@0..93
+            SourceFile@0..59
               Blankspace@0..9 "\n        "
-              FunctionDeclaration@9..84
+              FunctionDeclaration@9..50
                 Fn@9..11 "fn"
                 Blankspace@11..12 " "
                 Name@12..15
@@ -302,7 +51,7 @@ fn function_compound_nested() {
                   ParenthesisLeft@15..16 "("
                   ParenthesisRight@16..17 ")"
                 Blankspace@17..18 " "
-                CompoundStatement@18..84
+                CompoundStatement@18..50
                   BraceLeft@18..19 "{"
                   Blankspace@19..20 " "
                   AttributeList@20..29
@@ -314,66 +63,29 @@ fn function_compound_nested() {
                         True@24..28 "true"
                       ParenthesisRight@28..29 ")"
                   Blankspace@29..30 " "
-                  CompoundStatement@30..82
+                  CompoundStatement@30..48
                     BraceLeft@30..31 "{"
                     Blankspace@31..32 " "
-                    VariableDeclaration@32..42
-                      Var@32..35 "var"
-                      Blankspace@35..36 " "
-                      Name@36..37
-                        Identifier@36..37 "x"
-                      Blankspace@37..38 " "
-                      Equal@38..39 "="
-                      Blankspace@39..40 " "
-                      Literal@40..41
-                        IntLiteral@40..41 "0"
-                      Semicolon@41..42 ";"
-                    Blankspace@42..43 " "
-                    CompoundStatement@43..61
-                      BraceLeft@43..44 "{"
+                    CompoundStatement@32..46
+                      BraceLeft@32..33 "{"
+                      Blankspace@33..34 " "
+                      VariableDeclaration@34..44
+                        Var@34..37 "var"
+                        Blankspace@37..38 " "
+                        Name@38..39
+                          Identifier@38..39 "x"
+                        Blankspace@39..40 " "
+                        Equal@40..41 "="
+                        Blankspace@41..42 " "
+                        Literal@42..43
+                          IntLiteral@42..43 "0"
+                        Semicolon@43..44 ";"
                       Blankspace@44..45 " "
-                      AttributeList@45..54
-                        IfAttribute@45..54
-                          AttributeOperator@45..46 "@"
-                          If@46..48 "if"
-                          ParenthesisLeft@48..49 "("
-                          Literal@49..53
-                            True@49..53 "true"
-                          ParenthesisRight@53..54 ")"
-                      Blankspace@54..55 " "
-                      IncrementDecrementStatement@55..59
-                        IdentExpression@55..56
-                          Path@55..56
-                            Identifier@55..56 "x"
-                        PlusPlus@56..58 "++"
-                        Semicolon@58..59 ";"
-                      Blankspace@59..60 " "
-                      BraceRight@60..61 "}"
-                    Blankspace@61..62 " "
-                    AttributeList@62..71
-                      IfAttribute@62..71
-                        AttributeOperator@62..63 "@"
-                        If@63..65 "if"
-                        ParenthesisLeft@65..66 "("
-                        Literal@66..70
-                          True@66..70 "true"
-                        ParenthesisRight@70..71 ")"
-                    Blankspace@71..72 " "
-                    CompoundStatement@72..80
-                      BraceLeft@72..73 "{"
-                      Blankspace@73..74 " "
-                      IncrementDecrementStatement@74..78
-                        IdentExpression@74..75
-                          Path@74..75
-                            Identifier@74..75 "x"
-                        MinusMinus@75..77 "--"
-                        Semicolon@77..78 ";"
-                      Blankspace@78..79 " "
-                      BraceRight@79..80 "}"
-                    Blankspace@80..81 " "
-                    BraceRight@81..82 "}"
-                  Blankspace@82..83 " "
-                  BraceRight@83..84 "}"
-              Blankspace@84..93 "\n        ""#]],
+                      BraceRight@45..46 "}"
+                    Blankspace@46..47 " "
+                    BraceRight@47..48 "}"
+                  Blankspace@48..49 " "
+                  BraceRight@49..50 "}"
+              Blankspace@50..59 "\n        ""#]],
     );
 }

--- a/crates/parser/src/tests/imports.rs
+++ b/crates/parser/src/tests/imports.rs
@@ -16,7 +16,7 @@ fn simplest_import_fail() {
 
             error at 0..6: 'import' is a reserved word in WGSL
             error at 0..6: switch to WESL to use `import`
-            error at 0..6: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
+            error at 0..6: invalid syntax, expected one of: 'alias', '@', '{', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
     );
 }
 

--- a/crates/parser/src/tests/keywords.rs
+++ b/crates/parser/src/tests/keywords.rs
@@ -453,7 +453,7 @@ fn reserved_words_do_not_parse() {
             error at 1132..1136: 'with' is a reserved word in WGSL
             error at 1137..1146: 'writeonly' is a reserved word in WGSL
             error at 1147..1152: 'yield' is a reserved word in WGSL
-            error at 9..13: invalid syntax, expected one of: 'alias', '@', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
+            error at 9..13: invalid syntax, expected one of: 'alias', '@', '{', 'const', 'const_assert', 'diagnostic', <end of file>, 'enable', 'fn', 'import', 'let', 'override', 'requires', ';', 'struct', 'var'"#]],
     );
 }
 

--- a/crates/parser/src/wesl.llw
+++ b/crates/parser/src/wesl.llw
@@ -156,6 +156,7 @@ global_item^:
 	| #2 global_directive
 	| #3 global_declaration
 	| #3 global_assert
+	| #3 global_compound_declaration
 );
 
 // WESL: Import statements
@@ -173,6 +174,14 @@ global_directive:
 	'diagnostic' diagnostic_control ';' @diagnostic_directive // §4.2
 	| 'enable' enable_extension_name (?1 ',' enable_extension_name)* [','] ';' @enable_directive // §4.1.1
 	| 'requires' language_extension_name (?1 ',' language_extension_name)* [','] ';' @requires_directive // §4.1.2
+;
+
+global_compound_declaration:
+    '{' (attribute_list global_compound_declaration_item)* '}'
+;
+
+global_compound_declaration_item^:
+	global_declaration | global_assert | global_compound_declaration
 ;
 
 diagnostic_control: '(' severity_control_name ',' diagnostic_rule_name [','] ')';

--- a/crates/parser/src/wesl.llw
+++ b/crates/parser/src/wesl.llw
@@ -164,6 +164,7 @@ global_item^:
 	| #1 global_directive
 	| #2 global_declaration
 	| #2 global_assert
+	| #2 global_compound_declaration
 ;
 
 global_assert: 'const_assert' expression ';' @assert_statement; // §10
@@ -171,6 +172,14 @@ global_directive:
 	'diagnostic' diagnostic_control ';' @diagnostic_directive // §4.2
 	| 'enable' enable_extension_name (?1 ',' enable_extension_name)* [','] ';' @enable_directive // §4.1.1
 	| 'requires' language_extension_name (?1 ',' language_extension_name)* [','] ';' @requires_directive // §4.1.2
+;
+
+global_compound_declaration:
+    '{' (attribute_list global_compound_declaration_item)* '}'
+;
+
+global_compound_declaration_item^:
+	global_declaration | global_assert | global_compound_declaration
 ;
 
 diagnostic_control: '(' severity_control_name ',' diagnostic_rule_name [','] ')';

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -292,6 +292,13 @@ impl HasName for FunctionDeclaration {}
 impl HasAttributes for FunctionDeclaration {}
 
 ast_node! {
+    GlobalCompoundDeclaration:
+    left_brace_token: Option<SyntaxToken BraceLeft>;
+    right_brace_token: Option<SyntaxToken BraceRight>;
+    items: AstChildren<Item>;
+}
+
+ast_node! {
     StructDeclaration:
     struct_token: Option<SyntaxToken Struct>;
     body: Option<StructBody>;
@@ -393,6 +400,7 @@ ast_enum! {
         TypeAliasDeclaration,
         StructDeclaration,
         AssertStatement,
+        GlobalCompoundDeclaration,
     }
 }
 
@@ -1409,5 +1417,26 @@ impl PrefixExpression {
             PrefixOperatorKind::And(_) => UnaryOperator::AddressOf,
         };
         Some(operator)
+    }
+}
+
+impl Item {
+    pub fn flatten_global_compound_declarations(self) -> Vec<Self> {
+        match self {
+            Self::GlobalCompoundDeclaration(global_compound_declaration) => {
+                global_compound_declaration
+                    .items()
+                    .flat_map(Self::flatten_global_compound_declarations)
+                    .collect()
+            },
+            Self::ImportStatement(_)
+            | Self::FunctionDeclaration(_)
+            | Self::VariableDeclaration(_)
+            | Self::ConstantDeclaration(_)
+            | Self::OverrideDeclaration(_)
+            | Self::TypeAliasDeclaration(_)
+            | Self::StructDeclaration(_)
+            | Self::AssertStatement(_) => vec![self],
+        }
     }
 }

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -777,6 +777,14 @@ impl Attribute {
             Self::ElseAttribute(inner) => inner.name(),
         }
     }
+
+    #[must_use]
+    pub const fn is_conditional_compilation(&self) -> bool {
+        matches!(
+            self,
+            Self::IfAttribute(_) | Self::ElifAttribute(_) | Self::ElseAttribute(_)
+        )
+    }
 }
 
 ast_node! {

--- a/editors/code/biome.jsonc
+++ b/editors/code/biome.jsonc
@@ -7,7 +7,7 @@
 		}
 	},
 	"files": {
-		"includes": ["**", "!**/out/**", "!**/.vscode-test/**", "!**/node_modules/**"]
+		"includes": ["**", "!**/out", "!**/.vscode-test", "!**/node_modules"]
 	},
 	"formatter": {
 		"indentStyle": "tab",
@@ -15,7 +15,6 @@
 	},
 	"linter": {
 		"rules": {
-			"recommended": false,
 			"complexity": {
 				"noAdjacentSpacesInRegex": "error",
 				"noExtraBooleanCast": "error",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -32,7 +32,7 @@
 		}
 	},
 	"engines": {
-		"vscode": "^1.120.0",
+		"vscode": "^1.125.0",
 		"node": "^24.15.0"
 	},
 	"devEngines": {
@@ -60,26 +60,26 @@
 		"watch": "pnpm run build-base --sourcemap --watch"
 	},
 	"dependencies": {
-		"@hpcc-js/wasm": "^2.34.7",
+		"@hpcc-js/wasm": "^2.35.0",
 		"anser": "^2.3.5",
 		"d3": "^7.9.0",
 		"d3-graphviz": "^5.6.0",
 		"fp-ts": "^2.16.11",
 		"io-ts": "^2.2.22",
 		"jiti": "^2.7.0",
-		"vscode-languageclient": "^9.0.1"
+		"vscode-languageclient": "^10.1.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.4",
+		"@biomejs/biome": "^2.5.8",
 		"@tsconfig/node-ts": "^23.6.4",
 		"@tsconfig/node22": "^22.0.5",
 		"@tsconfig/strictest": "^2.0.8",
-		"@types/node": "^26.1.1",
-		"@types/vscode": "^1.120.0",
-		"@vscode/test-electron": "^3.0.0",
+		"@types/node": "^25.9.5",
+		"@types/vscode": "^1.125.0",
+		"@vscode/test-electron": "^3.1.0",
 		"@vscode/vsce": "^3.9.2",
-		"esbuild": "^0.28.1",
-		"ovsx": "^1.0.2",
+		"esbuild": "^0.28.2",
+		"ovsx": "^1.1.1",
 		"tslib": "^2.8.1",
 		"typescript": "^6.0.3"
 	},

--- a/editors/code/pnpm-lock.yaml
+++ b/editors/code/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@hpcc-js/wasm':
-        specifier: ^2.34.7
-        version: 2.34.7
+        specifier: ^2.35.0
+        version: 2.35.0
       anser:
         specifier: ^2.3.5
         version: 2.3.5
@@ -30,12 +30,12 @@ importers:
         specifier: ^2.7.0
         version: 2.7.0
       vscode-languageclient:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^10.1.0
+        version: 10.1.0
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.4
-        version: 2.5.4
+        specifier: ^2.5.8
+        version: 2.5.8
       '@tsconfig/node-ts':
         specifier: ^23.6.4
         version: 23.6.4
@@ -46,23 +46,23 @@ importers:
         specifier: ^2.0.8
         version: 2.0.8
       '@types/node':
-        specifier: ^26.1.1
-        version: 26.1.1
+        specifier: ^25.9.5
+        version: 25.9.5
       '@types/vscode':
-        specifier: ^1.120.0
-        version: 1.120.0
+        specifier: ^1.125.0
+        version: 1.125.0
       '@vscode/test-electron':
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.1.0
+        version: 3.1.0
       '@vscode/vsce':
         specifier: ^3.9.2
         version: 3.9.2
       esbuild:
-        specifier: ^0.28.1
-        version: 0.28.1
+        specifier: ^0.28.2
+        version: 0.28.2
       ovsx:
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^1.1.1
+        version: 1.1.1(@types/node@25.9.5)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -78,13 +78,13 @@ packages:
   '@azu/style-format@1.0.1':
     resolution: {integrity: sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==}
 
-  '@azure/abort-controller@2.1.2':
-    resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
-    engines: {node: '>=18.0.0'}
+  '@azure/abort-controller@2.2.0':
+    resolution: {integrity: sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==}
+    engines: {node: '>=22.0.0'}
 
-  '@azure/core-auth@1.10.1':
-    resolution: {integrity: sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==}
-    engines: {node: '>=20.0.0'}
+  '@azure/core-auth@1.11.0':
+    resolution: {integrity: sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==}
+    engines: {node: '>=22.0.0'}
 
   '@azure/core-client@1.10.2':
     resolution: {integrity: sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==}
@@ -94,21 +94,21 @@ packages:
     resolution: {integrity: sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/core-tracing@1.3.1':
-    resolution: {integrity: sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==}
-    engines: {node: '>=20.0.0'}
+  '@azure/core-tracing@1.4.0':
+    resolution: {integrity: sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==}
+    engines: {node: '>=22.0.0'}
 
-  '@azure/core-util@1.13.1':
-    resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
-    engines: {node: '>=20.0.0'}
+  '@azure/core-util@1.14.0':
+    resolution: {integrity: sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==}
+    engines: {node: '>=22.0.0'}
 
   '@azure/identity@4.13.1':
     resolution: {integrity: sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/logger@1.3.0':
-    resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
-    engines: {node: '>=20.0.0'}
+  '@azure/logger@1.4.0':
+    resolution: {integrity: sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==}
+    engines: {node: '>=22.0.0'}
 
   '@azure/msal-browser@5.12.0':
     resolution: {integrity: sha512-eNf2aqx1C6I0yT1GEu5ukblFrmaBXGfe1bivpmlfqvK7giPZvoXLa404C8EfeHVsy6EIryfQuPRzuW1fPxWlHg==}
@@ -130,59 +130,59 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.5.4':
-    resolution: {integrity: sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==}
+  '@biomejs/biome@2.5.8':
+    resolution: {integrity: sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.4':
-    resolution: {integrity: sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==}
+  '@biomejs/cli-darwin-arm64@2.5.8':
+    resolution: {integrity: sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.4':
-    resolution: {integrity: sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==}
+  '@biomejs/cli-darwin-x64@2.5.8':
+    resolution: {integrity: sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.4':
-    resolution: {integrity: sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==}
+  '@biomejs/cli-linux-arm64-musl@2.5.8':
+    resolution: {integrity: sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.4':
-    resolution: {integrity: sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==}
+  '@biomejs/cli-linux-arm64@2.5.8':
+    resolution: {integrity: sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.4':
-    resolution: {integrity: sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==}
+  '@biomejs/cli-linux-x64-musl@2.5.8':
+    resolution: {integrity: sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.4':
-    resolution: {integrity: sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==}
+  '@biomejs/cli-linux-x64@2.5.8':
+    resolution: {integrity: sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.4':
-    resolution: {integrity: sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==}
+  '@biomejs/cli-win32-arm64@2.5.8':
+    resolution: {integrity: sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.4':
-    resolution: {integrity: sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==}
+  '@biomejs/cli-win32-x64@2.5.8':
+    resolution: {integrity: sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -196,165 +196,380 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@esbuild/aix-ppc64@0.28.1':
-    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.28.1':
-    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.28.1':
-    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.28.1':
-    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.28.1':
-    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.1':
-    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.28.1':
-    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.1':
-    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.28.1':
-    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.1':
-    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.1':
-    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.1':
-    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.1':
-    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.1':
-    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.1':
-    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.1':
-    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.1':
-    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.1':
-    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.1':
-    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.28.1':
-    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.28.1':
-    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.28.1':
-    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.1':
-    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.1':
-    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  '@hpcc-js/wasm@2.34.7':
-    resolution: {integrity: sha512-P4O1u0V1bZkSIlzs6TjQotqZDW5oLqF4zKcEz1CWRZkIbJNdw/eCrpncRC52Zu0qGCnctkCkdUQjULROtU1Sbg==}
+  '@hpcc-js/wasm@2.35.0':
+    resolution: {integrity: sha512-djUrdwBs3STf8EU6oLydHV5gh4yJRPGWdO7CrVEPzqZ1Ervp0yQipvS97x5a7ueUhP6nEzFgQ+njQH/co6Wyhw==}
     hasBin: true
+
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.3.0':
+    resolution: {integrity: sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -538,8 +753,8 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
-  '@types/node@26.1.1':
-    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+  '@types/node@25.9.5':
+    resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -547,15 +762,15 @@ packages:
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
 
-  '@types/vscode@1.120.0':
-    resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
+  '@types/vscode@1.125.0':
+    resolution: {integrity: sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==}
 
   '@typespec/ts-http-runtime@0.3.6':
     resolution: {integrity: sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==}
     engines: {node: '>=20.0.0'}
 
-  '@vscode/test-electron@3.0.0':
-    resolution: {integrity: sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==}
+  '@vscode/test-electron@3.1.0':
+    resolution: {integrity: sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==}
     engines: {node: '>=22'}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
@@ -609,7 +824,6 @@ packages:
   '@vscode/vsce@3.9.2':
     resolution: {integrity: sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==}
     engines: {node: '>= 20'}
-    hasBin: true
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -629,8 +843,8 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
     engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
@@ -654,9 +868,6 @@ packages:
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -677,12 +888,9 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -717,6 +925,9 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
 
@@ -737,6 +948,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
@@ -771,6 +986,11 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cross-keychain@1.1.0:
+    resolution: {integrity: sha512-244DWNdGepLKD5vEn3reZqwzZFiE/LD4U+XV9IaXQbtIXKvQkf0VkRaOj/9vPYauPdR12PSGB3U0cE7jJi3WTQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -818,7 +1038,6 @@ packages:
   d3-dsv@3.0.1:
     resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
     engines: {node: '>=12'}
-    hasBin: true
 
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
@@ -1028,8 +1247,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.28.1:
-    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1048,8 +1267,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1168,11 +1387,15 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
   immediate@3.0.6:
@@ -1204,7 +1427,6 @@ packages:
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1221,7 +1443,6 @@ packages:
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
-    hasBin: true
 
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
@@ -1256,14 +1477,12 @@ packages:
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
-    hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1271,7 +1490,6 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
-    hasBin: true
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
@@ -1349,14 +1567,17 @@ packages:
 
   markdown-it@14.2.0:
     resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
-    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mdurl@2.0.0:
-    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
+
+  meow@14.1.0:
+    resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
+    engines: {node: '>=20'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1377,7 +1598,6 @@ packages:
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
-    hasBin: true
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -1387,13 +1607,9 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
-
-  minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -1410,6 +1626,10 @@ packages:
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
@@ -1455,8 +1675,8 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
-  ovsx@1.0.2:
-    resolution: {integrity: sha512-N0gWlINGgoOA2Sn0AhrF9L3ap40a/QbsFUpMDKR+CKYyZGJeTFEoNGngplLHjAYtcjrrZv2jX2K7ktPzxWjPNg==}
+  ovsx@1.1.1:
+    resolution: {integrity: sha512-tklsCzvGVWKlM91Vc9U8tNnaQ+XacPJ12SWHjDaHGUJB49oMhoAULsJGeefhHebPvvckbcWbKqKIXODMZah5SA==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -1512,7 +1732,6 @@ packages:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -1536,7 +1755,6 @@ packages:
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   read-pkg@9.0.1:
     resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
@@ -1587,28 +1805,20 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sax@1.6.0:
-    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+  sax@1.6.1:
+    resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
 
   secretlint@10.2.2:
     resolution: {integrity: sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==}
     engines: {node: '>=20.0.0'}
-    hasBin: true
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
-    hasBin: true
-
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   semver@7.8.4:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
-    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1713,8 +1923,8 @@ packages:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -1759,7 +1969,6 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
-    hasBin: true
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
@@ -1767,8 +1976,8 @@ packages:
   underscore@1.13.8:
     resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
-  undici-types@8.3.0:
-    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@7.27.2:
     resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
@@ -1799,19 +2008,22 @@ packages:
     resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
     engines: {node: '>=4'}
 
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+  vscode-jsonrpc@9.0.1:
+    resolution: {integrity: sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==}
     engines: {node: '>=14.0.0'}
 
-  vscode-languageclient@9.0.1:
-    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
-    engines: {vscode: ^1.82.0}
+  vscode-languageclient@10.1.0:
+    resolution: {integrity: sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==}
+    engines: {vscode: ^1.91.0}
 
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+  vscode-languageserver-protocol@3.18.2:
+    resolution: {integrity: sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==}
 
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+  vscode-languageserver-textdocument@1.0.13:
+    resolution: {integrity: sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -1821,6 +2033,10 @@ packages:
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
@@ -1867,6 +2083,10 @@ packages:
   yazl@2.5.1:
     resolution: {integrity: sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==}
 
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
+
 snapshots:
 
   '@azu/format-text@1.0.2': {}
@@ -1875,49 +2095,49 @@ snapshots:
     dependencies:
       '@azu/format-text': 1.0.2
 
-  '@azure/abort-controller@2.1.2':
+  '@azure/abort-controller@2.2.0':
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-auth@1.10.1':
+  '@azure/core-auth@1.11.0':
     dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.13.1
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-util': 1.14.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
   '@azure/core-client@1.10.2':
     dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
       '@azure/core-rest-pipeline': 1.24.0
-      '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
   '@azure/core-rest-pipeline@1.24.0':
     dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
       '@typespec/ts-http-runtime': 0.3.6
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-tracing@1.3.1':
+  '@azure/core-tracing@1.4.0':
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-util@1.13.1':
+  '@azure/core-util@1.14.0':
     dependencies:
-      '@azure/abort-controller': 2.1.2
+      '@azure/abort-controller': 2.2.0
       '@typespec/ts-http-runtime': 0.3.6
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -1925,13 +2145,13 @@ snapshots:
 
   '@azure/identity@4.13.1':
     dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
       '@azure/core-client': 1.10.2
       '@azure/core-rest-pipeline': 1.24.0
-      '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
       '@azure/msal-browser': 5.12.0
       '@azure/msal-node': 5.2.3
       open: 10.2.0
@@ -1939,7 +2159,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/logger@1.3.0':
+  '@azure/logger@1.4.0':
     dependencies:
       '@typespec/ts-http-runtime': 0.3.6
       tslib: 2.8.1
@@ -1965,39 +2185,39 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@biomejs/biome@2.5.4':
+  '@biomejs/biome@2.5.8':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.4
-      '@biomejs/cli-darwin-x64': 2.5.4
-      '@biomejs/cli-linux-arm64': 2.5.4
-      '@biomejs/cli-linux-arm64-musl': 2.5.4
-      '@biomejs/cli-linux-x64': 2.5.4
-      '@biomejs/cli-linux-x64-musl': 2.5.4
-      '@biomejs/cli-win32-arm64': 2.5.4
-      '@biomejs/cli-win32-x64': 2.5.4
+      '@biomejs/cli-darwin-arm64': 2.5.8
+      '@biomejs/cli-darwin-x64': 2.5.8
+      '@biomejs/cli-linux-arm64': 2.5.8
+      '@biomejs/cli-linux-arm64-musl': 2.5.8
+      '@biomejs/cli-linux-x64': 2.5.8
+      '@biomejs/cli-linux-x64-musl': 2.5.8
+      '@biomejs/cli-win32-arm64': 2.5.8
+      '@biomejs/cli-win32-x64': 2.5.8
 
-  '@biomejs/cli-darwin-arm64@2.5.4':
+  '@biomejs/cli-darwin-arm64@2.5.8':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.4':
+  '@biomejs/cli-darwin-x64@2.5.8':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.4':
+  '@biomejs/cli-linux-arm64-musl@2.5.8':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.4':
+  '@biomejs/cli-linux-arm64@2.5.8':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.4':
+  '@biomejs/cli-linux-x64-musl@2.5.8':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.4':
+  '@biomejs/cli-linux-x64@2.5.8':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.4':
+  '@biomejs/cli-win32-arm64@2.5.8':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.4':
+  '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
   '@emnapi/core@1.11.1':
@@ -2016,87 +2236,264 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.1':
+  '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/android-arm64@0.28.1':
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
-  '@esbuild/android-arm@0.28.1':
+  '@esbuild/android-arm@0.28.2':
     optional: true
 
-  '@esbuild/android-x64@0.28.1':
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.1':
+  '@esbuild/darwin-arm64@0.28.2':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.1':
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.1':
+  '@esbuild/freebsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.1':
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.1':
+  '@esbuild/linux-arm64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm@0.28.1':
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.1':
+  '@esbuild/linux-ia32@0.28.2':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.1':
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.1':
+  '@esbuild/linux-mips64el@0.28.2':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.1':
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.1':
+  '@esbuild/linux-riscv64@0.28.2':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.1':
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
-  '@esbuild/linux-x64@0.28.1':
+  '@esbuild/linux-x64@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.1':
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.1':
+  '@esbuild/netbsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.1':
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.1':
+  '@esbuild/openbsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.1':
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.1':
+  '@esbuild/sunos-x64@0.28.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.1':
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.1':
+  '@esbuild/win32-ia32@0.28.2':
     optional: true
 
-  '@esbuild/win32-x64@0.28.1':
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@hpcc-js/wasm@2.34.7':
+  '@hpcc-js/wasm@2.35.0':
     dependencies:
       yargs: 18.0.0
+
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/confirm@5.1.21(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/core@10.3.2(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/editor@4.2.23(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/expand@4.0.23(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.5)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/number@3.0.23(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/password@4.0.23(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/prompts@7.10.1(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@25.9.5)
+      '@inquirer/confirm': 5.1.21(@types/node@25.9.5)
+      '@inquirer/editor': 4.2.23(@types/node@25.9.5)
+      '@inquirer/expand': 4.0.23(@types/node@25.9.5)
+      '@inquirer/input': 4.3.1(@types/node@25.9.5)
+      '@inquirer/number': 3.0.23(@types/node@25.9.5)
+      '@inquirer/password': 4.0.23(@types/node@25.9.5)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.9.5)
+      '@inquirer/search': 3.2.2(@types/node@25.9.5)
+      '@inquirer/select': 4.4.2(@types/node@25.9.5)
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/rawlist@4.1.11(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/search@3.2.2(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/select@4.4.2(@types/node@25.9.5)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@25.9.5)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.9.5)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@inquirer/type@3.0.10(@types/node@25.9.5)':
+    optionalDependencies:
+      '@types/node': 25.9.5
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring@1.3.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.3.0
+      '@napi-rs/keyring-darwin-x64': 1.3.0
+      '@napi-rs/keyring-freebsd-x64': 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-musl': 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.3.0
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -2294,15 +2691,15 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/node@26.1.1':
+  '@types/node@25.9.5':
     dependencies:
-      undici-types: 8.3.0
+      undici-types: 7.24.6
 
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/sarif@2.1.7': {}
 
-  '@types/vscode@1.120.0': {}
+  '@types/vscode@1.125.0': {}
 
   '@typespec/ts-http-runtime@0.3.6':
     dependencies:
@@ -2312,13 +2709,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vscode/test-electron@3.0.0':
+  '@vscode/test-electron@3.1.0':
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       jszip: 3.10.1
       ora: 8.2.0
-      semver: 7.8.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -2381,7 +2778,7 @@ snapshots:
       leven: 3.1.0
       markdown-it: 14.2.0
       mime: 1.6.0
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       parse-semver: 1.1.1
       read: 1.0.7
       secretlint: 10.2.2
@@ -2402,7 +2799,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2414,7 +2811,7 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.2: {}
+  ansi-regex@6.3.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -2432,8 +2829,6 @@ snapshots:
     dependencies:
       tunnel: 0.0.6
       typed-rest-client: 1.8.11
-
-  balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
@@ -2455,11 +2850,7 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@2.1.0:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2498,6 +2889,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chardet@2.2.0: {}
+
   cheerio-select@2.1.0:
     dependencies:
       boolbase: 1.0.0
@@ -2532,6 +2925,8 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
+  cli-width@4.1.0: {}
+
   cliui@9.0.1:
     dependencies:
       string-width: 7.2.0
@@ -2557,6 +2952,15 @@ snapshots:
   commander@7.2.0: {}
 
   core-util-is@1.0.3: {}
+
+  cross-keychain@1.1.0(@types/node@25.9.5):
+    dependencies:
+      '@inquirer/prompts': 7.10.1(@types/node@25.9.5)
+      meow: 14.1.0
+    optionalDependencies:
+      '@napi-rs/keyring': 1.3.0
+    transitivePeerDependencies:
+      - '@types/node'
 
   css-select@5.2.2:
     dependencies:
@@ -2629,7 +3033,7 @@ snapshots:
 
   d3-graphviz@5.6.0(d3-selection@3.0.0):
     dependencies:
-      '@hpcc-js/wasm': 2.34.7
+      '@hpcc-js/wasm': 2.35.0
       d3-dispatch: 3.0.1
       d3-format: 3.1.2
       d3-interpolate: 3.0.1
@@ -2843,34 +3247,34 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
-  esbuild@0.28.1:
+  esbuild@0.28.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.1
-      '@esbuild/android-arm': 0.28.1
-      '@esbuild/android-arm64': 0.28.1
-      '@esbuild/android-x64': 0.28.1
-      '@esbuild/darwin-arm64': 0.28.1
-      '@esbuild/darwin-x64': 0.28.1
-      '@esbuild/freebsd-arm64': 0.28.1
-      '@esbuild/freebsd-x64': 0.28.1
-      '@esbuild/linux-arm': 0.28.1
-      '@esbuild/linux-arm64': 0.28.1
-      '@esbuild/linux-ia32': 0.28.1
-      '@esbuild/linux-loong64': 0.28.1
-      '@esbuild/linux-mips64el': 0.28.1
-      '@esbuild/linux-ppc64': 0.28.1
-      '@esbuild/linux-riscv64': 0.28.1
-      '@esbuild/linux-s390x': 0.28.1
-      '@esbuild/linux-x64': 0.28.1
-      '@esbuild/netbsd-arm64': 0.28.1
-      '@esbuild/netbsd-x64': 0.28.1
-      '@esbuild/openbsd-arm64': 0.28.1
-      '@esbuild/openbsd-x64': 0.28.1
-      '@esbuild/openharmony-arm64': 0.28.1
-      '@esbuild/sunos-x64': 0.28.1
-      '@esbuild/win32-arm64': 0.28.1
-      '@esbuild/win32-ia32': 0.28.1
-      '@esbuild/win32-x64': 0.28.1
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -2887,7 +3291,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -2951,7 +3355,7 @@ snapshots:
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -2964,7 +3368,7 @@ snapshots:
     dependencies:
       '@sindresorhus/merge-streams': 2.3.0
       fast-glob: 3.3.3
-      ignore: 7.0.5
+      ignore: 7.0.6
       path-type: 6.0.0
       slash: 5.1.0
       unicorn-magic: 0.3.0
@@ -3022,10 +3426,14 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1:
     optional: true
 
-  ignore@7.0.5: {}
+  ignore@7.0.6: {}
 
   immediate@3.0.6: {}
 
@@ -3187,13 +3595,15 @@ snapshots:
       argparse: 2.0.1
       entities: 4.5.0
       linkify-it: 5.0.1
-      mdurl: 2.0.0
+      mdurl: 2.1.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
   math-intrinsics@1.1.0: {}
 
-  mdurl@2.0.0: {}
+  mdurl@2.1.0: {}
+
+  meow@14.1.0: {}
 
   merge2@1.4.1: {}
 
@@ -3215,13 +3625,9 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.6
-
-  minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 5.0.9
 
   minimist@1.2.8:
     optional: true
@@ -3234,6 +3640,8 @@ snapshots:
   ms@2.1.3: {}
 
   mute-stream@0.0.8: {}
+
+  mute-stream@2.0.0: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -3293,10 +3701,12 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ovsx@1.0.2:
+  ovsx@1.1.1(@types/node@25.9.5):
     dependencies:
+      '@inquirer/prompts': 7.10.1(@types/node@25.9.5)
       '@vscode/vsce': 3.9.2
       commander: 6.2.1
+      cross-keychain: 1.1.0(@types/node@25.9.5)
       follow-redirects: 1.16.0
       is-ci: 2.0.0
       leven: 3.1.0
@@ -3304,6 +3714,7 @@ snapshots:
       tmp: 0.2.7
       yauzl-promise: 4.0.0
     transitivePeerDependencies:
+      - '@types/node'
       - debug
       - supports-color
 
@@ -3363,7 +3774,7 @@ snapshots:
       pump: 3.0.4
       rc: 1.2.8
       simple-get: 4.0.1
-      tar-fs: 2.1.4
+      tar-fs: 2.1.5
       tunnel-agent: 0.6.0
     optional: true
 
@@ -3454,7 +3865,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sax@1.6.0: {}
+  sax@1.6.1: {}
 
   secretlint@10.2.2:
     dependencies:
@@ -3469,8 +3880,6 @@ snapshots:
       - supports-color
 
   semver@5.7.2: {}
-
-  semver@7.7.4: {}
 
   semver@7.8.4: {}
 
@@ -3571,7 +3980,7 @@ snapshots:
 
   strip-ansi@7.2.0:
     dependencies:
-      ansi-regex: 6.2.2
+      ansi-regex: 6.3.0
 
   strip-json-comments@2.0.1:
     optional: true
@@ -3597,7 +4006,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tar-fs@2.1.4:
+  tar-fs@2.1.5:
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
@@ -3654,7 +4063,7 @@ snapshots:
 
   underscore@1.13.8: {}
 
-  undici-types@8.3.0: {}
+  undici-types@7.24.6: {}
 
   undici@7.27.2: {}
 
@@ -3675,26 +4084,35 @@ snapshots:
 
   version-range@4.15.0: {}
 
-  vscode-jsonrpc@8.2.0: {}
+  vscode-jsonrpc@9.0.1: {}
 
-  vscode-languageclient@9.0.1:
+  vscode-languageclient@10.1.0:
     dependencies:
-      minimatch: 5.1.9
-      semver: 7.7.4
-      vscode-languageserver-protocol: 3.17.5
+      minimatch: 10.2.6
+      semver: 7.8.5
+      vscode-languageserver-protocol: 3.18.2
+      vscode-languageserver-textdocument: 1.0.13
 
-  vscode-languageserver-protocol@3.17.5:
+  vscode-languageserver-protocol@3.18.2:
     dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
+      vscode-jsonrpc: 9.0.1
+      vscode-languageserver-types: 3.18.0
 
-  vscode-languageserver-types@3.17.5: {}
+  vscode-languageserver-textdocument@1.0.13: {}
+
+  vscode-languageserver-types@3.18.0: {}
 
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@4.0.0: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@9.0.2:
     dependencies:
@@ -3711,7 +4129,7 @@ snapshots:
 
   xml2js@0.5.0:
     dependencies:
-      sax: 1.6.0
+      sax: 1.6.1
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
@@ -3744,3 +4162,5 @@ snapshots:
   yazl@2.5.1:
     dependencies:
       buffer-crc32: 0.2.13
+
+  yoctocolors-cjs@2.1.3: {}

--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -1,5 +1,5 @@
-import { exec } from "child_process";
-import * as os from "os";
+import { exec } from "node:child_process";
+import * as os from "node:os";
 import * as vscode from "vscode";
 
 import type { Config } from "./config";
@@ -46,6 +46,7 @@ async function getServer(
 	} = context.extension.packageJSON;
 
 	// check if the server path is configured explicitly
+	// biome-ignore lint/complexity/useLiteralKeys: conflicting lint
 	const explicitPath = process.env["__WA_LSP_SERVER_DEBUG"] ?? config.serverPath;
 	if (explicitPath) {
 		if (explicitPath.startsWith("~/")) {
@@ -169,7 +170,7 @@ async function patchelf(destination: vscode.Uri): Promise<void> {
                     '';
                 }
             `;
-			const originalFile = vscode.Uri.file(destination.fsPath + "-orig");
+			const originalFile = vscode.Uri.file(`${destination.fsPath}-orig`);
 			await vscode.workspace.fs.rename(destination, originalFile, {
 				overwrite: true,
 			});

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -1,19 +1,18 @@
+import { sep as pathSeparator } from "node:path"; // spellchecker:disable-line
 import anser from "anser";
-import { sep as pathSeparator } from "path"; // spellchecker:disable-line
 import * as vscode from "vscode";
 import { WorkspaceEdit } from "vscode";
-import * as Is from "vscode-languageclient/lib/common/utils/is";
 import * as lc from "vscode-languageclient/node";
-
 import { type Config, prepareVSCodeConfig } from "./config";
 import * as diagnostics from "./diagnostics";
+import * as Is from "./is";
 import { WaLanguageClient } from "./lang_client";
 import * as wa from "./lsp_ext";
 import { assert } from "./utilities";
 
 export function createClient(
-	traceOutputChannel: vscode.OutputChannel,
-	outputChannel: vscode.OutputChannel,
+	traceOutputChannel: vscode.LogOutputChannel,
+	outputChannel: vscode.LogOutputChannel,
 	initializationOptions: vscode.WorkspaceConfiguration,
 	serverOptions: lc.ServerOptions,
 	config: Config,
@@ -70,11 +69,11 @@ export function createClient(
 						unlinkedFiles.push(uri);
 						const folder = vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath;
 						if (folder) {
-							const parentBackslash = uri.fsPath.lastIndexOf(pathSeparator + "src");
+							const parentBackslash = uri.fsPath.lastIndexOf(`${pathSeparator}src`);
 							const parent = uri.fsPath.substring(0, parentBackslash);
 
 							if (parent.startsWith(folder)) {
-								const path = vscode.Uri.file(parent + pathSeparator + "wesl.toml");
+								const path = vscode.Uri.file(`${parent}${pathSeparator}wesl.toml`);
 								void vscode.workspace.fs.stat(path).then(async () => {
 									const choice = await vscode.window.showInformationMessage(
 										`This file does not belong to a loaded project. It looks like it might belong to the workspace at ${path.path}, do you want to add it to the linked projects?`,
@@ -88,8 +87,7 @@ export function createClient(
 										case "No":
 											break;
 										case "Yes": {
-											const pathToInsert =
-												"." + parent.substring(folder.length) + pathSeparator + "wesl.toml";
+											const pathToInsert = `.${parent.substring(folder.length)}${pathSeparator}wesl.toml`;
 											const value = config
 												// biome-ignore lint/suspicious/noExplicitAny: Signature comes from upstream
 												.get<any[]>("linkedProjects")
@@ -235,7 +233,7 @@ export function createClient(
 						const args = [
 							{
 								label: primary.title,
-								arguments: primary.command!.arguments![0],
+								arguments: primary.command?.arguments?.[0],
 							},
 							...items,
 						];
@@ -403,7 +401,7 @@ function renderHoverActions(actions: wa.CommandLinkGroup[]): vscode.MarkdownStri
 	const text = actions
 		.map(
 			(group) =>
-				(group.title ? group.title + " " : "") + group.commands.map(renderCommand).join(" | "),
+				(group.title ? `${group.title} ` : "") + group.commands.map(renderCommand).join(" | "),
 		)
 		.join(" | ");
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1,15 +1,11 @@
-import * as path from "path";
+import * as path from "node:path";
 import * as vscode from "vscode";
 import * as lc from "vscode-languageclient";
 import type { LanguageClient } from "vscode-languageclient/node";
 import { HOVER_REFERENCE_COMMAND } from "./client";
 import type { Cmd, Context, InitializedContext } from "./context";
 import * as wa from "./lsp_ext";
-import {
-	applySnippetTextEdits,
-	applySnippetWorkspaceEdit,
-	type SnippetTextDocumentEdit,
-} from "./snippets";
+import { applySnippetTextEdits, applySnippetWorkspaceEdit } from "./snippets";
 import type { SyntaxElement } from "./syntax_tree_provider";
 import {
 	isWeslDocument,
@@ -67,7 +63,7 @@ export function memoryUsage(context: InitializedContext): Cmd {
 			}
 
 			return context.client.sendRequest(wa.memoryUsage).then((memory: string) => {
-				return "Per-query memory usage:\n" + memory + "\n(note: database has been cleared)";
+				return `Per-query memory usage:\n${memory}\n(note: database has been cleared)`;
 			});
 		}
 
@@ -172,7 +168,7 @@ export function moveItem(context: InitializedContext, direction: wa.Direction): 
 			direction,
 		});
 
-		if (lcEdits.length == 0) {
+		if (lcEdits.length === 0) {
 			return;
 		}
 
@@ -734,72 +730,13 @@ export function resolveCodeAction(context: InitializedContext): Cmd {
 		if (!item?.edit) {
 			return;
 		}
-		const itemEdit = item.edit;
-		// filter out all text edits and recreate the WorkspaceEdit without them so we can apply
-		// snippet edits on our own
-		const lcFileSystemEdit = {
-			...itemEdit,
-			documentChanges: itemEdit.documentChanges?.filter((change) => "kind" in change),
-		};
-		const fileSystemEdit = await client.protocol2CodeConverter.asWorkspaceEdit(lcFileSystemEdit);
-		await vscode.workspace.applyEdit(fileSystemEdit);
+		const workspaceEdit = await client.protocol2CodeConverter.asWorkspaceEdit(item.edit);
+		await vscode.workspace.applyEdit(workspaceEdit);
 
-		// replace all text edits so that we can convert snippet text edits into `vscode.SnippetTextEdit`s
-		// FIXME: this is a workaround until vscode-languageclient supports doing the SnippeTextEdit conversion itself
-		// also need to carry the snippetTextDocumentEdits separately, since we cannot retrieve them again using WorkspaceEdit.entries
-		const [workspaceTextEdit, snippetTextDocumentEdits] = asWorkspaceSnippetEdit(context, itemEdit);
-		await applySnippetWorkspaceEdit(workspaceTextEdit, snippetTextDocumentEdits);
 		if (item.command != null) {
 			await vscode.commands.executeCommand(item.command.command, item.command.arguments);
 		}
 	};
-}
-
-function asWorkspaceSnippetEdit(
-	context: InitializedContext,
-	item: lc.WorkspaceEdit,
-): [vscode.WorkspaceEdit, SnippetTextDocumentEdit[]] {
-	const client = context.client;
-
-	// partially borrowed from https://github.com/microsoft/vscode-languageserver-node/blob/295aaa393fda8ecce110c38880a00466b9320e63/client/src/common/protocolConverter.ts#L1060-L1101
-	const result = new vscode.WorkspaceEdit();
-
-	if (item.documentChanges) {
-		const snippetTextDocumentEdits: SnippetTextDocumentEdit[] = [];
-
-		for (const change of item.documentChanges) {
-			if (lc.TextDocumentEdit.is(change)) {
-				const uri = client.protocol2CodeConverter.asUri(change.textDocument.uri);
-				const snippetTextEdits: (vscode.TextEdit | vscode.SnippetTextEdit)[] = [];
-
-				for (const edit of change.edits) {
-					if ("insertTextFormat" in edit && edit.insertTextFormat === lc.InsertTextFormat.Snippet) {
-						// is a snippet text edit
-						snippetTextEdits.push(
-							new vscode.SnippetTextEdit(
-								client.protocol2CodeConverter.asRange(edit.range),
-								new vscode.SnippetString(edit.newText),
-							),
-						);
-					} else {
-						// always as a text document edit
-						snippetTextEdits.push(
-							vscode.TextEdit.replace(
-								client.protocol2CodeConverter.asRange(edit.range),
-								edit.newText,
-							),
-						);
-					}
-				}
-
-				snippetTextDocumentEdits.push([uri, snippetTextEdits]);
-			}
-		}
-		return [result, snippetTextDocumentEdits];
-	} else {
-		// we do not handle WorkspaceEdit.changes since it is not relevant for code actions
-		return [result, []];
-	}
 }
 
 export function applySnippetWorkspaceEditCommand(_ctx: InitializedContext): Cmd {
@@ -1110,7 +1047,7 @@ export function toggleLSPLogs(context: Context): Cmd {
 			config.get<string | undefined>("trace.server") === "verbose" ? undefined : "verbose";
 
 		await config.update("trace.server", targetValue, vscode.ConfigurationTarget.Workspace);
-		if (targetValue && context.client && context.client.traceOutputChannel) {
+		if (targetValue && context.client?.traceOutputChannel) {
 			context.client.traceOutputChannel.show();
 		}
 	};

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -1,8 +1,8 @@
-import * as os from "os";
-import * as path from "path";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { Disposable } from "vscode";
 import * as vscode from "vscode";
-import * as Is from "vscode-languageclient/lib/common/utils/is";
+import * as Is from "./is";
 
 import type { Env } from "./utilities";
 
@@ -229,9 +229,9 @@ export class Config {
 		const config = this.cfg.inspect<boolean>("checkOnSave") ?? {
 			key: "checkOnSave",
 		};
-		let overrideInLanguage;
-		let target;
-		let value;
+		let overrideInLanguage: boolean | undefined;
+		let target: number | undefined;
+		let value: boolean | undefined;
 		if (
 			config.workspaceFolderValue !== undefined
 			|| config.workspaceFolderLanguageValue !== undefined
@@ -274,6 +274,7 @@ export class Config {
 		let sourceFileMap = this.get<Record<string, string> | "auto">("debug.sourceFileMap");
 		if (sourceFileMap !== "auto") {
 			// "/wesl/<id>" used by suggestions only.
+			// biome-ignore lint/complexity/useLiteralKeys: conflicting lint
 			const { ["/wesl/<id>"]: _, ...trimmed } =
 				this.get<Record<string, string>>("debug.sourceFileMap") ?? {};
 			sourceFileMap = trimmed;
@@ -354,8 +355,9 @@ export function substituteVariablesInEnv(env: Env): Env {
 		Object.entries(env).map(([key, value]) => {
 			const dependencies = new Set<string>();
 			const depRe = new RegExp(/\$\{(?<depName>.+?)\}/g);
-			let match = undefined;
-			while ((match = depRe.exec(value))) {
+			let match: RegExpExecArray | null = depRe.exec(value);
+			while (match) {
+				// biome-ignore lint/complexity/useLiteralKeys: conflicting lint
 				const depName = unwrapUndefinable(match.groups?.["depName"]);
 				dependencies.add(depName);
 				// `depName` at this point can have a form of `expression` or
@@ -363,6 +365,7 @@ export function substituteVariablesInEnv(env: Env): Env {
 				if (!definedEnvKeys.has(depName)) {
 					missingDeps.add(depName);
 				}
+				match = depRe.exec(value);
 			}
 			return [`env:${key}`, { dependencies: [...dependencies], value }];
 		}),
@@ -385,14 +388,14 @@ export function substituteVariablesInEnv(env: Env): Env {
 				// we cannot handle other prefixes at the moment
 				// leave values as is, but still mark them as resolved
 				envWithDeps[dep] = {
-					value: "${" + dep + "}",
+					value: `\${${dep}}`,
 					dependencies: [],
 				};
 				resolved.add(dep);
 			}
 		} else {
 			envWithDeps[dep] = {
-				value: computeVscodeVar(dep) || "${" + dep + "}",
+				value: computeVscodeVar(dep) || `\${${dep}}`,
 				dependencies: [],
 			};
 		}
@@ -466,6 +469,7 @@ function computeVscodeVar(varName: string): string | null {
 		// https://github.com/microsoft/vscode/blob/08ac1bb67ca2459496b272d8f4a908757f24f56f/src/vs/workbench/api/common/extHostVariableResolverService.ts#L81
 		// or
 		// https://github.com/microsoft/vscode/blob/29eb316bb9f154b7870eb5204ec7f2e7cf649bec/src/vs/server/node/remoteTerminalChannel.ts#L56
+		// biome-ignore lint/complexity/useLiteralKeys: conflicting lint
 		execPath: () => process.env["VSCODE_EXEC_PATH"] ?? process.execPath,
 
 		pathSeparator: () => path.sep, // spellchecker:disable-line

--- a/editors/code/src/context.ts
+++ b/editors/code/src/context.ts
@@ -60,9 +60,9 @@ export class Context implements WgslAnalyzerExtensionApi {
 
 	private _client: lc.LanguageClient | undefined;
 	private _serverPath: string | undefined;
-	private traceOutputChannel: vscode.OutputChannel | undefined;
+	private traceOutputChannel: vscode.LogOutputChannel | undefined;
 	private testController: vscode.TestController | undefined;
-	private outputChannel: vscode.OutputChannel | undefined;
+	private outputChannel: vscode.LogOutputChannel | undefined;
 	private clientSubscriptions: Disposable[];
 	private state: PersistentState;
 	private commandFactories: Record<string, CommandFactory>;
@@ -221,15 +221,17 @@ export class Context implements WgslAnalyzerExtensionApi {
 		return this._client;
 	}
 
-	private getOutputChannel(): vscode.OutputChannel {
+	private getOutputChannel(): vscode.LogOutputChannel {
 		if (!this.outputChannel) {
-			this.outputChannel = vscode.window.createOutputChannel("wgsl-analyzer Language Server");
+			this.outputChannel = vscode.window.createOutputChannel("wgsl-analyzer Language Server", {
+				log: true,
+			});
 			this.pushExtCleanup(this.outputChannel);
 		}
 		return this.outputChannel;
 	}
 
-	private getTraceOutputChannel(): vscode.OutputChannel {
+	private getTraceOutputChannel(): vscode.LogOutputChannel {
 		if (!this.traceOutputChannel) {
 			this.traceOutputChannel = new LazyOutputChannel("wgsl-analyzer Language Server Trace");
 			this.pushExtCleanup(this.traceOutputChannel);
@@ -378,9 +380,7 @@ export class Context implements WgslAnalyzerExtensionApi {
 		this.commandDisposables = [];
 
 		const clientRunning = (!forceDisable && this._client?.isRunning()) ?? false;
-		const isClientRunning = function (_ctx: Context): _ctx is InitializedContext {
-			return clientRunning;
-		};
+		const isClientRunning = (_ctx: Context): _ctx is InitializedContext => clientRunning;
 
 		for (const [name, factory] of Object.entries(this.commandFactories)) {
 			const fullName = `wgsl-analyzer.${name}`;

--- a/editors/code/src/diagnostics.ts
+++ b/editors/code/src/diagnostics.ts
@@ -45,7 +45,7 @@ function getRenderedDiagnostic(context: Context, uri: vscode.Uri): string {
 		return "Unable to find original diagnostic";
 	}
 
-	const diagnostic = diagnostics[parseInt(uri.query)];
+	const diagnostic = diagnostics[parseInt(uri.query, 10)];
 	if (!diagnostic) {
 		return "Unable to find original diagnostic";
 	}
@@ -211,7 +211,7 @@ export class AnsiDecorationProvider implements vscode.Disposable {
 
 		const themeColor = AnsiDecorationProvider._anserToThemeColor[color];
 		if (themeColor) {
-			return new ThemeColor("terminal." + themeColor.id);
+			return new ThemeColor(`terminal.${themeColor.id}`);
 		}
 		return undefined;
 	}

--- a/editors/code/src/is.ts
+++ b/editors/code/src/is.ts
@@ -1,0 +1,15 @@
+// biome-ignore lint/suspicious/noExplicitAny: todo
+export function string(value: any): value is string {
+	return typeof value === "string" || value instanceof String;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: todo
+export function array<T>(value: any): value is T[] {
+	return Array.isArray(value);
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: todo
+export function typedArray<T>(value: any, check: (value: any) => boolean): value is T[] {
+	// biome-ignore lint/suspicious/noExplicitAny: todo
+	return Array.isArray(value) && (<any[]>value).every(check);
+}

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -1,4 +1,6 @@
-import { InlayHint } from "vscode";
+// biome-ignore-all lint/complexity/noBannedTypes: intentional
+
+import type { InlayHint } from "vscode";
 import * as lc from "vscode-languageclient";
 
 // wgsl-analyzer overrides
@@ -109,7 +111,7 @@ export type AnalyzerStatusParameters = {
 	textDocument?: lc.TextDocumentIdentifier;
 };
 
-export interface FetchDependencyListParameters {}
+export type FetchDependencyListParameters = {};
 
 export interface FetchDependencyListResult {
 	crates: {
@@ -125,7 +127,7 @@ export const fetchDependencyList = new lc.RequestType<
 	void
 >("wgsl-analyzer/fetchDependencyList");
 
-export interface FetchModuleGraphParameters {}
+export type FetchModuleGraphParameters = {};
 
 export interface FetchModuleGraphResult {
 	modules: {
@@ -140,7 +142,7 @@ export const fetchModuleGraph = new lc.RequestType<
 	void
 >("wgsl-analyzer/fetchModuleGraph");
 
-export interface FetchPackageGraphParameters {}
+export type FetchPackageGraphParameters = {};
 
 export interface FetchPackageGraphResult {
 	packages: {

--- a/editors/code/src/syntax_tree_provider.ts
+++ b/editors/code/src/syntax_tree_provider.ts
@@ -90,7 +90,15 @@ export class SyntaxTreeProvider implements vscode.TreeDataProvider<SyntaxElement
 					end: end_offset,
 				};
 
-				let inner;
+				let inner:
+					| {
+							offsets: {
+								start: number;
+								end: number;
+							};
+							range: vscode.Range;
+					  }
+					| undefined;
 				if (value.start_index && value.end_index) {
 					const [start_offset, start_line, start_column] = value.start_index;
 					const [end_offset, end_line, end_column] = value.end_index;

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -125,7 +125,8 @@ export async function targetToExecution(
 	},
 	cargo?: string,
 ): Promise<vscode.ProcessExecution | vscode.ShellExecution> {
-	let command, args;
+	let command: string | undefined;
+	let args: string[] | undefined;
 	if (isWeslTask(definition)) {
 		// FIXME: The server should provide wesl-rs
 		command = cargo || (await toolchain.weslPath(options?.env));

--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -1,5 +1,5 @@
-import * as os from "os";
-import * as path from "path";
+import * as os from "node:os";
+import * as path from "node:path";
 import * as vscode from "vscode";
 
 import { log, memoizeAsync } from "./utilities";
@@ -18,6 +18,7 @@ export interface ArtifactSpec {
 
 // FIXME: The server should provide this
 export function weslPath(env?: Record<string, string>): Promise<string> {
+	// biome-ignore lint/complexity/useLiteralKeys: conflicting lint
 	if (env?.["WESLRS_TOOLCHAIN"]) {
 		return Promise.resolve("wesl");
 	}
@@ -45,6 +46,7 @@ const getPathForExecutable = memoizeAsync(
 );
 
 async function lookupInPath(exec: string): Promise<boolean> {
+	// biome-ignore lint/complexity/useLiteralKeys: conflicting lint
 	const paths = process.env["PATH"] ?? "";
 
 	const candidates = paths.split(path.delimiter).flatMap((directoryInPath) => {
@@ -61,6 +63,7 @@ async function lookupInPath(exec: string): Promise<boolean> {
 }
 
 function getCargoHome(): vscode.Uri | null {
+	// biome-ignore lint/complexity/useLiteralKeys: conflicting lint
 	const envVar = process.env["CARGO_HOME"];
 	if (envVar) return vscode.Uri.file(envVar);
 	try {

--- a/editors/code/src/utilities.ts
+++ b/editors/code/src/utilities.ts
@@ -1,11 +1,11 @@
-import { strict as nativeAssert } from "assert";
+import { strict as nativeAssert } from "node:assert";
 import {
 	type ExecOptionsWithStringEncoding,
 	exec,
 	type SpawnOptionsWithoutStdio,
 	spawn,
-} from "child_process";
-import { inspect } from "util";
+} from "node:child_process";
+import { inspect } from "node:util";
 import * as vscode from "vscode";
 
 export function assert(condition: boolean, explanation: string): asserts condition {
@@ -157,19 +157,49 @@ export function execute(command: string, options: ExecOptionsWithStringEncoding)
 	});
 }
 
-export class LazyOutputChannel implements vscode.OutputChannel {
+export class LazyOutputChannel implements vscode.LogOutputChannel {
 	constructor(name: string) {
 		this.name = name;
 	}
-
 	name: string;
-	_channel: vscode.OutputChannel | undefined;
+	_channel: vscode.LogOutputChannel | undefined;
 
-	get channel(): vscode.OutputChannel {
+	get channel(): vscode.LogOutputChannel {
 		if (!this._channel) {
-			this._channel = vscode.window.createOutputChannel(this.name);
+			this._channel = vscode.window.createOutputChannel(this.name, { log: true });
 		}
 		return this._channel;
+	}
+	get logLevel(): vscode.LogLevel {
+		return this.channel.logLevel;
+	}
+	get onDidChangeLogLevel(): vscode.Event<vscode.LogLevel> {
+		return this.channel.onDidChangeLogLevel;
+	}
+
+	// biome-ignore lint/suspicious/noExplicitAny: Signature comes from upstream
+	trace(message: string, ...args: any[]): void {
+		this.channel.trace(message, ...args);
+	}
+
+	// biome-ignore lint/suspicious/noExplicitAny: Signature comes from upstream
+	debug(message: string, ...args: any[]): void {
+		this.channel.debug(message, ...args);
+	}
+
+	// biome-ignore lint/suspicious/noExplicitAny: Signature comes from upstream
+	info(message: string, ...args: any[]): void {
+		this.channel.info(message, ...args);
+	}
+
+	// biome-ignore lint/suspicious/noExplicitAny: Signature comes from upstream
+	warn(message: string, ...args: any[]): void {
+		this.channel.warn(message, ...args);
+	}
+
+	// biome-ignore lint/suspicious/noExplicitAny: Signature comes from upstream
+	error(error: string | Error, ...args: any[]): void {
+		this.channel.error(error, ...args);
 	}
 
 	append(value: string): void {

--- a/editors/code/tests/runTests.ts
+++ b/editors/code/tests/runTests.ts
@@ -1,9 +1,9 @@
-import { runTests, TestOptions } from "@vscode/test-electron";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { runTests, type TestOptions } from "@vscode/test-electron";
 import { fold } from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
-import * as fs from "fs";
 import * as Decoder from "io-ts/Decoder";
-import * as path from "path";
 
 const PackageJson = Decoder.struct({
 	engines: Decoder.struct({ vscode: Decoder.string }),

--- a/editors/code/tests/unit/index.ts
+++ b/editors/code/tests/unit/index.ts
@@ -1,7 +1,7 @@
 import * as assert from "node:assert/strict";
-import { readdir } from "fs/promises";
-import * as path from "path";
-import { pathToFileURL } from "url";
+import { readdir } from "node:fs/promises";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 
 class Test {
 	readonly name: string;

--- a/editors/code/tests/unit/settings.test.ts
+++ b/editors/code/tests/unit/settings.test.ts
@@ -1,4 +1,5 @@
-import * as assert from "assert";
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: intentional
+import * as assert from "node:assert";
 import { substituteVariablesInEnv } from "../../src/config";
 import type { Context } from ".";
 
@@ -39,6 +40,7 @@ export async function getTests(context: Context) {
 		});
 
 		suite.addSyncTest("Should support external variables", () => {
+			// biome-ignore lint/complexity/useLiteralKeys: conflicting lint
 			process.env["TEST_VARIABLE"] = "test";
 			const envJson = {
 				USING_EXTERNAL_VAR: "${env:TEST_VARIABLE} test ${env:TEST_VARIABLE}",
@@ -49,6 +51,7 @@ export async function getTests(context: Context) {
 
 			const actualEnv = substituteVariablesInEnv(envJson);
 			assert.deepStrictEqual(actualEnv, expectedEnv);
+			// biome-ignore lint/complexity/useLiteralKeys: conflicting lint
 			delete process.env["TEST_VARIABLE"];
 		});
 
@@ -57,6 +60,7 @@ export async function getTests(context: Context) {
 				USING_VSCODE_VAR: "${workspaceFolderBasename}",
 			};
 			const actualEnv = substituteVariablesInEnv(envJson);
+			// biome-ignore lint/complexity/useLiteralKeys: conflicting lint
 			assert.deepStrictEqual(actualEnv["USING_VSCODE_VAR"], "code");
 		});
 	});

--- a/editors/code/tests/unit/tasks.test.ts
+++ b/editors/code/tests/unit/tasks.test.ts
@@ -1,4 +1,4 @@
-import * as assert from "assert";
+import * as assert from "node:assert";
 import * as vscode from "vscode";
 import { targetToExecution } from "../../src/tasks";
 import type { Context } from ".";


### PR DESCRIPTION
# Objective

Support the experimental wesl-rs feature where `@if()` does not crate a scope, aka is "flattened" .

## Solution

Add to the grammar and lower the ast constructs.

## Testing

Added hir-ty tests. hir-def tests including snapshot tests to show scopes is TODO.
Missing coverage is due to no goto definition tests. #1384

## Showcase

<img width="1359" height="818" alt="2026-08-12_14-04" src="https://github.com/user-attachments/assets/83642d07-6888-4782-85b2-8abbea670373" />
