### PR TITLE
Fix copy-paste error in diagnostic message

### DIFF
--- a/crates/hir_ty/src/lower/builtin.rs
+++ b/crates/hir_ty/src/lower/builtin.rs
@@ -1019,7 +1019,7 @@ impl TypeLoweringContext<'_> {
                 return Err(TypeLoweringError {
                     container: *template_parameters.container(),
                     kind: TypeLoweringErrorKind::MissingTemplateArgument(
-                        "an address space".to_owned(),
+                        "a texel format".to_owned(),
                     ),
                 });
             },
@@ -1044,7 +1044,7 @@ impl TypeLoweringContext<'_> {
                 return Err(TypeLoweringError {
                     container: *template_parameters.container(),
                     kind: TypeLoweringErrorKind::MissingTemplateArgument(
-                        "an address space".to_owned(),
+                        "an access mode".to_owned(),
                     ),
                 });
             },

--- a/crates/hir_ty/src/tests/builtins/zero_value.rs
+++ b/crates/hir_ty/src/tests/builtins/zero_value.rs
@@ -195,7 +195,7 @@ fn foo() {
             658..663 'ptr()': expected 2 to 3 template arguments, but got 0
             658..663 'ptr()': missing template argument, expected an address space
             739..759 'textur...e_2d()': expected 1 to 2 template arguments, but got 0
-            739..759 'textur...e_2d()': missing template argument, expected an address space
+            739..759 'textur...e_2d()': missing template argument, expected a texel format
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -1914,9 +1914,9 @@ fn storage_texture_template() {
             166..169 'i32': unexpected template argument, expected an enumerant, actual: i32
             176..188 'tex_storage4': ref<handle, [error], read>
             190..208 'textur...age_2d': expected 1 to 2 template arguments, but got 0
-            190..208 'textur...age_2d': missing template argument, expected an address space
+            190..208 'textur...age_2d': missing template argument, expected a texel format
             214..226 'tex_storage5': ref<handle, [error], read>
-            228..258 'textur...unorm>': missing template argument, expected an address space
+            228..258 'textur...unorm>': missing template argument, expected an access mode
             264..276 'tex_storage5': ref<handle, [error], read>
             297..307 'read_write': unexpected template argument, expected a texel format (`rgba8unorm`, `rgba8snorm`, ...), actual: read_write
             314..326 'tex_storage3': ref<handle, [error], read>


### PR DESCRIPTION
# Objective

The message is correct and hints at the solution.

## Solution

Make the text match the actual semantics.

## Testing

Updated tests.
