### PR TITLE
Fix some cyclic inference cases

### DIFF
--- a/crates/hir_def/src/signature.rs
+++ b/crates/hir_def/src/signature.rs
@@ -53,7 +53,6 @@ impl FunctionSignature {
     }
 
     #[salsa::tracked(returns(ref))]
-
     pub fn with_source_map(
         db: &dyn SourceDatabase,
         id: FunctionId,

--- a/crates/hir_ty/src/db.rs
+++ b/crates/hir_ty/src/db.rs
@@ -2,7 +2,7 @@
 //! type inference-related queries.
 
 use base_db::{EditionedFileId, Intern as _, Lookup as _, SourceDatabase};
-use hir_def::db::Location;
+use hir_def::db::{Location, ModuleDefinitionId};
 use hir_def::signature::{StructSignature, TypeAliasSignature};
 use hir_def::{
     db::{DefinitionWithBodyId, FunctionId, StructId, TypeAliasId},
@@ -15,6 +15,7 @@ use la_arena::ArenaMap;
 use triomphe::Arc;
 use wgsl_types::syntax::AddressSpace;
 
+use crate::infer::get_name_and_range;
 use crate::{
     diagnostics::{InferenceDiagnostic, InferenceDiagnosticKind},
     function::{FunctionDetails, ResolvedFunctionId},
@@ -107,7 +108,7 @@ fn field_types(
     Arc::new((map, diagnostics))
 }
 
-#[salsa::tracked(returns(clone))]
+#[salsa::tracked(returns(clone), cycle_result = type_alias_type_cycle_result)]
 fn type_alias_type(
     db: &dyn HirDatabase,
     type_alias: TypeAliasId,
@@ -199,4 +200,18 @@ fn struct_is_used_in_uniform(
             | hir_def::item_tree::ModuleItemId::TypeAlias(_)
             | hir_def::item_tree::ModuleItemId::ImportStatement(_) => false,
         })
+}
+
+fn type_alias_type_cycle_result(
+    db: &dyn HirDatabase,
+    _: salsa::Id,
+    type_alias: TypeAliasId,
+) -> Arc<(Type, Vec<InferenceDiagnostic>)> {
+    let data = TypeAliasSignature::of(db, type_alias);
+    let (name, range) = get_name_and_range(db, ModuleDefinitionId::TypeAlias(type_alias));
+    let error = InferenceDiagnostic {
+        source: data.store.store_source,
+        kind: InferenceDiagnosticKind::CyclicType { name, range },
+    };
+    Arc::new((TypeKind::Error.intern(db), vec![error]))
 }

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -118,7 +118,7 @@ fn infer_cycle_result(
     inference_result
 }
 
-fn get_name_and_range(
+pub fn get_name_and_range(
     db: &dyn HirDatabase,
     definition: ModuleDefinitionId,
 ) -> (Name, base_db::TextRange) {

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -2125,3 +2125,34 @@ fn foo() {
         "#]],
     );
 }
+
+// TODO https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1389
+#[test]
+fn function_cycle() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+fn foo() {
+    foo();
+}
+        ",
+        expect![[r#"
+            15..20 'foo()': [error]
+        "#]],
+    );
+}
+
+#[test]
+fn alias_cycle() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+alias Foo = Bar;
+alias Bar = Foo;
+        ",
+        expect![[r#"
+            [EditionedFileId(Id(300))] CyclicType { name: Name("Foo"), range: 0..16 } in Signature
+            [EditionedFileId(Id(300))] CyclicType { name: Name("Bar"), range: 17..33 } in Signature
+        "#]],
+    );
+}

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -2052,3 +2052,76 @@ fn override_declaration() {
         "#]],
     );
 }
+
+#[test]
+fn function_call_argument_type_mismatch() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+fn foo(x: i32, y: u32) {
+    foo(y, x);
+}
+        ",
+        expect![[r#"
+            7..8 'x': i32
+            15..16 'y': u32
+            29..38 'foo(y, x)': [error]
+            33..34 'y': u32
+            36..37 'x': i32
+            33..34 'y': expected i32 but got u32
+            36..37 'x': expected u32 but got i32
+        "#]],
+    );
+}
+
+#[test]
+fn ident_override_inference() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+override bar: u32;
+fn foo() {
+    let x = bar;
+}
+        ",
+        expect![[r#"
+            9..12 'bar': u32
+            38..39 'x': u32
+            42..45 'bar': u32
+        "#]],
+    );
+}
+
+#[test]
+fn var_cycle() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+var x = y;
+var y = x;
+        ",
+        expect![[r#"
+            [EditionedFileId(Id(300))] CyclicType { name: Name("x"), range: 0..10 } in Body
+            [EditionedFileId(Id(300))] CyclicType { name: Name("y"), range: 11..21 } in Body
+        "#]],
+    );
+}
+
+#[test]
+fn struct_cycle() {
+    check_infer(
+        ExtensionsConfig::default(),
+        "
+struct Foo { foo: Bar }
+struct Bar { foo: Foo }
+fn foo() {
+    let x = Foo();
+}
+        ",
+        expect![[r#"
+            67..68 'x': Foo
+            71..76 'Foo()': Foo
+            71..76 'Foo()': type `Foo` is not constructible
+        "#]],
+    );
+}

--- a/crates/hir_ty/src/ty.rs
+++ b/crates/hir_ty/src/ty.rs
@@ -110,11 +110,21 @@ impl Type {
         }
     }
 
-    #[expect(clippy::doc_paragraphs_missing_punctuation, reason = "false positive")]
+    pub fn contains_struct(
+        self,
+        db: &dyn HirDatabase,
+        r#struct: StructId,
+    ) -> bool {
+        self.kind(db).contains_struct(db, r#struct)
+    }
+}
+
+#[salsa::tracked]
+impl Type {
     /// Apply the load rule.
     ///
     /// Reference: <https://www.w3.org/TR/WGSL/#load-rule>
-    #[must_use]
+    #[salsa::tracked(cycle_result = |_, _, _| false)]
     pub fn is_constructible(
         self,
         db: &dyn HirDatabase,
@@ -127,11 +137,11 @@ impl Type {
                 .field_types(struct_id)
                 .0
                 .iter()
-                .all(|(_, field_type)| field_type.is_constructible(db)),
+                .all(|(_, field_type)| *field_type.is_constructible(db)),
             TypeKind::BuiltinStruct(builtin_struct) => builtin_struct
                 .fields
                 .iter()
-                .all(|(_, field_type)| field_type.is_constructible(db)),
+                .all(|(_, field_type)| *field_type.is_constructible(db)),
             TypeKind::Array(array_type) => array_type.is_constructible(db),
             TypeKind::Atomic(_)
             | TypeKind::Texture(_)
@@ -141,14 +151,6 @@ impl Type {
             | TypeKind::StorageTypeOfTexelFormat(_)
             | TypeKind::BoundVariable(_) => false,
         }
-    }
-
-    pub fn contains_struct(
-        self,
-        db: &dyn HirDatabase,
-        r#struct: StructId,
-    ) -> bool {
-        self.kind(db).contains_struct(db, r#struct)
     }
 }
 
@@ -740,7 +742,7 @@ impl ArrayType {
         &self,
         db: &dyn HirDatabase,
     ) -> bool {
-        self.size != ArraySize::Dynamic && self.inner.is_constructible(db)
+        self.size != ArraySize::Dynamic && *self.inner.is_constructible(db)
     }
 }
 


### PR DESCRIPTION
# Objective

Inference should succeed and emit a diagnostic if the user created cyclic definitions. This is in-line with the WGSL spec.

> It is a [shader-creation error](https://www.w3.org/TR/WGSL/#shader-creation-error) if any [module scope](https://www.w3.org/TR/WGSL/#module-scope) declaration is recursive. That is, no cycles can exist among the declarations:

## Solution

Add checks and use salsa to detect cycles.

## Testing

Added tests.
