### PR TITLE
fix future clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,16 +223,16 @@ indexing_slicing = "allow"
 # tombi: format.rules.table-keys-order.disabled = true
 [workspace.lints.rust]
 warnings = { level = "warn", priority = -2 }
-deprecated-safe = { level = "deny", priority = -1 }
-future-incompatible = { level = "deny", priority = -1 }
-keyword-idents = { level = "deny", priority = -1 }
-let-underscore = { level = "deny", priority = -1 }
-nonstandard-style = { level = "deny", priority = -1 }
-refining-impl-trait = { level = "deny", priority = -1 }
-rust-2018-compatibility = { level = "deny", priority = -1 }
-rust-2018-idioms = { level = "deny", priority = -1 }
-rust-2021-compatibility = { level = "deny", priority = -1 }
-rust-2024-compatibility = { level = "deny", priority = -1 }
+deprecated_safe = { level = "deny", priority = -1 }
+future_incompatible = { level = "deny", priority = -1 }
+keyword_idents = { level = "deny", priority = -1 }
+let_underscore = { level = "deny", priority = -1 }
+nonstandard_style = { level = "deny", priority = -1 }
+refining_impl_trait = { level = "deny", priority = -1 }
+rust_2018_compatibility = { level = "deny", priority = -1 }
+rust_2018_idioms = { level = "deny", priority = -1 }
+rust_2021_compatibility = { level = "deny", priority = -1 }
+rust_2024_compatibility = { level = "deny", priority = -1 }
 unused = { level = "allow", priority = 1 }
 
 [workspace.lints.rustdoc]

--- a/crates/hir_ty/build.rs
+++ b/crates/hir_ty/build.rs
@@ -178,11 +178,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         if line.is_empty() || line.starts_with("//") {
             continue;
         }
-        if seen.contains(line) {
-            panic!("duplicate builtint: {line}");
-        } else {
-            seen.insert(line);
-        }
+        let has_line = seen.insert(line);
+        assert!(has_line, "duplicate builtin: {line}");
+
         let (name, overload) = parse_line(line);
         let builtin = builtins.entry(name.to_owned()).or_default();
         builtin.overloads.push(overload);

--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -171,30 +171,28 @@ fn ensure_file_contents(
     }
 
     let display_path = file.strip_prefix(project_root()).unwrap_or(file);
-    if check {
-        panic!(
-            "{} was not up-to-date{}",
-            file.display(),
-            if std::env::var("CI").is_ok() {
-                format!(
-                    "\n    NOTE: run `cargo xtask codegen {cg}` locally and commit the updated files\n"
-                )
-            } else {
-                String::new()
-            }
-        );
-    } else {
-        eprintln!(
-            "\n\x1b[31;1merror\x1b[0m: {} was not up-to-date, updating\n",
-            display_path.display()
-        );
-
-        if let Some(parent) = file.parent() {
-            fs::create_dir_all(parent).unwrap();
+    assert!(
+        !check,
+        "{} was not up-to-date{}",
+        file.display(),
+        if std::env::var("CI").is_ok() {
+            format!(
+                "\n    NOTE: run `cargo xtask codegen {cg}` locally and commit the updated files\n"
+            )
+        } else {
+            String::new()
         }
-        fs::write(file, contents).unwrap();
-        true
+    );
+    eprintln!(
+        "\n\x1b[31;1merror\x1b[0m: {} was not up-to-date, updating\n",
+        display_path.display()
+    );
+
+    if let Some(parent) = file.parent() {
+        fs::create_dir_all(parent).unwrap();
     }
+    fs::write(file, contents).unwrap();
+    true
 }
 
 fn normalize_newlines(string: &str) -> String {


### PR DESCRIPTION
# Objective

I'm running the nightly Rust toolchain locally and noticed that Clippy is going to warn about a few more things. This fixes that.

## Solution

Do what clippy wants.

## Testing

Unit tests still pass