### PR TITLE
fix swapped builtin classes

### DIFF
--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -221,7 +221,7 @@ impl<'db> Resolver<'db> {
                 for name in wgsl_types::idents::BUILTIN_TYPE_GENERATOR_NAMES {
                     callback(
                         &(*name).into(),
-                        ScopeDef::BuiltIn(BuiltInKind::Type((*name).into())),
+                        ScopeDef::BuiltIn(BuiltInKind::TypeGenerator((*name).into())),
                     );
                 }
                 for name in wgsl_types::idents::BUILTIN_TYPE_NAMES
@@ -230,7 +230,7 @@ impl<'db> Resolver<'db> {
                 {
                     callback(
                         &(*name).into(),
-                        ScopeDef::BuiltIn(BuiltInKind::TypeGenerator((*name).into())),
+                        ScopeDef::BuiltIn(BuiltInKind::Type((*name).into())),
                     );
                 }
             },

--- a/crates/ide_completion/src/tests.rs
+++ b/crates/ide_completion/src/tests.rs
@@ -300,20 +300,20 @@ fn no_completions_in_comments() {
             builtin constructor RayDesc
             builtin constructor RayIntersection
             builtin function abs
-            builtin type generator acceleration_structure
+            builtin type acceleration_structure
             builtin function acos
             builtin function acosh
             builtin function all
             builtin function any
             builtin constructor array
-            builtin type array
+            builtin type generator array
             builtin function arrayLength
             builtin function asin
             builtin function asinh
             builtin function atan
             builtin function atan2
             builtin function atanh
-            builtin type atomic
+            builtin type generator atomic
             builtin function atomicAdd
             builtin function atomicAnd
             builtin function atomicCompareExchangeWeak
@@ -326,10 +326,10 @@ fn no_completions_in_comments() {
             builtin function atomicSub
             builtin function atomicXor
             builtin enumerant bgra8unorm
-            builtin type binding_array
+            builtin type generator binding_array
             builtin function bitcast
             builtin constructor bool
-            builtin type generator bool
+            builtin type bool
             builtin function ceil
             builtin function clamp
             builtin function cos
@@ -354,11 +354,11 @@ fn no_completions_in_comments() {
             builtin function exp2
             builtin function extractBits
             builtin constructor f16
-            builtin type generator f16
+            builtin type f16
             builtin constructor f32
-            builtin type generator f32
+            builtin type f32
             builtin constructor f64
-            builtin type generator f64
+            builtin type f64
             builtin function faceForward
             builtin function firstLeadingBit
             builtin function firstTrailingBit
@@ -373,9 +373,9 @@ fn no_completions_in_comments() {
             builtin function getCandidateHitVertexPositions
             builtin function getCommittedHitVertexPositions
             builtin constructor i32
-            builtin type generator i32
+            builtin type i32
             builtin constructor i64
-            builtin type generator i64
+            builtin type i64
             builtin enumerant immediate
             builtin function insertBits
             builtin function inverseSqrt
@@ -384,55 +384,55 @@ fn no_completions_in_comments() {
             builtin function log
             builtin function log2
             builtin constructor mat2x2
-            builtin type mat2x2
+            builtin type generator mat2x2
             builtin alias mat2x2f
             builtin constructor mat2x2f
             builtin alias mat2x2h
             builtin constructor mat2x2h
             builtin constructor mat2x3
-            builtin type mat2x3
+            builtin type generator mat2x3
             builtin alias mat2x3f
             builtin constructor mat2x3f
             builtin alias mat2x3h
             builtin constructor mat2x3h
             builtin constructor mat2x4
-            builtin type mat2x4
+            builtin type generator mat2x4
             builtin alias mat2x4f
             builtin constructor mat2x4f
             builtin alias mat2x4h
             builtin constructor mat2x4h
             builtin constructor mat3x2
-            builtin type mat3x2
+            builtin type generator mat3x2
             builtin alias mat3x2f
             builtin constructor mat3x2f
             builtin alias mat3x2h
             builtin constructor mat3x2h
             builtin constructor mat3x3
-            builtin type mat3x3
+            builtin type generator mat3x3
             builtin alias mat3x3f
             builtin constructor mat3x3f
             builtin alias mat3x3h
             builtin constructor mat3x3h
             builtin constructor mat3x4
-            builtin type mat3x4
+            builtin type generator mat3x4
             builtin alias mat3x4f
             builtin constructor mat3x4f
             builtin alias mat3x4h
             builtin constructor mat3x4h
             builtin constructor mat4x2
-            builtin type mat4x2
+            builtin type generator mat4x2
             builtin alias mat4x2f
             builtin constructor mat4x2f
             builtin alias mat4x2h
             builtin constructor mat4x2h
             builtin constructor mat4x3
-            builtin type mat4x3
+            builtin type generator mat4x3
             builtin alias mat4x3f
             builtin constructor mat4x3f
             builtin alias mat4x3h
             builtin constructor mat4x3h
             builtin constructor mat4x4
-            builtin type mat4x4
+            builtin type generator mat4x4
             builtin alias mat4x4f
             builtin constructor mat4x4f
             builtin alias mat4x4h
@@ -453,7 +453,7 @@ fn no_completions_in_comments() {
             builtin function pack4xU8Clamp
             builtin function pow
             builtin enumerant private
-            builtin type ptr
+            builtin type generator ptr
             builtin function quadBroadcast
             builtin function quadSwapDiagonal
             builtin function quadSwapX
@@ -480,7 +480,7 @@ fn no_completions_in_comments() {
             builtin function rayQueryInitialize
             builtin function rayQueryProceed
             builtin function rayQueryTerminate
-            builtin type generator ray_query
+            builtin type ray_query
             builtin enumerant read
             builtin enumerant read_write
             builtin function reflect
@@ -514,8 +514,8 @@ fn no_completions_in_comments() {
             builtin enumerant rgba8uint
             builtin enumerant rgba8unorm
             builtin function round
-            builtin type generator sampler
-            builtin type generator sampler_comparison
+            builtin type sampler
+            builtin type sampler_comparison
             builtin function saturate
             builtin function select
             builtin function sign
@@ -567,32 +567,32 @@ fn no_completions_in_comments() {
             builtin function textureSampleGrad
             builtin function textureSampleLevel
             builtin function textureStore
-            builtin type texture_1d
-            builtin type texture_1d_array
-            builtin type texture_2d
-            builtin type texture_2d_array
-            builtin type texture_3d
-            builtin type texture_cube
-            builtin type texture_cube_array
-            builtin type generator texture_depth_2d
-            builtin type generator texture_depth_2d_array
-            builtin type generator texture_depth_cube
-            builtin type generator texture_depth_cube_array
-            builtin type generator texture_depth_multisampled_2d
-            builtin type generator texture_external
-            builtin type texture_multisampled_2d
-            builtin type texture_multisampled_2d_array
-            builtin type texture_storage_1d
-            builtin type texture_storage_1d_array
-            builtin type texture_storage_2d
-            builtin type texture_storage_2d_array
-            builtin type texture_storage_3d
+            builtin type generator texture_1d
+            builtin type generator texture_1d_array
+            builtin type generator texture_2d
+            builtin type generator texture_2d_array
+            builtin type generator texture_3d
+            builtin type generator texture_cube
+            builtin type generator texture_cube_array
+            builtin type texture_depth_2d
+            builtin type texture_depth_2d_array
+            builtin type texture_depth_cube
+            builtin type texture_depth_cube_array
+            builtin type texture_depth_multisampled_2d
+            builtin type texture_external
+            builtin type generator texture_multisampled_2d
+            builtin type generator texture_multisampled_2d_array
+            builtin type generator texture_storage_1d
+            builtin type generator texture_storage_1d_array
+            builtin type generator texture_storage_2d
+            builtin type generator texture_storage_2d_array
+            builtin type generator texture_storage_3d
             builtin function transpose
             builtin function trunc
             builtin constructor u32
-            builtin type generator u32
+            builtin type u32
             builtin constructor u64
-            builtin type generator u64
+            builtin type u64
             builtin enumerant uniform
             builtin function unpack2x16float
             builtin function unpack2x16snorm
@@ -602,7 +602,7 @@ fn no_completions_in_comments() {
             builtin function unpack4xI8
             builtin function unpack4xU8
             builtin constructor vec2
-            builtin type vec2
+            builtin type generator vec2
             builtin alias vec2f
             builtin constructor vec2f
             builtin alias vec2h
@@ -612,7 +612,7 @@ fn no_completions_in_comments() {
             builtin alias vec2u
             builtin constructor vec2u
             builtin constructor vec3
-            builtin type vec3
+            builtin type generator vec3
             builtin alias vec3f
             builtin constructor vec3f
             builtin alias vec3h
@@ -622,7 +622,7 @@ fn no_completions_in_comments() {
             builtin alias vec3u
             builtin constructor vec3u
             builtin constructor vec4
-            builtin type vec4
+            builtin type generator vec4
             builtin alias vec4f
             builtin constructor vec4f
             builtin alias vec4h
@@ -665,20 +665,20 @@ fn no_completions_in_comments() {
             builtin constructor RayDesc
             builtin constructor RayIntersection
             builtin function abs
-            builtin type generator acceleration_structure
+            builtin type acceleration_structure
             builtin function acos
             builtin function acosh
             builtin function all
             builtin function any
             builtin constructor array
-            builtin type array
+            builtin type generator array
             builtin function arrayLength
             builtin function asin
             builtin function asinh
             builtin function atan
             builtin function atan2
             builtin function atanh
-            builtin type atomic
+            builtin type generator atomic
             builtin function atomicAdd
             builtin function atomicAnd
             builtin function atomicCompareExchangeWeak
@@ -691,10 +691,10 @@ fn no_completions_in_comments() {
             builtin function atomicSub
             builtin function atomicXor
             builtin enumerant bgra8unorm
-            builtin type binding_array
+            builtin type generator binding_array
             builtin function bitcast
             builtin constructor bool
-            builtin type generator bool
+            builtin type bool
             builtin function ceil
             builtin function clamp
             builtin function cos
@@ -719,11 +719,11 @@ fn no_completions_in_comments() {
             builtin function exp2
             builtin function extractBits
             builtin constructor f16
-            builtin type generator f16
+            builtin type f16
             builtin constructor f32
-            builtin type generator f32
+            builtin type f32
             builtin constructor f64
-            builtin type generator f64
+            builtin type f64
             builtin function faceForward
             builtin function firstLeadingBit
             builtin function firstTrailingBit
@@ -738,9 +738,9 @@ fn no_completions_in_comments() {
             builtin function getCandidateHitVertexPositions
             builtin function getCommittedHitVertexPositions
             builtin constructor i32
-            builtin type generator i32
+            builtin type i32
             builtin constructor i64
-            builtin type generator i64
+            builtin type i64
             builtin enumerant immediate
             builtin function insertBits
             builtin function inverseSqrt
@@ -749,55 +749,55 @@ fn no_completions_in_comments() {
             builtin function log
             builtin function log2
             builtin constructor mat2x2
-            builtin type mat2x2
+            builtin type generator mat2x2
             builtin alias mat2x2f
             builtin constructor mat2x2f
             builtin alias mat2x2h
             builtin constructor mat2x2h
             builtin constructor mat2x3
-            builtin type mat2x3
+            builtin type generator mat2x3
             builtin alias mat2x3f
             builtin constructor mat2x3f
             builtin alias mat2x3h
             builtin constructor mat2x3h
             builtin constructor mat2x4
-            builtin type mat2x4
+            builtin type generator mat2x4
             builtin alias mat2x4f
             builtin constructor mat2x4f
             builtin alias mat2x4h
             builtin constructor mat2x4h
             builtin constructor mat3x2
-            builtin type mat3x2
+            builtin type generator mat3x2
             builtin alias mat3x2f
             builtin constructor mat3x2f
             builtin alias mat3x2h
             builtin constructor mat3x2h
             builtin constructor mat3x3
-            builtin type mat3x3
+            builtin type generator mat3x3
             builtin alias mat3x3f
             builtin constructor mat3x3f
             builtin alias mat3x3h
             builtin constructor mat3x3h
             builtin constructor mat3x4
-            builtin type mat3x4
+            builtin type generator mat3x4
             builtin alias mat3x4f
             builtin constructor mat3x4f
             builtin alias mat3x4h
             builtin constructor mat3x4h
             builtin constructor mat4x2
-            builtin type mat4x2
+            builtin type generator mat4x2
             builtin alias mat4x2f
             builtin constructor mat4x2f
             builtin alias mat4x2h
             builtin constructor mat4x2h
             builtin constructor mat4x3
-            builtin type mat4x3
+            builtin type generator mat4x3
             builtin alias mat4x3f
             builtin constructor mat4x3f
             builtin alias mat4x3h
             builtin constructor mat4x3h
             builtin constructor mat4x4
-            builtin type mat4x4
+            builtin type generator mat4x4
             builtin alias mat4x4f
             builtin constructor mat4x4f
             builtin alias mat4x4h
@@ -818,7 +818,7 @@ fn no_completions_in_comments() {
             builtin function pack4xU8Clamp
             builtin function pow
             builtin enumerant private
-            builtin type ptr
+            builtin type generator ptr
             builtin function quadBroadcast
             builtin function quadSwapDiagonal
             builtin function quadSwapX
@@ -845,7 +845,7 @@ fn no_completions_in_comments() {
             builtin function rayQueryInitialize
             builtin function rayQueryProceed
             builtin function rayQueryTerminate
-            builtin type generator ray_query
+            builtin type ray_query
             builtin enumerant read
             builtin enumerant read_write
             builtin function reflect
@@ -879,8 +879,8 @@ fn no_completions_in_comments() {
             builtin enumerant rgba8uint
             builtin enumerant rgba8unorm
             builtin function round
-            builtin type generator sampler
-            builtin type generator sampler_comparison
+            builtin type sampler
+            builtin type sampler_comparison
             builtin function saturate
             builtin function select
             builtin function sign
@@ -932,32 +932,32 @@ fn no_completions_in_comments() {
             builtin function textureSampleGrad
             builtin function textureSampleLevel
             builtin function textureStore
-            builtin type texture_1d
-            builtin type texture_1d_array
-            builtin type texture_2d
-            builtin type texture_2d_array
-            builtin type texture_3d
-            builtin type texture_cube
-            builtin type texture_cube_array
-            builtin type generator texture_depth_2d
-            builtin type generator texture_depth_2d_array
-            builtin type generator texture_depth_cube
-            builtin type generator texture_depth_cube_array
-            builtin type generator texture_depth_multisampled_2d
-            builtin type generator texture_external
-            builtin type texture_multisampled_2d
-            builtin type texture_multisampled_2d_array
-            builtin type texture_storage_1d
-            builtin type texture_storage_1d_array
-            builtin type texture_storage_2d
-            builtin type texture_storage_2d_array
-            builtin type texture_storage_3d
+            builtin type generator texture_1d
+            builtin type generator texture_1d_array
+            builtin type generator texture_2d
+            builtin type generator texture_2d_array
+            builtin type generator texture_3d
+            builtin type generator texture_cube
+            builtin type generator texture_cube_array
+            builtin type texture_depth_2d
+            builtin type texture_depth_2d_array
+            builtin type texture_depth_cube
+            builtin type texture_depth_cube_array
+            builtin type texture_depth_multisampled_2d
+            builtin type texture_external
+            builtin type generator texture_multisampled_2d
+            builtin type generator texture_multisampled_2d_array
+            builtin type generator texture_storage_1d
+            builtin type generator texture_storage_1d_array
+            builtin type generator texture_storage_2d
+            builtin type generator texture_storage_2d_array
+            builtin type generator texture_storage_3d
             builtin function transpose
             builtin function trunc
             builtin constructor u32
-            builtin type generator u32
+            builtin type u32
             builtin constructor u64
-            builtin type generator u64
+            builtin type u64
             builtin enumerant uniform
             builtin function unpack2x16float
             builtin function unpack2x16snorm
@@ -967,7 +967,7 @@ fn no_completions_in_comments() {
             builtin function unpack4xI8
             builtin function unpack4xU8
             builtin constructor vec2
-            builtin type vec2
+            builtin type generator vec2
             builtin alias vec2f
             builtin constructor vec2f
             builtin alias vec2h
@@ -977,7 +977,7 @@ fn no_completions_in_comments() {
             builtin alias vec2u
             builtin constructor vec2u
             builtin constructor vec3
-            builtin type vec3
+            builtin type generator vec3
             builtin alias vec3f
             builtin constructor vec3f
             builtin alias vec3h
@@ -987,7 +987,7 @@ fn no_completions_in_comments() {
             builtin alias vec3u
             builtin constructor vec3u
             builtin constructor vec4
-            builtin type vec4
+            builtin type generator vec4
             builtin alias vec4f
             builtin constructor vec4f
             builtin alias vec4h
@@ -1029,20 +1029,20 @@ fn no_completions_in_comments() {
             builtin constructor RayDesc
             builtin constructor RayIntersection
             builtin function abs
-            builtin type generator acceleration_structure
+            builtin type acceleration_structure
             builtin function acos
             builtin function acosh
             builtin function all
             builtin function any
             builtin constructor array
-            builtin type array
+            builtin type generator array
             builtin function arrayLength
             builtin function asin
             builtin function asinh
             builtin function atan
             builtin function atan2
             builtin function atanh
-            builtin type atomic
+            builtin type generator atomic
             builtin function atomicAdd
             builtin function atomicAnd
             builtin function atomicCompareExchangeWeak
@@ -1055,10 +1055,10 @@ fn no_completions_in_comments() {
             builtin function atomicSub
             builtin function atomicXor
             builtin enumerant bgra8unorm
-            builtin type binding_array
+            builtin type generator binding_array
             builtin function bitcast
             builtin constructor bool
-            builtin type generator bool
+            builtin type bool
             builtin function ceil
             builtin function clamp
             builtin function cos
@@ -1083,11 +1083,11 @@ fn no_completions_in_comments() {
             builtin function exp2
             builtin function extractBits
             builtin constructor f16
-            builtin type generator f16
+            builtin type f16
             builtin constructor f32
-            builtin type generator f32
+            builtin type f32
             builtin constructor f64
-            builtin type generator f64
+            builtin type f64
             builtin function faceForward
             builtin function firstLeadingBit
             builtin function firstTrailingBit
@@ -1102,9 +1102,9 @@ fn no_completions_in_comments() {
             builtin function getCandidateHitVertexPositions
             builtin function getCommittedHitVertexPositions
             builtin constructor i32
-            builtin type generator i32
+            builtin type i32
             builtin constructor i64
-            builtin type generator i64
+            builtin type i64
             builtin enumerant immediate
             builtin function insertBits
             builtin function inverseSqrt
@@ -1113,55 +1113,55 @@ fn no_completions_in_comments() {
             builtin function log
             builtin function log2
             builtin constructor mat2x2
-            builtin type mat2x2
+            builtin type generator mat2x2
             builtin alias mat2x2f
             builtin constructor mat2x2f
             builtin alias mat2x2h
             builtin constructor mat2x2h
             builtin constructor mat2x3
-            builtin type mat2x3
+            builtin type generator mat2x3
             builtin alias mat2x3f
             builtin constructor mat2x3f
             builtin alias mat2x3h
             builtin constructor mat2x3h
             builtin constructor mat2x4
-            builtin type mat2x4
+            builtin type generator mat2x4
             builtin alias mat2x4f
             builtin constructor mat2x4f
             builtin alias mat2x4h
             builtin constructor mat2x4h
             builtin constructor mat3x2
-            builtin type mat3x2
+            builtin type generator mat3x2
             builtin alias mat3x2f
             builtin constructor mat3x2f
             builtin alias mat3x2h
             builtin constructor mat3x2h
             builtin constructor mat3x3
-            builtin type mat3x3
+            builtin type generator mat3x3
             builtin alias mat3x3f
             builtin constructor mat3x3f
             builtin alias mat3x3h
             builtin constructor mat3x3h
             builtin constructor mat3x4
-            builtin type mat3x4
+            builtin type generator mat3x4
             builtin alias mat3x4f
             builtin constructor mat3x4f
             builtin alias mat3x4h
             builtin constructor mat3x4h
             builtin constructor mat4x2
-            builtin type mat4x2
+            builtin type generator mat4x2
             builtin alias mat4x2f
             builtin constructor mat4x2f
             builtin alias mat4x2h
             builtin constructor mat4x2h
             builtin constructor mat4x3
-            builtin type mat4x3
+            builtin type generator mat4x3
             builtin alias mat4x3f
             builtin constructor mat4x3f
             builtin alias mat4x3h
             builtin constructor mat4x3h
             builtin constructor mat4x4
-            builtin type mat4x4
+            builtin type generator mat4x4
             builtin alias mat4x4f
             builtin constructor mat4x4f
             builtin alias mat4x4h
@@ -1182,7 +1182,7 @@ fn no_completions_in_comments() {
             builtin function pack4xU8Clamp
             builtin function pow
             builtin enumerant private
-            builtin type ptr
+            builtin type generator ptr
             builtin function quadBroadcast
             builtin function quadSwapDiagonal
             builtin function quadSwapX
@@ -1209,7 +1209,7 @@ fn no_completions_in_comments() {
             builtin function rayQueryInitialize
             builtin function rayQueryProceed
             builtin function rayQueryTerminate
-            builtin type generator ray_query
+            builtin type ray_query
             builtin enumerant read
             builtin enumerant read_write
             builtin function reflect
@@ -1243,8 +1243,8 @@ fn no_completions_in_comments() {
             builtin enumerant rgba8uint
             builtin enumerant rgba8unorm
             builtin function round
-            builtin type generator sampler
-            builtin type generator sampler_comparison
+            builtin type sampler
+            builtin type sampler_comparison
             builtin function saturate
             builtin function select
             builtin function sign
@@ -1296,32 +1296,32 @@ fn no_completions_in_comments() {
             builtin function textureSampleGrad
             builtin function textureSampleLevel
             builtin function textureStore
-            builtin type texture_1d
-            builtin type texture_1d_array
-            builtin type texture_2d
-            builtin type texture_2d_array
-            builtin type texture_3d
-            builtin type texture_cube
-            builtin type texture_cube_array
-            builtin type generator texture_depth_2d
-            builtin type generator texture_depth_2d_array
-            builtin type generator texture_depth_cube
-            builtin type generator texture_depth_cube_array
-            builtin type generator texture_depth_multisampled_2d
-            builtin type generator texture_external
-            builtin type texture_multisampled_2d
-            builtin type texture_multisampled_2d_array
-            builtin type texture_storage_1d
-            builtin type texture_storage_1d_array
-            builtin type texture_storage_2d
-            builtin type texture_storage_2d_array
-            builtin type texture_storage_3d
+            builtin type generator texture_1d
+            builtin type generator texture_1d_array
+            builtin type generator texture_2d
+            builtin type generator texture_2d_array
+            builtin type generator texture_3d
+            builtin type generator texture_cube
+            builtin type generator texture_cube_array
+            builtin type texture_depth_2d
+            builtin type texture_depth_2d_array
+            builtin type texture_depth_cube
+            builtin type texture_depth_cube_array
+            builtin type texture_depth_multisampled_2d
+            builtin type texture_external
+            builtin type generator texture_multisampled_2d
+            builtin type generator texture_multisampled_2d_array
+            builtin type generator texture_storage_1d
+            builtin type generator texture_storage_1d_array
+            builtin type generator texture_storage_2d
+            builtin type generator texture_storage_2d_array
+            builtin type generator texture_storage_3d
             builtin function transpose
             builtin function trunc
             builtin constructor u32
-            builtin type generator u32
+            builtin type u32
             builtin constructor u64
-            builtin type generator u64
+            builtin type u64
             builtin enumerant uniform
             builtin function unpack2x16float
             builtin function unpack2x16snorm
@@ -1331,7 +1331,7 @@ fn no_completions_in_comments() {
             builtin function unpack4xI8
             builtin function unpack4xU8
             builtin constructor vec2
-            builtin type vec2
+            builtin type generator vec2
             builtin alias vec2f
             builtin constructor vec2f
             builtin alias vec2h
@@ -1341,7 +1341,7 @@ fn no_completions_in_comments() {
             builtin alias vec2u
             builtin constructor vec2u
             builtin constructor vec3
-            builtin type vec3
+            builtin type generator vec3
             builtin alias vec3f
             builtin constructor vec3f
             builtin alias vec3h
@@ -1351,7 +1351,7 @@ fn no_completions_in_comments() {
             builtin alias vec3u
             builtin constructor vec3u
             builtin constructor vec4
-            builtin type vec4
+            builtin type generator vec4
             builtin alias vec4f
             builtin constructor vec4f
             builtin alias vec4h

--- a/crates/ide_completion/src/tests/module_items.rs
+++ b/crates/ide_completion/src/tests/module_items.rs
@@ -209,20 +209,20 @@ fn complete_variable() {
             builtin constructor RayDesc
             builtin constructor RayIntersection
             builtin function abs
-            builtin type generator acceleration_structure
+            builtin type acceleration_structure
             builtin function acos
             builtin function acosh
             builtin function all
             builtin function any
             builtin constructor array
-            builtin type array
+            builtin type generator array
             builtin function arrayLength
             builtin function asin
             builtin function asinh
             builtin function atan
             builtin function atan2
             builtin function atanh
-            builtin type atomic
+            builtin type generator atomic
             builtin function atomicAdd
             builtin function atomicAnd
             builtin function atomicCompareExchangeWeak
@@ -235,10 +235,10 @@ fn complete_variable() {
             builtin function atomicSub
             builtin function atomicXor
             builtin enumerant bgra8unorm
-            builtin type binding_array
+            builtin type generator binding_array
             builtin function bitcast
             builtin constructor bool
-            builtin type generator bool
+            builtin type bool
             builtin function ceil
             builtin function clamp
             builtin function cos
@@ -263,11 +263,11 @@ fn complete_variable() {
             builtin function exp2
             builtin function extractBits
             builtin constructor f16
-            builtin type generator f16
+            builtin type f16
             builtin constructor f32
-            builtin type generator f32
+            builtin type f32
             builtin constructor f64
-            builtin type generator f64
+            builtin type f64
             builtin function faceForward
             builtin function firstLeadingBit
             builtin function firstTrailingBit
@@ -282,9 +282,9 @@ fn complete_variable() {
             builtin function getCandidateHitVertexPositions
             builtin function getCommittedHitVertexPositions
             builtin constructor i32
-            builtin type generator i32
+            builtin type i32
             builtin constructor i64
-            builtin type generator i64
+            builtin type i64
             builtin enumerant immediate
             builtin function insertBits
             builtin function inverseSqrt
@@ -293,55 +293,55 @@ fn complete_variable() {
             builtin function log
             builtin function log2
             builtin constructor mat2x2
-            builtin type mat2x2
+            builtin type generator mat2x2
             builtin alias mat2x2f
             builtin constructor mat2x2f
             builtin alias mat2x2h
             builtin constructor mat2x2h
             builtin constructor mat2x3
-            builtin type mat2x3
+            builtin type generator mat2x3
             builtin alias mat2x3f
             builtin constructor mat2x3f
             builtin alias mat2x3h
             builtin constructor mat2x3h
             builtin constructor mat2x4
-            builtin type mat2x4
+            builtin type generator mat2x4
             builtin alias mat2x4f
             builtin constructor mat2x4f
             builtin alias mat2x4h
             builtin constructor mat2x4h
             builtin constructor mat3x2
-            builtin type mat3x2
+            builtin type generator mat3x2
             builtin alias mat3x2f
             builtin constructor mat3x2f
             builtin alias mat3x2h
             builtin constructor mat3x2h
             builtin constructor mat3x3
-            builtin type mat3x3
+            builtin type generator mat3x3
             builtin alias mat3x3f
             builtin constructor mat3x3f
             builtin alias mat3x3h
             builtin constructor mat3x3h
             builtin constructor mat3x4
-            builtin type mat3x4
+            builtin type generator mat3x4
             builtin alias mat3x4f
             builtin constructor mat3x4f
             builtin alias mat3x4h
             builtin constructor mat3x4h
             builtin constructor mat4x2
-            builtin type mat4x2
+            builtin type generator mat4x2
             builtin alias mat4x2f
             builtin constructor mat4x2f
             builtin alias mat4x2h
             builtin constructor mat4x2h
             builtin constructor mat4x3
-            builtin type mat4x3
+            builtin type generator mat4x3
             builtin alias mat4x3f
             builtin constructor mat4x3f
             builtin alias mat4x3h
             builtin constructor mat4x3h
             builtin constructor mat4x4
-            builtin type mat4x4
+            builtin type generator mat4x4
             builtin alias mat4x4f
             builtin constructor mat4x4f
             builtin alias mat4x4h
@@ -362,7 +362,7 @@ fn complete_variable() {
             builtin function pack4xU8Clamp
             builtin function pow
             builtin enumerant private
-            builtin type ptr
+            builtin type generator ptr
             builtin function quadBroadcast
             builtin function quadSwapDiagonal
             builtin function quadSwapX
@@ -389,7 +389,7 @@ fn complete_variable() {
             builtin function rayQueryInitialize
             builtin function rayQueryProceed
             builtin function rayQueryTerminate
-            builtin type generator ray_query
+            builtin type ray_query
             builtin enumerant read
             builtin enumerant read_write
             builtin function reflect
@@ -423,8 +423,8 @@ fn complete_variable() {
             builtin enumerant rgba8uint
             builtin enumerant rgba8unorm
             builtin function round
-            builtin type generator sampler
-            builtin type generator sampler_comparison
+            builtin type sampler
+            builtin type sampler_comparison
             builtin function saturate
             builtin function select
             builtin function sign
@@ -477,32 +477,32 @@ fn complete_variable() {
             builtin function textureSampleGrad
             builtin function textureSampleLevel
             builtin function textureStore
-            builtin type texture_1d
-            builtin type texture_1d_array
-            builtin type texture_2d
-            builtin type texture_2d_array
-            builtin type texture_3d
-            builtin type texture_cube
-            builtin type texture_cube_array
-            builtin type generator texture_depth_2d
-            builtin type generator texture_depth_2d_array
-            builtin type generator texture_depth_cube
-            builtin type generator texture_depth_cube_array
-            builtin type generator texture_depth_multisampled_2d
-            builtin type generator texture_external
-            builtin type texture_multisampled_2d
-            builtin type texture_multisampled_2d_array
-            builtin type texture_storage_1d
-            builtin type texture_storage_1d_array
-            builtin type texture_storage_2d
-            builtin type texture_storage_2d_array
-            builtin type texture_storage_3d
+            builtin type generator texture_1d
+            builtin type generator texture_1d_array
+            builtin type generator texture_2d
+            builtin type generator texture_2d_array
+            builtin type generator texture_3d
+            builtin type generator texture_cube
+            builtin type generator texture_cube_array
+            builtin type texture_depth_2d
+            builtin type texture_depth_2d_array
+            builtin type texture_depth_cube
+            builtin type texture_depth_cube_array
+            builtin type texture_depth_multisampled_2d
+            builtin type texture_external
+            builtin type generator texture_multisampled_2d
+            builtin type generator texture_multisampled_2d_array
+            builtin type generator texture_storage_1d
+            builtin type generator texture_storage_1d_array
+            builtin type generator texture_storage_2d
+            builtin type generator texture_storage_2d_array
+            builtin type generator texture_storage_3d
             builtin function transpose
             builtin function trunc
             builtin constructor u32
-            builtin type generator u32
+            builtin type u32
             builtin constructor u64
-            builtin type generator u64
+            builtin type u64
             builtin enumerant uniform
             builtin function unpack2x16float
             builtin function unpack2x16snorm
@@ -512,7 +512,7 @@ fn complete_variable() {
             builtin function unpack4xI8
             builtin function unpack4xU8
             builtin constructor vec2
-            builtin type vec2
+            builtin type generator vec2
             builtin alias vec2f
             builtin constructor vec2f
             builtin alias vec2h
@@ -522,7 +522,7 @@ fn complete_variable() {
             builtin alias vec2u
             builtin constructor vec2u
             builtin constructor vec3
-            builtin type vec3
+            builtin type generator vec3
             builtin alias vec3f
             builtin constructor vec3f
             builtin alias vec3h
@@ -532,7 +532,7 @@ fn complete_variable() {
             builtin alias vec3u
             builtin constructor vec3u
             builtin constructor vec4
-            builtin type vec4
+            builtin type generator vec4
             builtin alias vec4f
             builtin constructor vec4f
             builtin alias vec4h
@@ -578,20 +578,20 @@ fn complete_keyword() {
             builtin constructor RayDesc
             builtin constructor RayIntersection
             builtin function abs
-            builtin type generator acceleration_structure
+            builtin type acceleration_structure
             builtin function acos
             builtin function acosh
             builtin function all
             builtin function any
             builtin constructor array
-            builtin type array
+            builtin type generator array
             builtin function arrayLength
             builtin function asin
             builtin function asinh
             builtin function atan
             builtin function atan2
             builtin function atanh
-            builtin type atomic
+            builtin type generator atomic
             builtin function atomicAdd
             builtin function atomicAnd
             builtin function atomicCompareExchangeWeak
@@ -604,10 +604,10 @@ fn complete_keyword() {
             builtin function atomicSub
             builtin function atomicXor
             builtin enumerant bgra8unorm
-            builtin type binding_array
+            builtin type generator binding_array
             builtin function bitcast
             builtin constructor bool
-            builtin type generator bool
+            builtin type bool
             builtin function ceil
             builtin function clamp
             builtin function cos
@@ -632,11 +632,11 @@ fn complete_keyword() {
             builtin function exp2
             builtin function extractBits
             builtin constructor f16
-            builtin type generator f16
+            builtin type f16
             builtin constructor f32
-            builtin type generator f32
+            builtin type f32
             builtin constructor f64
-            builtin type generator f64
+            builtin type f64
             builtin function faceForward
             builtin function firstLeadingBit
             builtin function firstTrailingBit
@@ -651,9 +651,9 @@ fn complete_keyword() {
             builtin function getCandidateHitVertexPositions
             builtin function getCommittedHitVertexPositions
             builtin constructor i32
-            builtin type generator i32
+            builtin type i32
             builtin constructor i64
-            builtin type generator i64
+            builtin type i64
             builtin enumerant immediate
             builtin function insertBits
             builtin function inverseSqrt
@@ -662,55 +662,55 @@ fn complete_keyword() {
             builtin function log
             builtin function log2
             builtin constructor mat2x2
-            builtin type mat2x2
+            builtin type generator mat2x2
             builtin alias mat2x2f
             builtin constructor mat2x2f
             builtin alias mat2x2h
             builtin constructor mat2x2h
             builtin constructor mat2x3
-            builtin type mat2x3
+            builtin type generator mat2x3
             builtin alias mat2x3f
             builtin constructor mat2x3f
             builtin alias mat2x3h
             builtin constructor mat2x3h
             builtin constructor mat2x4
-            builtin type mat2x4
+            builtin type generator mat2x4
             builtin alias mat2x4f
             builtin constructor mat2x4f
             builtin alias mat2x4h
             builtin constructor mat2x4h
             builtin constructor mat3x2
-            builtin type mat3x2
+            builtin type generator mat3x2
             builtin alias mat3x2f
             builtin constructor mat3x2f
             builtin alias mat3x2h
             builtin constructor mat3x2h
             builtin constructor mat3x3
-            builtin type mat3x3
+            builtin type generator mat3x3
             builtin alias mat3x3f
             builtin constructor mat3x3f
             builtin alias mat3x3h
             builtin constructor mat3x3h
             builtin constructor mat3x4
-            builtin type mat3x4
+            builtin type generator mat3x4
             builtin alias mat3x4f
             builtin constructor mat3x4f
             builtin alias mat3x4h
             builtin constructor mat3x4h
             builtin constructor mat4x2
-            builtin type mat4x2
+            builtin type generator mat4x2
             builtin alias mat4x2f
             builtin constructor mat4x2f
             builtin alias mat4x2h
             builtin constructor mat4x2h
             builtin constructor mat4x3
-            builtin type mat4x3
+            builtin type generator mat4x3
             builtin alias mat4x3f
             builtin constructor mat4x3f
             builtin alias mat4x3h
             builtin constructor mat4x3h
             builtin constructor mat4x4
-            builtin type mat4x4
+            builtin type generator mat4x4
             builtin alias mat4x4f
             builtin constructor mat4x4f
             builtin alias mat4x4h
@@ -731,7 +731,7 @@ fn complete_keyword() {
             builtin function pack4xU8Clamp
             builtin function pow
             builtin enumerant private
-            builtin type ptr
+            builtin type generator ptr
             builtin function quadBroadcast
             builtin function quadSwapDiagonal
             builtin function quadSwapX
@@ -758,7 +758,7 @@ fn complete_keyword() {
             builtin function rayQueryInitialize
             builtin function rayQueryProceed
             builtin function rayQueryTerminate
-            builtin type generator ray_query
+            builtin type ray_query
             builtin enumerant read
             builtin enumerant read_write
             builtin function reflect
@@ -792,8 +792,8 @@ fn complete_keyword() {
             builtin enumerant rgba8uint
             builtin enumerant rgba8unorm
             builtin function round
-            builtin type generator sampler
-            builtin type generator sampler_comparison
+            builtin type sampler
+            builtin type sampler_comparison
             builtin function saturate
             builtin function select
             builtin function sign
@@ -845,32 +845,32 @@ fn complete_keyword() {
             builtin function textureSampleGrad
             builtin function textureSampleLevel
             builtin function textureStore
-            builtin type texture_1d
-            builtin type texture_1d_array
-            builtin type texture_2d
-            builtin type texture_2d_array
-            builtin type texture_3d
-            builtin type texture_cube
-            builtin type texture_cube_array
-            builtin type generator texture_depth_2d
-            builtin type generator texture_depth_2d_array
-            builtin type generator texture_depth_cube
-            builtin type generator texture_depth_cube_array
-            builtin type generator texture_depth_multisampled_2d
-            builtin type generator texture_external
-            builtin type texture_multisampled_2d
-            builtin type texture_multisampled_2d_array
-            builtin type texture_storage_1d
-            builtin type texture_storage_1d_array
-            builtin type texture_storage_2d
-            builtin type texture_storage_2d_array
-            builtin type texture_storage_3d
+            builtin type generator texture_1d
+            builtin type generator texture_1d_array
+            builtin type generator texture_2d
+            builtin type generator texture_2d_array
+            builtin type generator texture_3d
+            builtin type generator texture_cube
+            builtin type generator texture_cube_array
+            builtin type texture_depth_2d
+            builtin type texture_depth_2d_array
+            builtin type texture_depth_cube
+            builtin type texture_depth_cube_array
+            builtin type texture_depth_multisampled_2d
+            builtin type texture_external
+            builtin type generator texture_multisampled_2d
+            builtin type generator texture_multisampled_2d_array
+            builtin type generator texture_storage_1d
+            builtin type generator texture_storage_1d_array
+            builtin type generator texture_storage_2d
+            builtin type generator texture_storage_2d_array
+            builtin type generator texture_storage_3d
             builtin function transpose
             builtin function trunc
             builtin constructor u32
-            builtin type generator u32
+            builtin type u32
             builtin constructor u64
-            builtin type generator u64
+            builtin type u64
             builtin enumerant uniform
             builtin function unpack2x16float
             builtin function unpack2x16snorm
@@ -880,7 +880,7 @@ fn complete_keyword() {
             builtin function unpack4xI8
             builtin function unpack4xU8
             builtin constructor vec2
-            builtin type vec2
+            builtin type generator vec2
             builtin alias vec2f
             builtin constructor vec2f
             builtin alias vec2h
@@ -890,7 +890,7 @@ fn complete_keyword() {
             builtin alias vec2u
             builtin constructor vec2u
             builtin constructor vec3
-            builtin type vec3
+            builtin type generator vec3
             builtin alias vec3f
             builtin constructor vec3f
             builtin alias vec3h
@@ -900,7 +900,7 @@ fn complete_keyword() {
             builtin alias vec3u
             builtin constructor vec3u
             builtin constructor vec4
-            builtin type vec4
+            builtin type generator vec4
             builtin alias vec4f
             builtin constructor vec4f
             builtin alias vec4h
@@ -946,20 +946,20 @@ fn complete_snippet() {
             builtin constructor RayDesc
             builtin constructor RayIntersection
             builtin function abs
-            builtin type generator acceleration_structure
+            builtin type acceleration_structure
             builtin function acos
             builtin function acosh
             builtin function all
             builtin function any
             builtin constructor array
-            builtin type array
+            builtin type generator array
             builtin function arrayLength
             builtin function asin
             builtin function asinh
             builtin function atan
             builtin function atan2
             builtin function atanh
-            builtin type atomic
+            builtin type generator atomic
             builtin function atomicAdd
             builtin function atomicAnd
             builtin function atomicCompareExchangeWeak
@@ -972,10 +972,10 @@ fn complete_snippet() {
             builtin function atomicSub
             builtin function atomicXor
             builtin enumerant bgra8unorm
-            builtin type binding_array
+            builtin type generator binding_array
             builtin function bitcast
             builtin constructor bool
-            builtin type generator bool
+            builtin type bool
             builtin function ceil
             builtin function clamp
             builtin function cos
@@ -1000,11 +1000,11 @@ fn complete_snippet() {
             builtin function exp2
             builtin function extractBits
             builtin constructor f16
-            builtin type generator f16
+            builtin type f16
             builtin constructor f32
-            builtin type generator f32
+            builtin type f32
             builtin constructor f64
-            builtin type generator f64
+            builtin type f64
             builtin function faceForward
             builtin function firstLeadingBit
             builtin function firstTrailingBit
@@ -1019,9 +1019,9 @@ fn complete_snippet() {
             builtin function getCandidateHitVertexPositions
             builtin function getCommittedHitVertexPositions
             builtin constructor i32
-            builtin type generator i32
+            builtin type i32
             builtin constructor i64
-            builtin type generator i64
+            builtin type i64
             builtin enumerant immediate
             builtin function insertBits
             builtin function inverseSqrt
@@ -1030,55 +1030,55 @@ fn complete_snippet() {
             builtin function log
             builtin function log2
             builtin constructor mat2x2
-            builtin type mat2x2
+            builtin type generator mat2x2
             builtin alias mat2x2f
             builtin constructor mat2x2f
             builtin alias mat2x2h
             builtin constructor mat2x2h
             builtin constructor mat2x3
-            builtin type mat2x3
+            builtin type generator mat2x3
             builtin alias mat2x3f
             builtin constructor mat2x3f
             builtin alias mat2x3h
             builtin constructor mat2x3h
             builtin constructor mat2x4
-            builtin type mat2x4
+            builtin type generator mat2x4
             builtin alias mat2x4f
             builtin constructor mat2x4f
             builtin alias mat2x4h
             builtin constructor mat2x4h
             builtin constructor mat3x2
-            builtin type mat3x2
+            builtin type generator mat3x2
             builtin alias mat3x2f
             builtin constructor mat3x2f
             builtin alias mat3x2h
             builtin constructor mat3x2h
             builtin constructor mat3x3
-            builtin type mat3x3
+            builtin type generator mat3x3
             builtin alias mat3x3f
             builtin constructor mat3x3f
             builtin alias mat3x3h
             builtin constructor mat3x3h
             builtin constructor mat3x4
-            builtin type mat3x4
+            builtin type generator mat3x4
             builtin alias mat3x4f
             builtin constructor mat3x4f
             builtin alias mat3x4h
             builtin constructor mat3x4h
             builtin constructor mat4x2
-            builtin type mat4x2
+            builtin type generator mat4x2
             builtin alias mat4x2f
             builtin constructor mat4x2f
             builtin alias mat4x2h
             builtin constructor mat4x2h
             builtin constructor mat4x3
-            builtin type mat4x3
+            builtin type generator mat4x3
             builtin alias mat4x3f
             builtin constructor mat4x3f
             builtin alias mat4x3h
             builtin constructor mat4x3h
             builtin constructor mat4x4
-            builtin type mat4x4
+            builtin type generator mat4x4
             builtin alias mat4x4f
             builtin constructor mat4x4f
             builtin alias mat4x4h
@@ -1099,7 +1099,7 @@ fn complete_snippet() {
             builtin function pack4xU8Clamp
             builtin function pow
             builtin enumerant private
-            builtin type ptr
+            builtin type generator ptr
             builtin function quadBroadcast
             builtin function quadSwapDiagonal
             builtin function quadSwapX
@@ -1126,7 +1126,7 @@ fn complete_snippet() {
             builtin function rayQueryInitialize
             builtin function rayQueryProceed
             builtin function rayQueryTerminate
-            builtin type generator ray_query
+            builtin type ray_query
             builtin enumerant read
             builtin enumerant read_write
             builtin function reflect
@@ -1160,8 +1160,8 @@ fn complete_snippet() {
             builtin enumerant rgba8uint
             builtin enumerant rgba8unorm
             builtin function round
-            builtin type generator sampler
-            builtin type generator sampler_comparison
+            builtin type sampler
+            builtin type sampler_comparison
             builtin function saturate
             builtin function select
             builtin function sign
@@ -1213,32 +1213,32 @@ fn complete_snippet() {
             builtin function textureSampleGrad
             builtin function textureSampleLevel
             builtin function textureStore
-            builtin type texture_1d
-            builtin type texture_1d_array
-            builtin type texture_2d
-            builtin type texture_2d_array
-            builtin type texture_3d
-            builtin type texture_cube
-            builtin type texture_cube_array
-            builtin type generator texture_depth_2d
-            builtin type generator texture_depth_2d_array
-            builtin type generator texture_depth_cube
-            builtin type generator texture_depth_cube_array
-            builtin type generator texture_depth_multisampled_2d
-            builtin type generator texture_external
-            builtin type texture_multisampled_2d
-            builtin type texture_multisampled_2d_array
-            builtin type texture_storage_1d
-            builtin type texture_storage_1d_array
-            builtin type texture_storage_2d
-            builtin type texture_storage_2d_array
-            builtin type texture_storage_3d
+            builtin type generator texture_1d
+            builtin type generator texture_1d_array
+            builtin type generator texture_2d
+            builtin type generator texture_2d_array
+            builtin type generator texture_3d
+            builtin type generator texture_cube
+            builtin type generator texture_cube_array
+            builtin type texture_depth_2d
+            builtin type texture_depth_2d_array
+            builtin type texture_depth_cube
+            builtin type texture_depth_cube_array
+            builtin type texture_depth_multisampled_2d
+            builtin type texture_external
+            builtin type generator texture_multisampled_2d
+            builtin type generator texture_multisampled_2d_array
+            builtin type generator texture_storage_1d
+            builtin type generator texture_storage_1d_array
+            builtin type generator texture_storage_2d
+            builtin type generator texture_storage_2d_array
+            builtin type generator texture_storage_3d
             builtin function transpose
             builtin function trunc
             builtin constructor u32
-            builtin type generator u32
+            builtin type u32
             builtin constructor u64
-            builtin type generator u64
+            builtin type u64
             builtin enumerant uniform
             builtin function unpack2x16float
             builtin function unpack2x16snorm
@@ -1248,7 +1248,7 @@ fn complete_snippet() {
             builtin function unpack4xI8
             builtin function unpack4xU8
             builtin constructor vec2
-            builtin type vec2
+            builtin type generator vec2
             builtin alias vec2f
             builtin constructor vec2f
             builtin alias vec2h
@@ -1258,7 +1258,7 @@ fn complete_snippet() {
             builtin alias vec2u
             builtin constructor vec2u
             builtin constructor vec3
-            builtin type vec3
+            builtin type generator vec3
             builtin alias vec3f
             builtin constructor vec3f
             builtin alias vec3h
@@ -1268,7 +1268,7 @@ fn complete_snippet() {
             builtin alias vec3u
             builtin constructor vec3u
             builtin constructor vec4
-            builtin type vec4
+            builtin type generator vec4
             builtin alias vec4f
             builtin constructor vec4f
             builtin alias vec4h
@@ -1315,20 +1315,20 @@ fn complete_constant() {
             builtin constructor RayDesc
             builtin constructor RayIntersection
             builtin function abs
-            builtin type generator acceleration_structure
+            builtin type acceleration_structure
             builtin function acos
             builtin function acosh
             builtin function all
             builtin function any
             builtin constructor array
-            builtin type array
+            builtin type generator array
             builtin function arrayLength
             builtin function asin
             builtin function asinh
             builtin function atan
             builtin function atan2
             builtin function atanh
-            builtin type atomic
+            builtin type generator atomic
             builtin function atomicAdd
             builtin function atomicAnd
             builtin function atomicCompareExchangeWeak
@@ -1341,10 +1341,10 @@ fn complete_constant() {
             builtin function atomicSub
             builtin function atomicXor
             builtin enumerant bgra8unorm
-            builtin type binding_array
+            builtin type generator binding_array
             builtin function bitcast
             builtin constructor bool
-            builtin type generator bool
+            builtin type bool
             builtin function ceil
             builtin function clamp
             builtin function cos
@@ -1369,11 +1369,11 @@ fn complete_constant() {
             builtin function exp2
             builtin function extractBits
             builtin constructor f16
-            builtin type generator f16
+            builtin type f16
             builtin constructor f32
-            builtin type generator f32
+            builtin type f32
             builtin constructor f64
-            builtin type generator f64
+            builtin type f64
             builtin function faceForward
             builtin function firstLeadingBit
             builtin function firstTrailingBit
@@ -1388,9 +1388,9 @@ fn complete_constant() {
             builtin function getCandidateHitVertexPositions
             builtin function getCommittedHitVertexPositions
             builtin constructor i32
-            builtin type generator i32
+            builtin type i32
             builtin constructor i64
-            builtin type generator i64
+            builtin type i64
             builtin enumerant immediate
             builtin function insertBits
             builtin function inverseSqrt
@@ -1399,55 +1399,55 @@ fn complete_constant() {
             builtin function log
             builtin function log2
             builtin constructor mat2x2
-            builtin type mat2x2
+            builtin type generator mat2x2
             builtin alias mat2x2f
             builtin constructor mat2x2f
             builtin alias mat2x2h
             builtin constructor mat2x2h
             builtin constructor mat2x3
-            builtin type mat2x3
+            builtin type generator mat2x3
             builtin alias mat2x3f
             builtin constructor mat2x3f
             builtin alias mat2x3h
             builtin constructor mat2x3h
             builtin constructor mat2x4
-            builtin type mat2x4
+            builtin type generator mat2x4
             builtin alias mat2x4f
             builtin constructor mat2x4f
             builtin alias mat2x4h
             builtin constructor mat2x4h
             builtin constructor mat3x2
-            builtin type mat3x2
+            builtin type generator mat3x2
             builtin alias mat3x2f
             builtin constructor mat3x2f
             builtin alias mat3x2h
             builtin constructor mat3x2h
             builtin constructor mat3x3
-            builtin type mat3x3
+            builtin type generator mat3x3
             builtin alias mat3x3f
             builtin constructor mat3x3f
             builtin alias mat3x3h
             builtin constructor mat3x3h
             builtin constructor mat3x4
-            builtin type mat3x4
+            builtin type generator mat3x4
             builtin alias mat3x4f
             builtin constructor mat3x4f
             builtin alias mat3x4h
             builtin constructor mat3x4h
             builtin constructor mat4x2
-            builtin type mat4x2
+            builtin type generator mat4x2
             builtin alias mat4x2f
             builtin constructor mat4x2f
             builtin alias mat4x2h
             builtin constructor mat4x2h
             builtin constructor mat4x3
-            builtin type mat4x3
+            builtin type generator mat4x3
             builtin alias mat4x3f
             builtin constructor mat4x3f
             builtin alias mat4x3h
             builtin constructor mat4x3h
             builtin constructor mat4x4
-            builtin type mat4x4
+            builtin type generator mat4x4
             builtin alias mat4x4f
             builtin constructor mat4x4f
             builtin alias mat4x4h
@@ -1468,7 +1468,7 @@ fn complete_constant() {
             builtin function pack4xU8Clamp
             builtin function pow
             builtin enumerant private
-            builtin type ptr
+            builtin type generator ptr
             builtin function quadBroadcast
             builtin function quadSwapDiagonal
             builtin function quadSwapX
@@ -1495,7 +1495,7 @@ fn complete_constant() {
             builtin function rayQueryInitialize
             builtin function rayQueryProceed
             builtin function rayQueryTerminate
-            builtin type generator ray_query
+            builtin type ray_query
             builtin enumerant read
             builtin enumerant read_write
             builtin function reflect
@@ -1529,8 +1529,8 @@ fn complete_constant() {
             builtin enumerant rgba8uint
             builtin enumerant rgba8unorm
             builtin function round
-            builtin type generator sampler
-            builtin type generator sampler_comparison
+            builtin type sampler
+            builtin type sampler_comparison
             builtin function saturate
             builtin function select
             builtin function sign
@@ -1582,32 +1582,32 @@ fn complete_constant() {
             builtin function textureSampleGrad
             builtin function textureSampleLevel
             builtin function textureStore
-            builtin type texture_1d
-            builtin type texture_1d_array
-            builtin type texture_2d
-            builtin type texture_2d_array
-            builtin type texture_3d
-            builtin type texture_cube
-            builtin type texture_cube_array
-            builtin type generator texture_depth_2d
-            builtin type generator texture_depth_2d_array
-            builtin type generator texture_depth_cube
-            builtin type generator texture_depth_cube_array
-            builtin type generator texture_depth_multisampled_2d
-            builtin type generator texture_external
-            builtin type texture_multisampled_2d
-            builtin type texture_multisampled_2d_array
-            builtin type texture_storage_1d
-            builtin type texture_storage_1d_array
-            builtin type texture_storage_2d
-            builtin type texture_storage_2d_array
-            builtin type texture_storage_3d
+            builtin type generator texture_1d
+            builtin type generator texture_1d_array
+            builtin type generator texture_2d
+            builtin type generator texture_2d_array
+            builtin type generator texture_3d
+            builtin type generator texture_cube
+            builtin type generator texture_cube_array
+            builtin type texture_depth_2d
+            builtin type texture_depth_2d_array
+            builtin type texture_depth_cube
+            builtin type texture_depth_cube_array
+            builtin type texture_depth_multisampled_2d
+            builtin type texture_external
+            builtin type generator texture_multisampled_2d
+            builtin type generator texture_multisampled_2d_array
+            builtin type generator texture_storage_1d
+            builtin type generator texture_storage_1d_array
+            builtin type generator texture_storage_2d
+            builtin type generator texture_storage_2d_array
+            builtin type generator texture_storage_3d
             builtin function transpose
             builtin function trunc
             builtin constructor u32
-            builtin type generator u32
+            builtin type u32
             builtin constructor u64
-            builtin type generator u64
+            builtin type u64
             builtin enumerant uniform
             builtin function unpack2x16float
             builtin function unpack2x16snorm
@@ -1617,7 +1617,7 @@ fn complete_constant() {
             builtin function unpack4xI8
             builtin function unpack4xU8
             builtin constructor vec2
-            builtin type vec2
+            builtin type generator vec2
             builtin alias vec2f
             builtin constructor vec2f
             builtin alias vec2h
@@ -1627,7 +1627,7 @@ fn complete_constant() {
             builtin alias vec2u
             builtin constructor vec2u
             builtin constructor vec3
-            builtin type vec3
+            builtin type generator vec3
             builtin alias vec3f
             builtin constructor vec3f
             builtin alias vec3h
@@ -1637,7 +1637,7 @@ fn complete_constant() {
             builtin alias vec3u
             builtin constructor vec3u
             builtin constructor vec4
-            builtin type vec4
+            builtin type generator vec4
             builtin alias vec4f
             builtin constructor vec4f
             builtin alias vec4h
@@ -1684,20 +1684,20 @@ fn complete_struct() {
             builtin constructor RayDesc
             builtin constructor RayIntersection
             builtin function abs
-            builtin type generator acceleration_structure
+            builtin type acceleration_structure
             builtin function acos
             builtin function acosh
             builtin function all
             builtin function any
             builtin constructor array
-            builtin type array
+            builtin type generator array
             builtin function arrayLength
             builtin function asin
             builtin function asinh
             builtin function atan
             builtin function atan2
             builtin function atanh
-            builtin type atomic
+            builtin type generator atomic
             builtin function atomicAdd
             builtin function atomicAnd
             builtin function atomicCompareExchangeWeak
@@ -1710,10 +1710,10 @@ fn complete_struct() {
             builtin function atomicSub
             builtin function atomicXor
             builtin enumerant bgra8unorm
-            builtin type binding_array
+            builtin type generator binding_array
             builtin function bitcast
             builtin constructor bool
-            builtin type generator bool
+            builtin type bool
             builtin function ceil
             builtin function clamp
             builtin function cos
@@ -1738,11 +1738,11 @@ fn complete_struct() {
             builtin function exp2
             builtin function extractBits
             builtin constructor f16
-            builtin type generator f16
+            builtin type f16
             builtin constructor f32
-            builtin type generator f32
+            builtin type f32
             builtin constructor f64
-            builtin type generator f64
+            builtin type f64
             builtin function faceForward
             builtin function firstLeadingBit
             builtin function firstTrailingBit
@@ -1757,9 +1757,9 @@ fn complete_struct() {
             builtin function getCandidateHitVertexPositions
             builtin function getCommittedHitVertexPositions
             builtin constructor i32
-            builtin type generator i32
+            builtin type i32
             builtin constructor i64
-            builtin type generator i64
+            builtin type i64
             builtin enumerant immediate
             builtin function insertBits
             builtin function inverseSqrt
@@ -1768,55 +1768,55 @@ fn complete_struct() {
             builtin function log
             builtin function log2
             builtin constructor mat2x2
-            builtin type mat2x2
+            builtin type generator mat2x2
             builtin alias mat2x2f
             builtin constructor mat2x2f
             builtin alias mat2x2h
             builtin constructor mat2x2h
             builtin constructor mat2x3
-            builtin type mat2x3
+            builtin type generator mat2x3
             builtin alias mat2x3f
             builtin constructor mat2x3f
             builtin alias mat2x3h
             builtin constructor mat2x3h
             builtin constructor mat2x4
-            builtin type mat2x4
+            builtin type generator mat2x4
             builtin alias mat2x4f
             builtin constructor mat2x4f
             builtin alias mat2x4h
             builtin constructor mat2x4h
             builtin constructor mat3x2
-            builtin type mat3x2
+            builtin type generator mat3x2
             builtin alias mat3x2f
             builtin constructor mat3x2f
             builtin alias mat3x2h
             builtin constructor mat3x2h
             builtin constructor mat3x3
-            builtin type mat3x3
+            builtin type generator mat3x3
             builtin alias mat3x3f
             builtin constructor mat3x3f
             builtin alias mat3x3h
             builtin constructor mat3x3h
             builtin constructor mat3x4
-            builtin type mat3x4
+            builtin type generator mat3x4
             builtin alias mat3x4f
             builtin constructor mat3x4f
             builtin alias mat3x4h
             builtin constructor mat3x4h
             builtin constructor mat4x2
-            builtin type mat4x2
+            builtin type generator mat4x2
             builtin alias mat4x2f
             builtin constructor mat4x2f
             builtin alias mat4x2h
             builtin constructor mat4x2h
             builtin constructor mat4x3
-            builtin type mat4x3
+            builtin type generator mat4x3
             builtin alias mat4x3f
             builtin constructor mat4x3f
             builtin alias mat4x3h
             builtin constructor mat4x3h
             builtin constructor mat4x4
-            builtin type mat4x4
+            builtin type generator mat4x4
             builtin alias mat4x4f
             builtin constructor mat4x4f
             builtin alias mat4x4h
@@ -1837,7 +1837,7 @@ fn complete_struct() {
             builtin function pack4xU8Clamp
             builtin function pow
             builtin enumerant private
-            builtin type ptr
+            builtin type generator ptr
             builtin function quadBroadcast
             builtin function quadSwapDiagonal
             builtin function quadSwapX
@@ -1864,7 +1864,7 @@ fn complete_struct() {
             builtin function rayQueryInitialize
             builtin function rayQueryProceed
             builtin function rayQueryTerminate
-            builtin type generator ray_query
+            builtin type ray_query
             builtin enumerant read
             builtin enumerant read_write
             builtin function reflect
@@ -1898,8 +1898,8 @@ fn complete_struct() {
             builtin enumerant rgba8uint
             builtin enumerant rgba8unorm
             builtin function round
-            builtin type generator sampler
-            builtin type generator sampler_comparison
+            builtin type sampler
+            builtin type sampler_comparison
             builtin function saturate
             builtin function select
             builtin function sign
@@ -1951,32 +1951,32 @@ fn complete_struct() {
             builtin function textureSampleGrad
             builtin function textureSampleLevel
             builtin function textureStore
-            builtin type texture_1d
-            builtin type texture_1d_array
-            builtin type texture_2d
-            builtin type texture_2d_array
-            builtin type texture_3d
-            builtin type texture_cube
-            builtin type texture_cube_array
-            builtin type generator texture_depth_2d
-            builtin type generator texture_depth_2d_array
-            builtin type generator texture_depth_cube
-            builtin type generator texture_depth_cube_array
-            builtin type generator texture_depth_multisampled_2d
-            builtin type generator texture_external
-            builtin type texture_multisampled_2d
-            builtin type texture_multisampled_2d_array
-            builtin type texture_storage_1d
-            builtin type texture_storage_1d_array
-            builtin type texture_storage_2d
-            builtin type texture_storage_2d_array
-            builtin type texture_storage_3d
+            builtin type generator texture_1d
+            builtin type generator texture_1d_array
+            builtin type generator texture_2d
+            builtin type generator texture_2d_array
+            builtin type generator texture_3d
+            builtin type generator texture_cube
+            builtin type generator texture_cube_array
+            builtin type texture_depth_2d
+            builtin type texture_depth_2d_array
+            builtin type texture_depth_cube
+            builtin type texture_depth_cube_array
+            builtin type texture_depth_multisampled_2d
+            builtin type texture_external
+            builtin type generator texture_multisampled_2d
+            builtin type generator texture_multisampled_2d_array
+            builtin type generator texture_storage_1d
+            builtin type generator texture_storage_1d_array
+            builtin type generator texture_storage_2d
+            builtin type generator texture_storage_2d_array
+            builtin type generator texture_storage_3d
             builtin function transpose
             builtin function trunc
             builtin constructor u32
-            builtin type generator u32
+            builtin type u32
             builtin constructor u64
-            builtin type generator u64
+            builtin type u64
             builtin enumerant uniform
             builtin function unpack2x16float
             builtin function unpack2x16snorm
@@ -1986,7 +1986,7 @@ fn complete_struct() {
             builtin function unpack4xI8
             builtin function unpack4xU8
             builtin constructor vec2
-            builtin type vec2
+            builtin type generator vec2
             builtin alias vec2f
             builtin constructor vec2f
             builtin alias vec2h
@@ -1996,7 +1996,7 @@ fn complete_struct() {
             builtin alias vec2u
             builtin constructor vec2u
             builtin constructor vec3
-            builtin type vec3
+            builtin type generator vec3
             builtin alias vec3f
             builtin constructor vec3f
             builtin alias vec3h
@@ -2006,7 +2006,7 @@ fn complete_struct() {
             builtin alias vec3u
             builtin constructor vec3u
             builtin constructor vec4
-            builtin type vec4
+            builtin type generator vec4
             builtin alias vec4f
             builtin constructor vec4f
             builtin alias vec4h
@@ -2055,20 +2055,20 @@ fn complete_type_alias() {
             builtin constructor RayDesc
             builtin constructor RayIntersection
             builtin function abs
-            builtin type generator acceleration_structure
+            builtin type acceleration_structure
             builtin function acos
             builtin function acosh
             builtin function all
             builtin function any
             builtin constructor array
-            builtin type array
+            builtin type generator array
             builtin function arrayLength
             builtin function asin
             builtin function asinh
             builtin function atan
             builtin function atan2
             builtin function atanh
-            builtin type atomic
+            builtin type generator atomic
             builtin function atomicAdd
             builtin function atomicAnd
             builtin function atomicCompareExchangeWeak
@@ -2081,10 +2081,10 @@ fn complete_type_alias() {
             builtin function atomicSub
             builtin function atomicXor
             builtin enumerant bgra8unorm
-            builtin type binding_array
+            builtin type generator binding_array
             builtin function bitcast
             builtin constructor bool
-            builtin type generator bool
+            builtin type bool
             builtin function ceil
             builtin function clamp
             builtin function cos
@@ -2109,11 +2109,11 @@ fn complete_type_alias() {
             builtin function exp2
             builtin function extractBits
             builtin constructor f16
-            builtin type generator f16
+            builtin type f16
             builtin constructor f32
-            builtin type generator f32
+            builtin type f32
             builtin constructor f64
-            builtin type generator f64
+            builtin type f64
             builtin function faceForward
             builtin function firstLeadingBit
             builtin function firstTrailingBit
@@ -2128,9 +2128,9 @@ fn complete_type_alias() {
             builtin function getCandidateHitVertexPositions
             builtin function getCommittedHitVertexPositions
             builtin constructor i32
-            builtin type generator i32
+            builtin type i32
             builtin constructor i64
-            builtin type generator i64
+            builtin type i64
             builtin enumerant immediate
             builtin function insertBits
             builtin function inverseSqrt
@@ -2139,55 +2139,55 @@ fn complete_type_alias() {
             builtin function log
             builtin function log2
             builtin constructor mat2x2
-            builtin type mat2x2
+            builtin type generator mat2x2
             builtin alias mat2x2f
             builtin constructor mat2x2f
             builtin alias mat2x2h
             builtin constructor mat2x2h
             builtin constructor mat2x3
-            builtin type mat2x3
+            builtin type generator mat2x3
             builtin alias mat2x3f
             builtin constructor mat2x3f
             builtin alias mat2x3h
             builtin constructor mat2x3h
             builtin constructor mat2x4
-            builtin type mat2x4
+            builtin type generator mat2x4
             builtin alias mat2x4f
             builtin constructor mat2x4f
             builtin alias mat2x4h
             builtin constructor mat2x4h
             builtin constructor mat3x2
-            builtin type mat3x2
+            builtin type generator mat3x2
             builtin alias mat3x2f
             builtin constructor mat3x2f
             builtin alias mat3x2h
             builtin constructor mat3x2h
             builtin constructor mat3x3
-            builtin type mat3x3
+            builtin type generator mat3x3
             builtin alias mat3x3f
             builtin constructor mat3x3f
             builtin alias mat3x3h
             builtin constructor mat3x3h
             builtin constructor mat3x4
-            builtin type mat3x4
+            builtin type generator mat3x4
             builtin alias mat3x4f
             builtin constructor mat3x4f
             builtin alias mat3x4h
             builtin constructor mat3x4h
             builtin constructor mat4x2
-            builtin type mat4x2
+            builtin type generator mat4x2
             builtin alias mat4x2f
             builtin constructor mat4x2f
             builtin alias mat4x2h
             builtin constructor mat4x2h
             builtin constructor mat4x3
-            builtin type mat4x3
+            builtin type generator mat4x3
             builtin alias mat4x3f
             builtin constructor mat4x3f
             builtin alias mat4x3h
             builtin constructor mat4x3h
             builtin constructor mat4x4
-            builtin type mat4x4
+            builtin type generator mat4x4
             builtin alias mat4x4f
             builtin constructor mat4x4f
             builtin alias mat4x4h
@@ -2208,7 +2208,7 @@ fn complete_type_alias() {
             builtin function pack4xU8Clamp
             builtin function pow
             builtin enumerant private
-            builtin type ptr
+            builtin type generator ptr
             builtin function quadBroadcast
             builtin function quadSwapDiagonal
             builtin function quadSwapX
@@ -2235,7 +2235,7 @@ fn complete_type_alias() {
             builtin function rayQueryInitialize
             builtin function rayQueryProceed
             builtin function rayQueryTerminate
-            builtin type generator ray_query
+            builtin type ray_query
             builtin enumerant read
             builtin enumerant read_write
             builtin function reflect
@@ -2269,8 +2269,8 @@ fn complete_type_alias() {
             builtin enumerant rgba8uint
             builtin enumerant rgba8unorm
             builtin function round
-            builtin type generator sampler
-            builtin type generator sampler_comparison
+            builtin type sampler
+            builtin type sampler_comparison
             builtin function saturate
             builtin function select
             builtin function sign
@@ -2322,32 +2322,32 @@ fn complete_type_alias() {
             builtin function textureSampleGrad
             builtin function textureSampleLevel
             builtin function textureStore
-            builtin type texture_1d
-            builtin type texture_1d_array
-            builtin type texture_2d
-            builtin type texture_2d_array
-            builtin type texture_3d
-            builtin type texture_cube
-            builtin type texture_cube_array
-            builtin type generator texture_depth_2d
-            builtin type generator texture_depth_2d_array
-            builtin type generator texture_depth_cube
-            builtin type generator texture_depth_cube_array
-            builtin type generator texture_depth_multisampled_2d
-            builtin type generator texture_external
-            builtin type texture_multisampled_2d
-            builtin type texture_multisampled_2d_array
-            builtin type texture_storage_1d
-            builtin type texture_storage_1d_array
-            builtin type texture_storage_2d
-            builtin type texture_storage_2d_array
-            builtin type texture_storage_3d
+            builtin type generator texture_1d
+            builtin type generator texture_1d_array
+            builtin type generator texture_2d
+            builtin type generator texture_2d_array
+            builtin type generator texture_3d
+            builtin type generator texture_cube
+            builtin type generator texture_cube_array
+            builtin type texture_depth_2d
+            builtin type texture_depth_2d_array
+            builtin type texture_depth_cube
+            builtin type texture_depth_cube_array
+            builtin type texture_depth_multisampled_2d
+            builtin type texture_external
+            builtin type generator texture_multisampled_2d
+            builtin type generator texture_multisampled_2d_array
+            builtin type generator texture_storage_1d
+            builtin type generator texture_storage_1d_array
+            builtin type generator texture_storage_2d
+            builtin type generator texture_storage_2d_array
+            builtin type generator texture_storage_3d
             builtin function transpose
             builtin function trunc
             builtin constructor u32
-            builtin type generator u32
+            builtin type u32
             builtin constructor u64
-            builtin type generator u64
+            builtin type u64
             builtin enumerant uniform
             builtin function unpack2x16float
             builtin function unpack2x16snorm
@@ -2357,7 +2357,7 @@ fn complete_type_alias() {
             builtin function unpack4xI8
             builtin function unpack4xU8
             builtin constructor vec2
-            builtin type vec2
+            builtin type generator vec2
             builtin alias vec2f
             builtin constructor vec2f
             builtin alias vec2h
@@ -2367,7 +2367,7 @@ fn complete_type_alias() {
             builtin alias vec2u
             builtin constructor vec2u
             builtin constructor vec3
-            builtin type vec3
+            builtin type generator vec3
             builtin alias vec3f
             builtin constructor vec3f
             builtin alias vec3h
@@ -2377,7 +2377,7 @@ fn complete_type_alias() {
             builtin alias vec3u
             builtin constructor vec3u
             builtin constructor vec4
-            builtin type vec4
+            builtin type generator vec4
             builtin alias vec4f
             builtin constructor vec4f
             builtin alias vec4h


### PR DESCRIPTION
# Objective

I noticed that the language server currently fails to resolve `acceleration_structure` as a builtin type and I found that it was partially because of this and also it is missing from`lower_builtin_type`.

## Solution

Swap these around. Add a test case, but adding the type to the type system and lowering will be a follow-up.

## Testing

Added test case and updated tests.
