### PR TITLE
replace minor-patch with not-breaking

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,5 @@
 {
 	extends: [
-		"group:allNonMajor",
 		"group:monorepos",
 		"helpers:disableTypesNodeMajor",
 		"helpers:githubDigestChangelogs",
@@ -16,6 +15,19 @@
 	],
 	minimumReleaseAge: "7 days",
 	packageRules: [
+		{
+			"description": "Group not-breaking updates",
+			"matchUpdateTypes": ["minor", "patch", "digest"],
+			"matchJsonata": ["isBreaking != true"],
+			"groupName": "All not-breaking updates"
+		},
+		{
+			"description": "Cargo not-breaking 0.x patches",
+			"matchManagers": ["cargo"],
+			"matchUpdateTypes": ["patch"],
+			"matchCurrentVersion": ">=0.1.0 <1.0.0",
+			"groupName": "All not-breaking updates"
+		},
 		{
 			description: "Rust dependencies",
 			matchManagers: ["cargo"],


### PR DESCRIPTION
Versions are considered compatible if their left-most non-zero major/minor/patch component is the same. This is different from [SemVer](https://semver.org/) which considers all pre-1.0.0 packages to be incompatible.