### PR TITLE
Add diagnostic for import statements that are in the wrong order

### DIFF
--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -18,9 +18,17 @@ use crate::{Parse, ParseEntryPoint, SyntaxKind, cst_builder::CstBuilder, lexer::
 // cannot be in a submodule due to visibility of fields
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+enum TranslationUnitState {
+    #[default]
+    Imports,
+    Directives,
+    Declarations,
+}
+
 pub struct ParserContext {
     edition: Edition,
-    after_declarations: bool,
+    translation_unit_state: TranslationUnitState,
     extensions: ExtensionsConfig,
 
     /// The most recently completed `attribute_list`.
@@ -68,7 +76,7 @@ pub fn parse_entrypoint(
         &mut diagnostics,
         ParserContext {
             edition,
-            after_declarations: false,
+            translation_unit_state: TranslationUnitState::default(),
             extensions: ExtensionsConfig::default(),
             last_attribute_list: None,
         },
@@ -434,25 +442,42 @@ impl<'source> ParserCallbacks<'source> for Parser<'source> {
         None
     }
 
-    /// Called when semantic action `#2` in rule `global_item` is visited.
-    fn action_global_item_2(
-        &mut self,
-        diags: &mut Vec<Self::Diagnostic>,
-    ) {
-        self.context.after_declarations = true;
-    }
-
-    /// Called when semantic action `#1` in rule `global_item` is visited.
+    /// Called when an import is visited.
     fn action_global_item_1(
         &mut self,
         diags: &mut Vec<Self::Diagnostic>,
     ) {
-        if self.context.after_declarations {
+        if self.context.translation_unit_state > TranslationUnitState::Imports {
             diags.push(self.create_diagnostic(
                 self.span(),
-                "directives must come before other items".to_owned(),
+                "import statements must come before other items".to_owned(),
             ));
+        } else {
+            self.context.translation_unit_state = TranslationUnitState::Imports;
         }
+    }
+
+    /// Called when a directive is visited.
+    fn action_global_item_2(
+        &mut self,
+        diags: &mut Vec<Self::Diagnostic>,
+    ) {
+        if self.context.translation_unit_state > TranslationUnitState::Directives {
+            diags.push(self.create_diagnostic(
+                self.span(),
+                "directives must come before declarations".to_owned(),
+            ));
+        } else {
+            self.context.translation_unit_state = TranslationUnitState::Directives;
+        }
+    }
+
+    /// Called when a declaration is visited.
+    fn action_global_item_3(
+        &mut self,
+        _diags: &mut Vec<Self::Diagnostic>,
+    ) {
+        self.context.translation_unit_state = TranslationUnitState::Declarations;
     }
 
     // attribute validation

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -2664,7 +2664,7 @@ fn directive_after_declaration() {
                 Semicolon@40..41 ";"
               Blankspace@41..50 "\n        "
 
-            error at 30..36: directives must come before other items"#]],
+            error at 30..36: directives must come before declarations"#]],
     );
 }
 

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -66,7 +66,7 @@ fn check_with_edition(
 }
 
 #[expect(clippy::needless_pass_by_value, reason = "intended API")]
-fn check_type_with_edition_with_edition(
+fn check_type_with_edition(
     edition: Edition,
     input: &str,
     expected_tree: Expect,
@@ -2631,6 +2631,81 @@ fn requires_directive() {
                 LanguageExtensionName@9..39
                   Identifier@9..39 "packed_4x8_integer_do ..."
                 Semicolon@39..40 ";""#]],
+    );
+}
+
+#[test]
+fn directive_after_directive() {
+    check_with_edition(
+        edition::Edition::Wesl2025Unstable,
+        "
+        enable f16;
+        import foo::bar;
+        ",
+        expect![[r#"
+            SourceFile@0..54
+              Blankspace@0..9 "\n        "
+              EnableDirective@9..20
+                Enable@9..15 "enable"
+                Blankspace@15..16 " "
+                EnableExtensionName@16..19
+                  Identifier@16..19 "f16"
+                Semicolon@19..20 ";"
+              Blankspace@20..29 "\n        "
+              ImportStatement@29..45
+                Import@29..35 "import"
+                Blankspace@35..36 " "
+                ImportPath@36..44
+                  Name@36..39
+                    Identifier@36..39 "foo"
+                  ColonColon@39..41 "::"
+                  ImportItem@41..44
+                    Name@41..44
+                      Identifier@41..44 "bar"
+                Semicolon@44..45 ";"
+              Blankspace@45..54 "\n        "
+
+            error at 29..35: import statements must come before other items"#]],
+    );
+}
+
+#[test]
+fn import_after_declaration() {
+    check_with_edition(
+        edition::Edition::Wesl2025Unstable,
+        "
+        const a = 3;
+        import foo::bar;
+        ",
+        expect![[r#"
+            SourceFile@0..55
+              Blankspace@0..9 "\n        "
+              ConstantDeclaration@9..21
+                Const@9..14 "const"
+                Blankspace@14..15 " "
+                Name@15..16
+                  Identifier@15..16 "a"
+                Blankspace@16..17 " "
+                Equal@17..18 "="
+                Blankspace@18..19 " "
+                Literal@19..20
+                  IntLiteral@19..20 "3"
+                Semicolon@20..21 ";"
+              Blankspace@21..30 "\n        "
+              ImportStatement@30..46
+                Import@30..36 "import"
+                Blankspace@36..37 " "
+                ImportPath@37..45
+                  Name@37..40
+                    Identifier@37..40 "foo"
+                  ColonColon@40..42 "::"
+                  ImportItem@42..45
+                    Name@42..45
+                      Identifier@42..45 "bar"
+                Semicolon@45..46 ";"
+              Blankspace@46..55 "\n        "
+
+            error at 30..36: import statements must come before other items"#]],
     );
 }
 

--- a/crates/parser/src/tests/keywords.rs
+++ b/crates/parser/src/tests/keywords.rs
@@ -770,12 +770,12 @@ fn keywords_do_not_parse() {
             error at 148..158: invalid syntax, expected one of: '@', '{', '}', ',', '=', <identifier>, ')', ';', <template start>
             error at 174..181: invalid syntax, expected one of: '@', '{', '}', ',', '=', <identifier>, ')', ';', <template start>
             error at 197..207: invalid syntax, expected one of: '@', '{', '}', ',', '=', <identifier>, ')', ';', <template start>
-            error at 197..207: directives must come before other items
+            error at 197..207: directives must come before declarations
             error at 207..208: invalid syntax, expected: '('
             error at 223..230: invalid syntax, expected one of: '@', '{', '}', ',', '=', <identifier>, ')', ';', <template start>
             error at 246..250: invalid syntax, expected one of: '@', '{', '}', ',', '=', <identifier>, ')', ';', <template start>
             error at 266..272: invalid syntax, expected one of: '@', '{', '}', ',', '=', <identifier>, ')', ';', <template start>
-            error at 266..272: directives must come before other items
+            error at 266..272: directives must come before declarations
             error at 272..273: invalid syntax, expected: <identifier>
             error at 272..272: unknown extension: ``
             error at 288..293: invalid syntax, expected one of: '@', '{', '}', ',', '=', <identifier>, ')', ';', <template start>
@@ -790,7 +790,7 @@ fn keywords_do_not_parse() {
             error at 403..411: invalid syntax, expected one of: '@', '{', '}', ',', '=', <identifier>, ')', ';', <template start>
             error at 411..412: invalid syntax, expected: <identifier>
             error at 427..435: invalid syntax, expected one of: '@', '{', '}', ',', '=', <identifier>, ')', ';', <template start>
-            error at 427..435: directives must come before other items
+            error at 427..435: directives must come before declarations
             error at 435..436: invalid syntax, expected: <identifier>
             error at 435..435: unknown extension: ``
             error at 451..457: invalid syntax, expected one of: '@', '{', '}', ',', '=', <identifier>, ')', ';', <template start>

--- a/crates/parser/src/wesl.llw
+++ b/crates/parser/src/wesl.llw
@@ -147,6 +147,17 @@ part expression;
 part statement;
 part type_specifier;
 
+attribute_list: attribute*;
+
+translation_unit: (global_item | ';')*;
+global_item^:
+	attribute_list (
+	#1 import_statement
+	| #2 global_directive
+	| #3 global_declaration
+	| #3 global_assert
+);
+
 // WESL: Import statements
 import_statement: 'import' [import_package_relative | import_super_relative] (import_collection | import_path) ';';
 import_package_relative: 'package' '::';
@@ -158,15 +169,6 @@ import_path: name (
 
 import_collection: '{' import_path (?1 ',' import_path)* [','] '}';
 
-translation_unit: (attribute_list global_item | ';')*;
-global_item^:
-	#2 import_statement
-	| #1 global_directive
-	| #2 global_declaration
-	| #2 global_assert
-;
-
-global_assert: 'const_assert' expression ';' @assert_statement; // §10
 global_directive:
 	'diagnostic' diagnostic_control ';' @diagnostic_directive // §4.2
 	| 'enable' enable_extension_name (?1 ',' enable_extension_name)* [','] ';' @enable_directive // §4.1.1
@@ -178,6 +180,8 @@ severity_control_name: Identifier;
 diagnostic_rule_name: Identifier ['.' Identifier];
 enable_extension_name: Identifier;
 language_extension_name: Identifier;
+
+global_assert: 'const_assert' expression ';' @assert_statement; // §10
 
 global_declaration:
 	'fn' name function_parameters [return_type] attribute_list !1 compound_statement @function_declaration
@@ -449,5 +453,3 @@ lhs_expression:
 	| '(' lhs_expression ')' @paren_expression // §8.4
 	| path @ident_expression
 ;
-
-attribute_list: attribute*;


### PR DESCRIPTION
# Objective

Fix #1044

## Solution

Pulled out the code from https://github.com/wgsl-analyzer/wgsl-analyzer/pull/1381

## Testing

Unit tests should still pass
