### PR TITLE
`#[derive(Default)]` on `ParserContext`

### DIFF
--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -26,6 +26,7 @@ enum TranslationUnitState {
     Declarations,
 }
 
+#[derive(Default)]
 pub struct ParserContext {
     edition: Edition,
     translation_unit_state: TranslationUnitState,


### PR DESCRIPTION
Hi there! This project surfaced while assessing what potential breakage PR https://github.com/rust-lang/rust/pull/159118 would cause to the Rust ecosystem. The PR fixes a bug in the compiler where some unsatisfiable `where`-clauses would be allowed to compile without error.

Unfortunately, after this fix, this project will no longer compile, since the code generated by lelwel contains a `Default` bound that `ParserContext` doesn't satisfy. To allow the code to continue to compile, this PR just adds a `#[derive(Default)]` on `ParserContext`, since all of its fields are already `Default`. lelwel itself also has an open PR addressing the `Default` bound in question: https://github.com/0x2a-42/lelwel/pull/70

For reference, the full list of build failures caused by the rustc PR can be found here: https://crater-reports.s3.amazonaws.com/pr-159118/index.html