### PR TITLE
update wgsl-types to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "wgsl-types"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8286b1a2ce08736a048da13f6fcdd427c7baf7e3c48e0b5a0c51f954675b2f73"
+checksum = "34db71d08dfbeda7eb4c3370c3dc37d901d2defd3a1b0ebd4d0de8ad811f5eea"
 dependencies = [
  "half",
  "itertools 0.15.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ tracing = { version = "0.1.44", default-features = false, features = ["attribute
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt", "local-time", "registry", "std", "time", "tracing-log"] }
 tracing-tree = "0.4.0"
 triomphe = { version = "0.1.15", default-features = false, features = ["std"] }
-wgsl-types = { version = "0.4.2", features = ["naga-ext"] }
+wgsl-types = { version = "0.4.3", features = ["naga-ext"] }
 indexmap = { version = "2.14.0" }
 
 # idna_adapter does not use semantic versioning


### PR DESCRIPTION
fixes incorrect builtins