### PR TITLE
Update formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -225,7 +225,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Tombi
-        uses: tombi-toml/setup-tombi@f2ae7247d62521245eb2793d653b9df472b9e090 # v1.2.4
+        uses: tombi-toml/setup-tombi@23af0f0e4fcad609f048a37fb312714cd6b07741 # v1.4.0
 
       - name: Lint TOML files
         run: tombi lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,16 +37,8 @@ wgsl-formatter = { path = "./crates/wgsl_formatter", version = "0.0.0" }
 edition = { path = "./crates/edition", version = "0.0.0" }
 #
 # rust-analyzer crates
-stdx = {
-	git = "https://github.com/rust-lang/rust-analyzer",
-	rev = "b42b63f390a4dab14e6efa34a70e67f5b087cc62",
-	version = "0.0.0"
-}
-paths = {
-	git = "https://github.com/rust-lang/rust-analyzer",
-	rev = "b42b63f390a4dab14e6efa34a70e67f5b087cc62",
-	version = "0.0.0"
-}
+stdx = { git = "https://github.com/rust-lang/rust-analyzer", rev = "b42b63f390a4dab14e6efa34a70e67f5b087cc62", version = "0.0.0" }
+paths = { git = "https://github.com/rust-lang/rust-analyzer", rev = "b42b63f390a4dab14e6efa34a70e67f5b087cc62", version = "0.0.0" }
 #
 # crates from rust-analyzer that are published separately
 line-index = "0.1.2"
@@ -74,42 +66,16 @@ rowan = "0.16.1"
 rustc-hash = "2.1.2"
 # Ideally we'd not enable the macros feature but unfortunately the `tracked` attribute does not work
 # on impls without it
-salsa = {
-	version = "0.28.2",
-	default-features = false,
-	features = ["inventory", "macros", "rayon", "salsa_unstable", "triomphe"]
-}
+salsa = { version = "0.28.2", default-features = false, features = ["inventory", "macros", "rayon", "salsa_unstable", "triomphe"] }
 salsa-macros = "0.28.2"
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
-smallvec = {
-	version = "1.15.1",
-	features = [
-		"const_generics",
-		"const_new",
-		"union",
-	]
-}
+smallvec = { version = "1.15.1", features = ["const_generics", "const_new", "union"] }
 smol_str = { version = "0.3.5", default-features = false }
 text-size = "1.1.1"
-tracing = {
-	version = "0.1.44",
-	default-features = false,
-	features = ["attributes", "std"]
-}
-tracing-subscriber = {
-	version = "0.3.23",
-	default-features = false,
-	features = [
-		"fmt",
-		"local-time",
-		"registry",
-		"std",
-		"time",
-		"tracing-log",
-	]
-}
+tracing = { version = "0.1.44", default-features = false, features = ["attributes", "std"] }
+tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt", "local-time", "registry", "std", "time", "tracing-log"] }
 tracing-tree = "0.4.0"
 triomphe = { version = "0.1.15", default-features = false, features = ["std"] }
 wgsl-types = { version = "0.4.2", features = ["naga-ext"] }

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,7 +1,7 @@
-toml-version = "v1.0.0"  # config file for tombi, the toml formatter. https://tombi-toml.github.io/tombi/
+# Config file for tombi, the toml formatter.
+# https://tombi-toml.github.io/tombi/
+toml-version = "v1.0.0"
 
 [format]
 [format.rules]
 indent-style = "tab"
-indent-sub-tables = false
-indent-table-key-value-pairs = false


### PR DESCRIPTION
Remove some default config and run the formatter. The diff is caused by tombi's strange choice to have formatting be based on magic hints instead of configuration.

This also makes wgsl-analyzer work with nix again because nix parses Cargo.toml with an out-of-date standard.