### PR TITLE
Add support for `swizzle_assignment` language extension

### DIFF
--- a/crates/edition/src/lib.rs
+++ b/crates/edition/src/lib.rs
@@ -223,6 +223,18 @@ pub struct ExtensionsConfig {
     ///
     /// Allow the declaration of variables with an opaque store type that can be reinterpreted as other host-shareable types.
     pub buffer_view: bool,
+
+    /// Supports swizzle view types.
+    ///
+    /// This enables swizzle assignments:
+    /// a single assignment statement can update multiple components of a vector without having to update the entire vector.
+    ///
+    /// For example, if variable `v` is a 4-element vector, then `v.xz = vec2(1,2);` is
+    /// a shorthand way of writing `v.x = 1; v.z = 2;`, while performing one read and one write.
+    ///
+    /// If `pointer_composite_access` is also supported, then this also works on pointers.
+    /// If `p` is a pointer to a vector of at least 3 elements, then `p.xz = vec2(1,2);` is shorthand for `(*p).x = 1; (*p).z = 2;`.
+    pub swizzle_assignment: bool,
 }
 
 // TODO: implement this in the frontend and add more https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1421

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -55,6 +55,9 @@ pub enum AnyDiagnostic {
         left_side: InFile<AstPointer<ast::Expression>>,
         actual: Type,
     },
+    AssignmentNotWritable {
+        left_side: InFile<AstPointer<ast::Expression>>,
+    },
     TypeMismatch {
         expression: InFile<AstPointer<ast::Expression>>,
         expected: TypeExpectation,
@@ -166,7 +169,7 @@ impl AnyDiagnostic {
     #[rustfmt::skip]
     pub const fn file_id(&self) -> EditionedFileId {
         match self {
-            Self::AssignmentNotAReference { left_side, actual: _  } => {
+            Self::AssignmentNotAReference { left_side, actual: _  } | Self::AssignmentNotWritable { left_side  } => {
                 left_side.file_id
             },
 
@@ -233,6 +236,11 @@ pub(crate) fn to_any_diagnostic(
                 left_side: source,
                 actual: *actual,
             }
+        },
+        InferenceDiagnosticKind::AssignmentNotWritable { left_side } => {
+            let pointer = source_map.expression_to_source(*left_side).ok()?.clone();
+            let source = InFile::new(file_id, pointer);
+            AnyDiagnostic::AssignmentNotWritable { left_side: source }
         },
         InferenceDiagnosticKind::TypeMismatch {
             expression,

--- a/crates/hir_ty/src/diagnostics.rs
+++ b/crates/hir_ty/src/diagnostics.rs
@@ -22,6 +22,9 @@ pub enum InferenceDiagnosticKind {
         left_side: ExpressionId,
         actual: Type,
     },
+    AssignmentNotWritable {
+        left_side: ExpressionId,
+    },
     TypeMismatch {
         expression: ExpressionId,
         expected: TypeExpectation,

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -694,6 +694,7 @@ impl<'db> InferenceContext<'db> {
                     | TypeKind::Texture(_)
                     | TypeKind::Sampler(_)
                     | TypeKind::Pointer(_)
+                    | TypeKind::RayQuery(_)
                     | TypeKind::AccelerationStructure(_) => {
                         if !left_type.is_err(self.db) {
                             self.push_diagnostic(
@@ -1506,32 +1507,15 @@ impl<'db> InferenceContext<'db> {
             Ok(index_list) => {
                 if index_list.iter().copied().any(index_out_of_bounds) {
                     error()
-                } else if let Some((address_space, access_mode)) = is_ref {
-                    if access_mode == AccessMode::ReadWrite {
-                        TypeKind::SwizzleView(SwizzleView {
-                            address_space,
-                            component_type: vector_type.component_type,
-                            vector_size: vector_type.size,
-                            index_list,
-                        })
-                        .intern(self.db)
-                    } else if let Some((address_space, access_mode)) = is_ref {
-                        self.make_ref(
-                            TypeKind::Vector(VectorType {
-                                size: index_list.length,
-                                component_type: vector_type.component_type,
-                            })
-                            .intern(self.db),
-                            address_space,
-                            access_mode,
-                        )
-                    } else {
-                        TypeKind::Vector(VectorType {
-                            size: index_list.length,
-                            component_type: vector_type.component_type,
-                        })
-                        .intern(self.db)
-                    }
+                } else if let Some((address_space, AccessMode::ReadWrite)) = is_ref {
+                    // TODO: gate behind enable extension
+                    TypeKind::SwizzleView(SwizzleView {
+                        address_space,
+                        component_type: vector_type.component_type,
+                        vector_size: vector_type.size,
+                        index_list,
+                    })
+                    .intern(self.db)
                 } else {
                     TypeKind::Vector(VectorType {
                         size: index_list.length,

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -668,7 +668,7 @@ impl<'db> InferenceContext<'db> {
                     // apply the load rule
                     TypeKind::Reference(reference) => reference.inner,
                     // apply the swizzle load rule
-                    TypeKind::SwizzleView(swizzle_view) => swizzle_view.loaded(self.db),
+                    TypeKind::SwizzleView(swizzle_view) => swizzle_view.loaded().intern(self.db),
                     TypeKind::Error
                     | TypeKind::Scalar(_)
                     | TypeKind::Atomic(_)

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -925,11 +925,6 @@ impl<'db> InferenceContext<'db> {
         r#type: Type,
         expectation: TypeExpectationInner,
     ) -> Result<(), ()> {
-        let type_kind = r#type.kind(self.db);
-        if type_kind == TypeKind::Error {
-            return Ok(());
-        }
-
         match expectation {
             TypeExpectationInner::Exact(expected_type) => {
                 if expected_type.kind(self.db) == TypeKind::Error
@@ -970,7 +965,6 @@ impl<'db> InferenceContext<'db> {
         store: &ExpressionStore,
     ) -> Type {
         let r#type = self.infer_expression(expression, store);
-
         match expected {
             TypeExpectation::Type(expected_type) => {
                 if !r#type.is_err(self.db)

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -38,8 +38,8 @@ use crate::{
         TypeLoweringError, WgslTypeConverter, to_wgsl_binary_operator, to_wgsl_unary_operator,
     },
     ty::{
-        ArraySize, ArrayType, BuiltinStruct, MatrixType, Pointer, Reference, ScalarType, Type,
-        TypeKind, VectorType,
+        ArraySize, ArrayType, BuiltinStruct, IndexList, MatrixType, ParseIndexListError, Pointer,
+        Reference, ScalarType, SwizzleView, Type, TypeKind, VecIndex, VectorType,
     },
 };
 
@@ -1037,6 +1037,7 @@ impl<'db> InferenceContext<'db> {
                         },
                     );
                 }
+                // The base may be a vector, matrix, or fixed-size array type, or a memory view to a vector, matrix, fixed-size array, or runtime-sized array type.
                 match left_kind {
                     TypeKind::Reference(Reference {
                         address_space,
@@ -1176,6 +1177,7 @@ impl<'db> InferenceContext<'db> {
             | TypeKind::Scalar(_)
             | TypeKind::Atomic(_)
             | TypeKind::Vector(_)
+            | TypeKind::SwizzleView(_)
             | TypeKind::Matrix(_)
             | TypeKind::Struct(_)
             | TypeKind::BuiltinStruct(_)
@@ -1764,6 +1766,7 @@ impl<'db> InferenceContext<'db> {
             | TypeKind::Atomic(_)
             | TypeKind::RayQuery(_)
             | TypeKind::AccelerationStructure(_)
+            | TypeKind::SwizzleView(_)
             | TypeKind::Reference(_) => {
                 debug_assert!(
                     !self.result.diagnostics.is_empty(),

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -666,7 +666,21 @@ impl<'db> InferenceContext<'db> {
                 let left_type = self.infer_expression(*left_side, body);
                 let left_loaded = match left_type.kind(self.db) {
                     // apply the load rule
-                    TypeKind::Reference(reference) => reference.inner,
+                    TypeKind::Reference(Reference {
+                        address_space: _,
+                        inner,
+                        access_mode,
+                    }) => {
+                        if !access_mode.is_write() {
+                            self.push_diagnostic(
+                                body.store_source,
+                                InferenceDiagnosticKind::AssignmentNotWritable {
+                                    left_side: *left_side,
+                                },
+                            );
+                        }
+                        inner
+                    },
                     // apply the swizzle load rule
                     TypeKind::SwizzleView(swizzle_view) => swizzle_view.loaded().intern(self.db),
                     TypeKind::Error

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -664,27 +664,39 @@ impl<'db> InferenceContext<'db> {
                 right_side,
             } => {
                 let left_type = self.infer_expression(*left_side, body);
-
-                let kind = left_type.kind(self.db);
-                let left_inner = if let TypeKind::Reference(reference) = kind {
-                    reference.inner
-                } else {
-                    if !left_type.is_err(self.db) {
-                        self.push_diagnostic(
-                            body.store_source,
-                            InferenceDiagnosticKind::AssignmentNotAReference {
-                                left_side: *left_side,
-                                actual: left_type,
-                            },
-                        );
-                    }
-                    // helpful instead of full error
-                    left_type
+                let left_loaded = match left_type.kind(self.db) {
+                    // apply the load rule
+                    TypeKind::Reference(reference) => reference.inner,
+                    // apply the swizzle load rule
+                    TypeKind::SwizzleView(swizzle_view) => swizzle_view.loaded(self.db),
+                    TypeKind::Error
+                    | TypeKind::Scalar(_)
+                    | TypeKind::Atomic(_)
+                    | TypeKind::Vector(_)
+                    | TypeKind::Matrix(_)
+                    | TypeKind::Struct(_)
+                    | TypeKind::BuiltinStruct(_)
+                    | TypeKind::Array(_)
+                    | TypeKind::Texture(_)
+                    | TypeKind::Sampler(_)
+                    | TypeKind::Pointer(_)
+                    | TypeKind::AccelerationStructure(_) => {
+                        if !left_type.is_err(self.db) {
+                            self.push_diagnostic(
+                                body.store_source,
+                                InferenceDiagnosticKind::AssignmentNotAReference {
+                                    left_side: *left_side,
+                                    actual: left_type,
+                                },
+                            );
+                        }
+                        // helpful instead of full error
+                        left_type
+                    },
                 };
-
                 self.infer_expression_expect(
                     *right_side,
-                    TypeExpectation::from_type(left_inner),
+                    TypeExpectation::from_type(left_loaded),
                     body,
                 );
             },
@@ -1098,6 +1110,27 @@ impl<'db> InferenceContext<'db> {
                         inner,
                         access_mode: _,
                     }) if inner.kind(self.db) == TypeKind::Error => self.error_type(),
+                    TypeKind::SwizzleView(SwizzleView {
+                        address_space,
+                        component_type,
+                        vector_size: _,
+                        index_list: _,
+                    }) => {
+                        // Swizzle views do not directly support indexing expressions.
+                        // When an indexing expression clause appears after a swizzle view,
+                        // the Swizzle View Load Rule is applied first to yield a vector value,
+                        // and then the indexing expression is applied to that vector value.
+
+                        // HOWEVER, we can shortcut that here since we know how that will go.
+                        // Also, the spec implies that this returns a vector type rather than a reference to a vector.
+                        self.make_ref(
+                            component_type,
+                            address_space,
+                            // https://www.w3.org/TR/WGSL/#swizzle-view
+                            // `p` is of type `ptr<AS,vecN<S>,read_write>`
+                            AccessMode::ReadWrite,
+                        )
+                    },
                     TypeKind::Scalar(_)
                     | TypeKind::Atomic(_)
                     | TypeKind::Struct(_)
@@ -1188,15 +1221,24 @@ impl<'db> InferenceContext<'db> {
             | TypeKind::Sampler(_)) => (kind, None),
         };
 
-        let r#type = match kind {
-            TypeKind::Struct(r#struct) => self.infer_struct_field_expression(
-                expression,
-                store,
-                field_expression,
-                name,
-                expression_type,
-                r#struct,
-            ),
+        match kind {
+            TypeKind::Struct(r#struct) => {
+                let r#type = self.infer_struct_field_expression(
+                    expression,
+                    store,
+                    field_expression,
+                    name,
+                    expression_type,
+                    r#struct,
+                );
+                match ref_info {
+                    Some((address_space, access_mode)) => {
+                        self.make_ref(r#type, address_space, access_mode)
+                    },
+                    None => r#type,
+                }
+            },
+            // there are no storable builtin structs
             TypeKind::BuiltinStruct(builtin_struct) => self.infer_builtin_struct_field_expression(
                 store,
                 field_expression,
@@ -1204,16 +1246,22 @@ impl<'db> InferenceContext<'db> {
                 expression_type,
                 builtin_struct,
             ),
-            TypeKind::Vector(vector_type) => {
-                return self.infer_vec_swizzle_expression(
-                    store,
-                    field_expression,
-                    name,
-                    expression_type,
-                    &vector_type,
-                    ref_info,
-                );
-            },
+            TypeKind::Vector(vector_type) => self.infer_vector_access_expression(
+                store,
+                field_expression,
+                name,
+                expression_type,
+                &vector_type,
+                ref_info,
+            ),
+            // swizzling a swizzle is allowed!
+            TypeKind::SwizzleView(swizzle_view) => self.infer_swizzle_view_expression(
+                store,
+                field_expression,
+                name,
+                expression_type,
+                &swizzle_view,
+            ),
             TypeKind::Error
             | TypeKind::Scalar(_)
             | TypeKind::Atomic(_)
@@ -1234,13 +1282,8 @@ impl<'db> InferenceContext<'db> {
                     },
                 );
                 // no more useful type to return here
-                return self.error_type();
+                self.error_type()
             },
-        };
-
-        match ref_info {
-            Some((address_space, access_mode)) => self.make_ref(r#type, address_space, access_mode),
-            None => r#type,
         }
     }
 
@@ -1410,25 +1453,7 @@ impl<'db> InferenceContext<'db> {
         }
     }
 
-    fn type_from_vec_size(
-        &self,
-        inner: Type,
-        vec_size: u8,
-    ) -> Type {
-        if vec_size == 1 {
-            inner
-        } else {
-            let kind = vec_size.try_into().map_or(TypeKind::Error, |size| {
-                TypeKind::Vector(VectorType {
-                    size,
-                    component_type: inner,
-                })
-            });
-            kind.intern(self.db)
-        }
-    }
-
-    fn infer_vec_swizzle_expression(
+    fn infer_vector_access_expression(
         &mut self,
         store: &ExpressionStore,
         field_expression: ExpressionId,
@@ -1437,11 +1462,8 @@ impl<'db> InferenceContext<'db> {
         vector_type: &VectorType,
         is_ref: Option<(AddressSpace, AccessMode)>,
     ) -> Type {
-        const SWIZZLES: [[char; 4]; 2] = [['x', 'y', 'z', 'w'], ['r', 'g', 'b', 'a']];
-        let max_size = 4;
-        let max_swizzle_index = vector_type.size.as_u8();
-
-        if name.as_str().len() > max_size {
+        let index_out_of_bounds = |index: VecIndex| index.as_u8() > vector_type.size.as_u8();
+        let mut error = || {
             self.push_diagnostic(
                 store.store_source,
                 InferenceDiagnosticKind::NoSuchField {
@@ -1450,38 +1472,116 @@ impl<'db> InferenceContext<'db> {
                     r#type: expression_type,
                 },
             );
-            return self.error_type();
-        }
-
-        for swizzle in &SWIZZLES {
-            let allowed_chars = &swizzle[..(usize::from(max_swizzle_index))];
-            if name
-                .as_str()
-                .chars()
-                .all(|character| allowed_chars.contains(&character))
-            {
-                let r#type = self.type_from_vec_size(
-                    vector_type.component_type,
-                    u8::try_from(name.as_str().len()).unwrap(),
-                );
-                if let Some((address_space, access_mode)) = is_ref
-                // proposal to remove this length check: https://github.com/gpuweb/gpuweb/pull/5268
-                    && name.as_str().len() == 1
-                {
-                    return self.make_ref(r#type, address_space, access_mode);
+            self.error_type()
+        };
+        match IndexList::parse_name(name) {
+            Err(
+                crate::ty::ParseIndexListError::InvalidLetter
+                | crate::ty::ParseIndexListError::MixingSwizzles
+                | crate::ty::ParseIndexListError::MoreThanFour,
+            ) => error(),
+            Err(ParseIndexListError::One(index)) => {
+                if index_out_of_bounds(index) {
+                    error()
+                } else if let Some((address_space, access_mode)) = is_ref {
+                    self.make_ref(vector_type.component_type, address_space, access_mode)
+                } else {
+                    vector_type.component_type
                 }
-                return r#type;
-            }
-        }
-        self.push_diagnostic(
-            store.store_source,
-            InferenceDiagnosticKind::NoSuchField {
-                expression: field_expression,
-                name: name.clone(),
-                r#type: expression_type,
             },
-        );
-        self.error_type()
+            Ok(index_list) => {
+                if index_list.iter().copied().any(index_out_of_bounds) {
+                    error()
+                } else if let Some((address_space, access_mode)) = is_ref {
+                    if access_mode == AccessMode::ReadWrite {
+                        TypeKind::SwizzleView(SwizzleView {
+                            address_space,
+                            component_type: vector_type.component_type,
+                            vector_size: vector_type.size,
+                            index_list,
+                        })
+                        .intern(self.db)
+                    } else if let Some((address_space, access_mode)) = is_ref {
+                        self.make_ref(
+                            TypeKind::Vector(VectorType {
+                                size: index_list.length,
+                                component_type: vector_type.component_type,
+                            })
+                            .intern(self.db),
+                            address_space,
+                            access_mode,
+                        )
+                    } else {
+                        TypeKind::Vector(VectorType {
+                            size: index_list.length,
+                            component_type: vector_type.component_type,
+                        })
+                        .intern(self.db)
+                    }
+                } else {
+                    TypeKind::Vector(VectorType {
+                        size: index_list.length,
+                        component_type: vector_type.component_type,
+                    })
+                    .intern(self.db)
+                }
+            },
+        }
+    }
+
+    fn infer_swizzle_view_expression(
+        &mut self,
+        store: &ExpressionStore,
+        field_expression: ExpressionId,
+        name: &Name,
+        expression_type: Type,
+        swizzle_view: &SwizzleView,
+    ) -> Type {
+        let index_out_of_bounds =
+            |index: VecIndex| index.as_u8() > swizzle_view.vector_size.as_u8();
+        let mut error = || {
+            self.push_diagnostic(
+                store.store_source,
+                InferenceDiagnosticKind::NoSuchField {
+                    expression: field_expression,
+                    name: name.clone(),
+                    r#type: expression_type,
+                },
+            );
+            self.error_type()
+        };
+        match IndexList::parse_name(name) {
+            Err(
+                crate::ty::ParseIndexListError::InvalidLetter
+                | crate::ty::ParseIndexListError::MixingSwizzles
+                | crate::ty::ParseIndexListError::MoreThanFour,
+            ) => error(),
+            Err(ParseIndexListError::One(index)) => {
+                if index_out_of_bounds(index) {
+                    return error();
+                }
+                self.make_ref(
+                    swizzle_view.component_type,
+                    swizzle_view.address_space,
+                    AccessMode::ReadWrite,
+                )
+            },
+            Ok(index_list) => {
+                if index_list.iter().copied().any(index_out_of_bounds) {
+                    return error();
+                }
+                TypeKind::SwizzleView(SwizzleView {
+                    address_space: swizzle_view.address_space,
+                    component_type: swizzle_view.component_type,
+                    vector_size: u8::try_from(name.as_str().len())
+                        .unwrap()
+                        .try_into()
+                        .unwrap(),
+                    index_list,
+                })
+                .intern(self.db)
+            },
+        }
     }
 
     /// Lowers the field expression: `struct_value.name`.

--- a/crates/hir_ty/src/layout.rs
+++ b/crates/hir_ty/src/layout.rs
@@ -149,6 +149,7 @@ impl TypeKind {
             Self::Error
             | Self::Scalar(ScalarType::AbstractFloat | ScalarType::AbstractInt)
             | Self::Vector(_)
+            | Self::SwizzleView(_)
             | Self::BuiltinStruct(_)
             | Self::Texture(_)
             | Self::Sampler(_)
@@ -251,6 +252,7 @@ impl TypeKind {
             | Self::Scalar(ScalarType::AbstractFloat | ScalarType::AbstractInt)
             | Self::BuiltinStruct(_)
             | Self::Vector(_)
+            | Self::SwizzleView(_)
             | Self::Texture(_)
             | Self::Sampler(_)
             | Self::RayQuery(_)

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -662,6 +662,16 @@ impl<'db> WgslTypeConverter<'db> {
                 size,
                 component_type,
             }) => wgsl_types::Type::Vec(size.as_u8(), Box::new(self.to_wgsl_types(component_type))),
+            // TODO: wgsl-types should have swizzle views eventually
+            TypeKind::SwizzleView(SwizzleView {
+                address_space: _,
+                component_type,
+                vector_size,
+                index_list: _,
+            }) => wgsl_types::Type::Vec(
+                vector_size.as_u8(),
+                Box::new(self.to_wgsl_types(component_type)),
+            ),
             TypeKind::Matrix(MatrixType {
                 columns,
                 rows,

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -22,8 +22,8 @@ use crate::{
     function::ResolvedFunctionId,
     ty::{
         ArraySize, ArrayType, AtomicType, BuiltinStruct, MatrixType, Pointer, Reference,
-        ScalarType, TextureDimensionality, TextureKind, TextureType, Type, TypeKind, VecSize,
-        VectorType, pretty::pretty_type,
+        ScalarType, SwizzleView, TextureDimensionality, TextureKind, TextureType, Type, TypeKind,
+        VecSize, VectorType, pretty::pretty_type,
     },
 };
 
@@ -639,6 +639,7 @@ impl<'db> WgslTypeConverter<'db> {
         clippy::wrong_self_convention,
         reason = "naming things is hard and this is probably changing in the future"
     )]
+    #[expect(clippy::too_many_lines, reason = "just a long but simple match")]
     pub fn to_wgsl_types(
         &mut self,
         r#type: Type,
@@ -1113,6 +1114,7 @@ impl<'db> WgslTypeConverter<'db> {
             | TypeKind::Scalar(_)
             | TypeKind::Atomic(_)
             | TypeKind::Vector(_)
+            | TypeKind::SwizzleView(_)
             | TypeKind::Matrix(_)
             | TypeKind::Struct(_)
             | TypeKind::BuiltinStruct(_)

--- a/crates/hir_ty/src/lower/builtin.rs
+++ b/crates/hir_ty/src/lower/builtin.rs
@@ -969,6 +969,7 @@ impl TypeLoweringContext<'_> {
                     | TypeKind::Scalar(_)
                     | TypeKind::Atomic(_)
                     | TypeKind::Vector(_)
+                    | TypeKind::SwizzleView(_)
                     | TypeKind::Matrix(_)
                     | TypeKind::Struct(_)
                     | TypeKind::BuiltinStruct(_)

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -220,6 +220,9 @@ impl<'db> InferPrinter<'db> {
                 );
                 self.print_assignment_not_a_reference(source_map, buffer, *actual, *left_side);
             },
+            InferenceDiagnosticKind::AssignmentNotWritable { left_side } => {
+                self.print_assignment_not_writable(source_map, buffer, *left_side);
+            },
             InferenceDiagnosticKind::CyclicType { name, range } => {
                 self.print_cyclic_type(buffer, name, *range);
             },
@@ -334,6 +337,23 @@ impl<'db> InferPrinter<'db> {
             "{range:?} '{}': cannot assign to non-reference `{}`",
             ellipsize(text, 15),
             pretty_type(self.db, actual),
+        )
+        .unwrap();
+    }
+
+    fn print_assignment_not_writable(
+        &self,
+        source_map: &ExpressionSourceMap,
+        buffer: &mut String,
+        left_side: ExpressionId,
+    ) {
+        let Some((range, text)) = self.get_expression_range_text(source_map, left_side) else {
+            return;
+        };
+        writeln!(
+            buffer,
+            "{range:?} '{}': cannot assign to value with `read` access mode",
+            ellipsize(text, 15),
         )
         .unwrap();
     }

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -47,6 +47,7 @@ use crate::{
 
 fn infer(
     capabilities: Capabilities,
+    verbosity: TypeVerbosity,
     wa_fixture: &str,
 ) -> String {
     let (mut db, files) = TestDatabase::with_many_files(wa_fixture);
@@ -57,7 +58,7 @@ fn infer(
         if index > 0 {
             buffer.push_str("---\n");
         }
-        InferPrinter::new(&db, file_id).infer_file(&mut buffer);
+        InferPrinter::new(&db, file_id, verbosity).infer_file(&mut buffer);
     }
     buffer.truncate(buffer.trim_end().len());
     buffer
@@ -67,17 +68,24 @@ struct InferPrinter<'db> {
     db: &'db TestDatabase,
     file_id: EditionedFileId,
     root: SyntaxNode,
+    verbosity: TypeVerbosity,
 }
 
 impl<'db> InferPrinter<'db> {
     fn new(
         db: &'db TestDatabase,
         file_id: EditionedFileId,
+        verbosity: TypeVerbosity,
     ) -> Self {
         let parse = file_id.parse(db);
         assert_eq!(<&[Diagnostic]>::default(), parse.errors());
         let root = parse.syntax();
-        Self { db, file_id, root }
+        Self {
+            db,
+            file_id,
+            root,
+            verbosity,
+        }
     }
 
     fn infer_file(
@@ -182,7 +190,7 @@ impl<'db> InferPrinter<'db> {
             node.text_range(),
             node.text().to_string().replace('\n', " "),
         );
-        let pretty = pretty_type_with_verbosity(self.db, r#type, TypeVerbosity::Full);
+        let pretty = pretty_type_with_verbosity(self.db, r#type, self.verbosity);
         writeln!(buffer, "{range:?} '{}': {pretty}", ellipsize(text, 15)).unwrap();
     }
 
@@ -383,8 +391,8 @@ impl<'db> InferPrinter<'db> {
             buffer,
             "{range:?} '{}': expected {} but got {}",
             ellipsize(text, 15),
-            pretty_type_expectation_with_verbosity(self.db, expected, TypeVerbosity::Full),
-            pretty_type_with_verbosity(self.db, actual, TypeVerbosity::Full)
+            pretty_type_expectation_with_verbosity(self.db, expected, self.verbosity),
+            pretty_type_with_verbosity(self.db, actual, self.verbosity)
         )
         .unwrap();
     }
@@ -434,9 +442,10 @@ impl<'db> InferPrinter<'db> {
             )
             .unwrap();
         } else {
-            let parameters = join_display(parameters.iter().map(|parameter| {
-                pretty_type_with_verbosity(self.db, *parameter, TypeVerbosity::Full)
-            }));
+            let parameters =
+                join_display(parameters.iter().map(|parameter| {
+                    pretty_type_with_verbosity(self.db, *parameter, self.verbosity)
+                }));
             writeln!(
                 buffer,
                 "{range:?} '{}': no overload of constructor `{}` found for arguments of type ({parameters})",
@@ -467,9 +476,10 @@ impl<'db> InferPrinter<'db> {
             )
             .unwrap();
         } else {
-            let parameters = join_display(parameters.iter().map(|parameter| {
-                pretty_type_with_verbosity(self.db, *parameter, TypeVerbosity::Full)
-            }));
+            let parameters =
+                join_display(parameters.iter().map(|parameter| {
+                    pretty_type_with_verbosity(self.db, *parameter, self.verbosity)
+                }));
             writeln!(
                 buffer,
                 "{range:?} '{}': no overload of function `{}` found for arguments of type ({parameters})",
@@ -534,7 +544,7 @@ impl<'db> InferPrinter<'db> {
             "{range:?} '{}': no such field `{}` on type `{}`",
             ellipsize(text, 15),
             name.as_str(),
-            pretty_type_with_verbosity(self.db, r#type, TypeVerbosity::Full),
+            pretty_type_with_verbosity(self.db, r#type, self.verbosity),
         )
         .unwrap();
     }
@@ -553,7 +563,7 @@ impl<'db> InferPrinter<'db> {
             buffer,
             "{range:?} '{}': expected storable type but got `{}`",
             ellipsize(text, 15),
-            pretty_type_with_verbosity(self.db, actual, TypeVerbosity::Full),
+            pretty_type_with_verbosity(self.db, actual, self.verbosity),
         )
         .unwrap();
     }
@@ -572,7 +582,7 @@ impl<'db> InferPrinter<'db> {
             buffer,
             "{range:?} '{}': cannot index into type {}",
             ellipsize(text, 15),
-            pretty_type_with_verbosity(self.db, r#type, TypeVerbosity::Full),
+            pretty_type_with_verbosity(self.db, r#type, self.verbosity),
         )
         .unwrap();
     }
@@ -591,7 +601,7 @@ impl<'db> InferPrinter<'db> {
             buffer,
             "{range:?} '{}': unexpected return value of type `{}` in function with no return type",
             ellipsize(text, 15),
-            pretty_type_with_verbosity(self.db, actual, TypeVerbosity::Full),
+            pretty_type_with_verbosity(self.db, actual, self.verbosity),
         )
         .unwrap();
     }
@@ -610,7 +620,7 @@ impl<'db> InferPrinter<'db> {
             buffer,
             "{range:?} '{}': type `{}` is not constructible",
             ellipsize(text, 15),
-            pretty_type_with_verbosity(self.db, r#type, TypeVerbosity::Full),
+            pretty_type_with_verbosity(self.db, r#type, self.verbosity),
         )
         .unwrap();
     }
@@ -790,7 +800,16 @@ fn check_infer(
     wa_fixture: &str,
     expect: Expect,
 ) {
-    check_infer_with_capabilities(Capabilities::default(), wa_fixture, expect)
+    check_infer_with_verbosity(TypeVerbosity::Full, wa_fixture, expect)
+}
+
+#[expect(clippy::semicolon_if_nothing_returned, reason = "wrapper")]
+fn check_infer_with_verbosity(
+    verbosity: TypeVerbosity,
+    wa_fixture: &str,
+    expect: Expect,
+) {
+    check_infer_with_capabilities_verbosity(Capabilities::default(), verbosity, wa_fixture, expect)
 }
 
 #[expect(clippy::needless_pass_by_value, reason = "Matches expect! macro")]
@@ -799,7 +818,18 @@ fn check_infer_with_capabilities(
     wa_fixture: &str,
     expect: Expect,
 ) {
-    let mut actual = infer(capabilities, wa_fixture);
+    let mut actual = infer(capabilities, TypeVerbosity::Full, wa_fixture);
+    actual.push('\n');
+    expect.assert_eq(&actual);
+}
+#[expect(clippy::needless_pass_by_value, reason = "Matches expect! macro")]
+fn check_infer_with_capabilities_verbosity(
+    capabilities: Capabilities,
+    verbosity: TypeVerbosity,
+    wa_fixture: &str,
+    expect: Expect,
+) {
+    let mut actual = infer(capabilities, verbosity, wa_fixture);
     actual.push('\n');
     expect.assert_eq(&actual);
 }

--- a/crates/hir_ty/src/tests/language_extensions.rs
+++ b/crates/hir_ty/src/tests/language_extensions.rs
@@ -1,2 +1,3 @@
 mod ray_query;
+mod swizzle_assignment;
 mod texture_formats_tier1;

--- a/crates/hir_ty/src/tests/language_extensions/swizzle_assignment.rs
+++ b/crates/hir_ty/src/tests/language_extensions/swizzle_assignment.rs
@@ -309,6 +309,7 @@ fn foo() {
     );
 }
 
+// TODO: once support for the enable extension is actually added, do this test but with read_write
 #[test]
 fn readonly_ref_vec_is_not_swizzle() {
     check_infer(
@@ -325,6 +326,7 @@ fn foo() {
             91..96 'robuf': ref<storage, vec4<u32>, read>
             91..99 'robuf.xz': ref<storage, vec2<u32>, read>
             102..109 'vec2u()': vec2<u32>
+            91..99 'robuf.xz': cannot assign to value with `read` access mode
         "#]],
     );
 }
@@ -410,6 +412,7 @@ fn foo() {
             180..185 'robuf': ref<storage, vec4<u32>, read>
             180..188 'robuf.xz': ref<storage, vec2<u32>, read>
             191..198 'vec2u()': vec2<u32>
+            180..188 'robuf.xz': cannot assign to value with `read` access mode
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/language_extensions/swizzle_assignment.rs
+++ b/crates/hir_ty/src/tests/language_extensions/swizzle_assignment.rs
@@ -324,9 +324,9 @@ fn foo() {
         expect![[r#"
             61..66 'robuf': ref<storage, vec4<u32>, read>
             91..96 'robuf': ref<storage, vec4<u32>, read>
-            91..99 'robuf.xz': ref<storage, vec2<u32>, read>
+            91..99 'robuf.xz': vec2<u32>
             102..109 'vec2u()': vec2<u32>
-            91..99 'robuf.xz': cannot assign to value with `read` access mode
+            91..99 'robuf.xz': cannot assign to non-reference `vec2<u32>`
         "#]],
     );
 }
@@ -410,9 +410,9 @@ fn foo() {
         expect![[r#"
             150..155 'robuf': ref<storage, vec4<u32>, read>
             180..185 'robuf': ref<storage, vec4<u32>, read>
-            180..188 'robuf.xz': ref<storage, vec2<u32>, read>
+            180..188 'robuf.xz': vec2<u32>
             191..198 'vec2u()': vec2<u32>
-            180..188 'robuf.xz': cannot assign to value with `read` access mode
+            180..188 'robuf.xz': cannot assign to non-reference `vec2<u32>`
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/language_extensions/swizzle_assignment.rs
+++ b/crates/hir_ty/src/tests/language_extensions/swizzle_assignment.rs
@@ -1,0 +1,413 @@
+use expect_test::expect;
+
+use crate::{tests::{check_infer, check_infer_with_verbosity}, ty::pretty::TypeVerbosity};
+
+#[test]
+fn reading_and_writing_via_swizzle_views_on_references() {
+    check_infer(
+        "
+// requires swizzle_assignment;
+
+fn swizzle_read_and_write() {
+    var v: vec4u;
+
+    // Same as:  v.y = 1; v.z = 2;
+    // However, the vector is read from memory and written to memory exactly once.
+    v.yz = vec2u(1,2);
+
+    // Same as: let u = vec3(v.a, v.g, v.b);
+    // Expression v.agb is a swizzle view of type swizzle<function,u32,4,3>.
+    // The effective-value-type of a let declaration must be concrete constructible
+    // or a pointer type.  So the swizzle view is automatically converted to vec3u
+    // by invoking the Swizzle View Load Rule.
+    let u = v.agb;
+
+    // Swizzles can be chained.
+    // Same as: v.zy = vec2(99,100);
+    v.yz.yx = vec2(99,100);
+
+    // Applying a single letter on a swizzle view yields a reference
+    // to a scalar component of the underlying vector.
+    // Same as: v.z = 99;
+    v.yz.y = 99;
+
+    // Indexing a swizzle view yields a reference to one of the vector's
+    // components. It acts as if forming a single-letter vector access,
+    // but the index chooses which letter to use from the swizzle name.
+    v.zy[1] = 50; // Same as v.y = 50;
+}
+        ",
+        expect![[r#"
+            71..72 'v': ref<function, vec4<u32>, read_write>
+            204..205 'v': ref<function, vec4<u32>, read_write>
+            204..208 'v.yz': swizzle<function, u32, 4, 2>
+            211..221 'vec2u(1,2)': vec2<u32>
+            217..218 '1': integer
+            219..220 '2': integer
+            568..569 'u': swizzle<function, u32, 4, 3>
+            572..573 'v': ref<function, vec4<u32>, read_write>
+            572..577 'v.agb': swizzle<function, u32, 4, 3>
+            653..654 'v': ref<function, vec4<u32>, read_write>
+            653..657 'v.yz': swizzle<function, u32, 4, 2>
+            653..660 'v.yz.yx': swizzle<function, u32, 2, 2>
+            663..675 'vec2(99,100)': vec2<integer>
+            668..670 '99': integer
+            671..674 '100': integer
+            832..833 'v': ref<function, vec4<u32>, read_write>
+            832..836 'v.yz': swizzle<function, u32, 4, 2>
+            832..838 'v.yz.y': ref<function, u32, read_write>
+            841..843 '99': integer
+            1067..1068 'v': ref<function, vec4<u32>, read_write>
+            1067..1071 'v.zy': swizzle<function, u32, 4, 2>
+            1067..1074 'v.zy[1]': ref<function, u32, read_write>
+            1072..1073 '1': integer
+            1077..1079 '50': integer
+        "#]],
+    );
+}
+
+#[test]
+fn reading_and_writing_via_swizzle_views_on_pointers() {
+    check_infer(
+        "
+// requires pointer_composite_access, swizzle_assignment;
+
+fn swizzle_read_and_write_via_pointer(p: ptr<function,vec4u>) {
+    // Same as:  (*p).y = 1; (*p).z = 2;
+    p.yz = vec2u(1,2);
+
+    // Same as: let u = vec3((*p).a, (*p).g, (*p).b);
+    let u = p.agb;
+
+    // Swizzles can be chained.
+    // Same as: p.zy = vec2(99,100);
+    p.yz.yx = vec2(99,100);
+
+    // A swizzle view can be constructed from a pointer.
+    // Applying a single letter to a swizzle view yields a reference
+    // to a scalar component of the underlying vector.
+    // Same as: (*p).z = 99;
+    p.yz.y = 99;
+
+    // Indexing a swizzle view yields a reference to one of the vector's
+    // components. It acts as if forming a single-letter vector access,
+    // but the index chooses which letter to use from the swizzle name.
+    p.zy[1] = 50; // Same as (*p).y = 50;
+}
+        ",
+        expect![[r#"
+            97..98 'p': ptr<function, vec4<u32>, read_write>
+            168..169 'p': ptr<function, vec4<u32>, read_write>
+            168..172 'p.yz': swizzle<function, u32, 4, 2>
+            175..185 'vec2u(1,2)': vec2<u32>
+            181..182 '1': integer
+            183..184 '2': integer
+            250..251 'u': swizzle<function, u32, 4, 3>
+            254..255 'p': ptr<function, vec4<u32>, read_write>
+            254..259 'p.agb': swizzle<function, u32, 4, 3>
+            335..336 'p': ptr<function, vec4<u32>, read_write>
+            335..339 'p.yz': swizzle<function, u32, 4, 2>
+            335..342 'p.yz.yx': swizzle<function, u32, 2, 2>
+            345..357 'vec2(99,100)': vec2<integer>
+            350..352 '99': integer
+            353..356 '100': integer
+            574..575 'p': ptr<function, vec4<u32>, read_write>
+            574..578 'p.yz': swizzle<function, u32, 4, 2>
+            574..580 'p.yz.y': ref<function, u32, read_write>
+            583..585 '99': integer
+            809..810 'p': ptr<function, vec4<u32>, read_write>
+            809..813 'p.zy': swizzle<function, u32, 4, 2>
+            809..816 'p.zy[1]': ref<function, u32, read_write>
+            814..815 '1': integer
+            819..821 '50': integer
+        "#]],
+    );
+}
+
+#[test]
+fn invalid_swizzle_views() {
+    check_infer(
+        "
+// requires pointer_composite_access, swizzle_assignment;
+
+fn swizzle_read_and_write_via_pointer(p: ptr<function,vec4u>) {
+    // Same as:  (*p).y = 1; (*p).z = 2;
+    p.yz = vec2u(1,2);
+
+    // Same as: let u = vec3((*p).a, (*p).g, (*p).b);
+    let u = p.agb;
+
+    // Swizzles can be chained.
+    // Same as: p.zy = vec2(99,100);
+    p.yz.yx = vec2(99,100);
+
+    // A swizzle view can be constructed from a pointer.
+    // Applying a single letter to a swizzle view yields a reference
+    // to a scalar component of the underlying vector.
+    // Same as: (*p).z = 99;
+    p.yz.y = 99;
+
+    // Indexing a swizzle view yields a reference to one of the vector's
+    // components. It acts as if forming a single-letter vector access,
+    // but the index chooses which letter to use from the swizzle name.
+    p.zy[1] = 50; // Same as (*p).y = 50;
+}
+        ",
+        expect![[r#"
+            97..98 'p': ptr<function, vec4<u32>, read_write>
+            168..169 'p': ptr<function, vec4<u32>, read_write>
+            168..172 'p.yz': swizzle<function, u32, 4, 2>
+            175..185 'vec2u(1,2)': vec2<u32>
+            181..182 '1': integer
+            183..184 '2': integer
+            250..251 'u': swizzle<function, u32, 4, 3>
+            254..255 'p': ptr<function, vec4<u32>, read_write>
+            254..259 'p.agb': swizzle<function, u32, 4, 3>
+            335..336 'p': ptr<function, vec4<u32>, read_write>
+            335..339 'p.yz': swizzle<function, u32, 4, 2>
+            335..342 'p.yz.yx': swizzle<function, u32, 2, 2>
+            345..357 'vec2(99,100)': vec2<integer>
+            350..352 '99': integer
+            353..356 '100': integer
+            574..575 'p': ptr<function, vec4<u32>, read_write>
+            574..578 'p.yz': swizzle<function, u32, 4, 2>
+            574..580 'p.yz.y': ref<function, u32, read_write>
+            583..585 '99': integer
+            809..810 'p': ptr<function, vec4<u32>, read_write>
+            809..813 'p.zy': swizzle<function, u32, 4, 2>
+            809..816 'p.zy[1]': ref<function, u32, read_write>
+            814..815 '1': integer
+            819..821 '50': integer
+        "#]],
+    );
+}
+
+#[test]
+fn swizzle_writes_to_different_vector_components_may_race() {
+    check_infer(
+        "
+// requires swizzle_assignment;
+
+var<workgroup> w: vec4u;
+
+@compute @workgroup_size(2)
+fn this_races(@builtin(local_invocation_index) gid: u32) {
+    if (gid == 0) {
+    w.xy = vec2u(0,1);  // Writes the whole vector, races with other invocation.
+    } else {
+    w.zw = vec2u(2,3);  // Writes the whole vector, races with other invocation.
+    }
+}
+        ",
+        expect![[r#"
+            48..49 'w': ref<workgroup, vec4<u32>, read_write>
+            134..137 'gid': u32
+            154..157 'gid': u32
+            154..162 'gid == 0': bool
+            161..162 '0': integer
+            170..171 'w': ref<workgroup, vec4<u32>, read_write>
+            170..174 'w.xy': swizzle<workgroup, u32, 4, 2>
+            177..187 'vec2u(0,1)': vec2<u32>
+            183..184 '0': integer
+            185..186 '1': integer
+            264..265 'w': ref<workgroup, vec4<u32>, read_write>
+            264..268 'w.zw': swizzle<workgroup, u32, 4, 2>
+            271..281 'vec2u(2,3)': vec2<u32>
+            277..278 '2': integer
+            279..280 '3': integer
+        "#]],
+    );
+}
+
+#[test]
+fn swizzle_swizzle() {
+    check_infer(
+        "
+// requires swizzle_assignment;
+fn foo() {
+    var v = vec2();
+    let s = v.yx.xy;
+}
+        ",
+        expect![[r#"
+            51..52 'v': ref<function, vec2<i32>, read_write>
+            55..61 'vec2()': vec2<integer>
+            71..72 's': swizzle<function, i32, 2, 2>
+            75..76 'v': ref<function, vec2<i32>, read_write>
+            75..79 'v.yx': swizzle<function, i32, 2, 2>
+            75..82 'v.yx.xy': swizzle<function, i32, 2, 2>
+        "#]],
+    );
+}
+
+#[test]
+fn swizzle_swizzle_too_high_one() {
+    check_infer(
+        "
+// requires swizzle_assignment;
+fn foo() {
+    var v = vec2();
+    let s = v.yx.z;
+}
+        ",
+        expect![[r#"
+            51..52 'v': ref<function, vec2<i32>, read_write>
+            55..61 'vec2()': vec2<integer>
+            71..72 's': [error]
+            75..76 'v': ref<function, vec2<i32>, read_write>
+            75..79 'v.yx': swizzle<function, i32, 2, 2>
+            75..81 'v.yx.z': [error]
+            75..81 'v.yx.z': no such field `z` on type `swizzle<function, i32, 2, 2>`
+        "#]],
+    );
+}
+
+#[test]
+fn swizzle_swizzle_too_high_multiple() {
+    check_infer(
+        "
+// requires swizzle_assignment;
+fn foo() {
+    var v = vec2();
+    let s = v.yx.zz;
+}
+        ",
+        expect![[r#"
+            19..20 'v': ref<function, vec2<i32>, read_write>
+            23..29 'vec2()': vec2<integer>
+            39..40 's': [error]
+            43..44 'v': ref<function, vec2<i32>, read_write>
+            43..47 'v.yx': swizzle<function, i32, 2, 2>
+            43..50 'v.yx.zz': [error]
+            43..50 'v.yx.zz': no such field `zz` on type `swizzle<function, i32, 2, 2>`
+        "#]],
+    );
+}
+
+#[test]
+fn swizzle_swizzle_bad() {
+    check_infer(
+        "
+// requires swizzle_assignment;
+fn foo() {
+    var v = vec2();
+    let s = v.yx.c;
+}
+        ",
+        expect![[r#"
+            51..52 'v': ref<function, vec2<i32>, read_write>
+            55..61 'vec2()': vec2<integer>
+            71..72 's': [error]
+            75..76 'v': ref<function, vec2<i32>, read_write>
+            75..79 'v.yx': swizzle<function, i32, 2, 2>
+            75..81 'v.yx.c': [error]
+            75..81 'v.yx.c': no such field `c` on type `swizzle<function, i32, 2, 2>`
+        "#]],
+    );
+}
+
+#[test]
+fn readonly_ref_vec_is_not_swizzle() {
+    check_infer(
+        "
+// Has access mode 'read'
+@group(0) @binding(0) var<storage> robuf: vec4u;
+
+fn foo() {
+    robuf.xz = vec2u();
+}
+        ",
+        expect![[r#"
+            61..66 'robuf': ref<storage, vec4<u32>, read>
+            91..96 'robuf': ref<storage, vec4<u32>, read>
+            91..99 'robuf.xz': vec2<u32>
+            102..109 'vec2u()': vec2<u32>
+            91..99 'robuf.xz': cannot assign to non-reference `vec2<u32>`
+        "#]],
+    );
+}
+
+#[test]
+fn swizzle_compact() {
+    check_infer_with_verbosity(
+        TypeVerbosity::Compact,
+        "
+fn foo() {
+    var v = vec2();
+    let s = v.yx;
+}
+        ",
+        expect![[r#"
+            19..20 'v': ref<vec2<i32>>
+            23..29 'vec2()': vec2<integer>
+            39..40 's': swizzle<vec2<i32>, 2>
+            43..44 'v': ref<vec2<i32>>
+            43..47 'v.yx': swizzle<vec2<i32>, 2>
+        "#]],
+    );
+}
+
+#[test]
+fn swizzle_inner() {
+    check_infer_with_verbosity(
+        TypeVerbosity::Inner,
+        "
+fn foo() {
+    var v = vec2();
+    let s = v.yx;
+}
+        ",
+        expect![[r#"
+            19..20 'v': vec2<i32>
+            23..29 'vec2()': vec2<integer>
+            39..40 's': vec2<i32>
+            43..44 'v': vec2<i32>
+            43..47 'v.yx': vec2<i32>
+        "#]],
+    );
+}
+
+#[test]
+fn swizzle_conversion_rank_nonzero() {
+    check_infer(
+        "
+fn foo() {
+    var v = vec2(1);
+    bar(v.yx);
+}
+
+fn bar(v: vec2<u32>) { }
+        ",
+        expect![[r#"
+            19..20 'v': ref<function, vec2<i32>, read_write>
+            23..30 'vec2(1)': vec2<integer>
+            28..29 '1': integer
+            36..45 'bar(v.yx)': [error]
+            40..41 'v': ref<function, vec2<i32>, read_write>
+            40..44 'v.yx': swizzle<function, i32, 2, 2>
+            40..44 'v.yx': expected vec2<u32> but got swizzle<function, i32, 2, 2>
+            57..58 'v': vec2<u32>
+        "#]],
+    );
+}
+
+#[test]
+fn missing_swizzle_assignment() {
+    check_infer(
+        "
+// explicitly not testing swizzle_assignment
+// currently have to make the access mode 'read' to get this behavior
+@group(0) @binding(0) var<storage> robuf: vec4u;
+
+fn foo() {
+    robuf.xz = vec2u();
+}
+        ",
+        expect![[r#"
+            150..155 'robuf': ref<storage, vec4<u32>, read>
+            180..185 'robuf': ref<storage, vec4<u32>, read>
+            180..188 'robuf.xz': ref<storage, vec2<u32>, read>
+            191..198 'vec2u()': vec2<u32>
+        "#]],
+    );
+}

--- a/crates/hir_ty/src/tests/language_extensions/swizzle_assignment.rs
+++ b/crates/hir_ty/src/tests/language_extensions/swizzle_assignment.rs
@@ -1,6 +1,9 @@
 use expect_test::expect;
 
-use crate::{tests::{check_infer, check_infer_with_verbosity}, ty::pretty::TypeVerbosity};
+use crate::{
+    tests::{check_infer, check_infer_with_verbosity},
+    ty::pretty::TypeVerbosity,
+};
 
 #[test]
 fn reading_and_writing_via_swizzle_views_on_references() {
@@ -44,7 +47,7 @@ fn swizzle_read_and_write() {
             211..221 'vec2u(1,2)': vec2<u32>
             217..218 '1': integer
             219..220 '2': integer
-            568..569 'u': swizzle<function, u32, 4, 3>
+            568..569 'u': vec3<u32>
             572..573 'v': ref<function, vec4<u32>, read_write>
             572..577 'v.agb': swizzle<function, u32, 4, 3>
             653..654 'v': ref<function, vec4<u32>, read_write>
@@ -102,7 +105,7 @@ fn swizzle_read_and_write_via_pointer(p: ptr<function,vec4u>) {
             175..185 'vec2u(1,2)': vec2<u32>
             181..182 '1': integer
             183..184 '2': integer
-            250..251 'u': swizzle<function, u32, 4, 3>
+            250..251 'u': vec3<u32>
             254..255 'p': ptr<function, vec4<u32>, read_write>
             254..259 'p.agb': swizzle<function, u32, 4, 3>
             335..336 'p': ptr<function, vec4<u32>, read_write>
@@ -160,7 +163,7 @@ fn swizzle_read_and_write_via_pointer(p: ptr<function,vec4u>) {
             175..185 'vec2u(1,2)': vec2<u32>
             181..182 '1': integer
             183..184 '2': integer
-            250..251 'u': swizzle<function, u32, 4, 3>
+            250..251 'u': vec3<u32>
             254..255 'p': ptr<function, vec4<u32>, read_write>
             254..259 'p.agb': swizzle<function, u32, 4, 3>
             335..336 'p': ptr<function, vec4<u32>, read_write>
@@ -232,7 +235,7 @@ fn foo() {
         expect![[r#"
             51..52 'v': ref<function, vec2<i32>, read_write>
             55..61 'vec2()': vec2<integer>
-            71..72 's': swizzle<function, i32, 2, 2>
+            71..72 's': vec2<i32>
             75..76 'v': ref<function, vec2<i32>, read_write>
             75..79 'v.yx': swizzle<function, i32, 2, 2>
             75..82 'v.yx.xy': swizzle<function, i32, 2, 2>
@@ -273,13 +276,13 @@ fn foo() {
 }
         ",
         expect![[r#"
-            19..20 'v': ref<function, vec2<i32>, read_write>
-            23..29 'vec2()': vec2<integer>
-            39..40 's': [error]
-            43..44 'v': ref<function, vec2<i32>, read_write>
-            43..47 'v.yx': swizzle<function, i32, 2, 2>
-            43..50 'v.yx.zz': [error]
-            43..50 'v.yx.zz': no such field `zz` on type `swizzle<function, i32, 2, 2>`
+            51..52 'v': ref<function, vec2<i32>, read_write>
+            55..61 'vec2()': vec2<integer>
+            71..72 's': [error]
+            75..76 'v': ref<function, vec2<i32>, read_write>
+            75..79 'v.yx': swizzle<function, i32, 2, 2>
+            75..82 'v.yx.zz': [error]
+            75..82 'v.yx.zz': no such field `zz` on type `swizzle<function, i32, 2, 2>`
         "#]],
     );
 }
@@ -320,9 +323,8 @@ fn foo() {
         expect![[r#"
             61..66 'robuf': ref<storage, vec4<u32>, read>
             91..96 'robuf': ref<storage, vec4<u32>, read>
-            91..99 'robuf.xz': vec2<u32>
+            91..99 'robuf.xz': ref<storage, vec2<u32>, read>
             102..109 'vec2u()': vec2<u32>
-            91..99 'robuf.xz': cannot assign to non-reference `vec2<u32>`
         "#]],
     );
 }
@@ -340,7 +342,7 @@ fn foo() {
         expect![[r#"
             19..20 'v': ref<vec2<i32>>
             23..29 'vec2()': vec2<integer>
-            39..40 's': swizzle<vec2<i32>, 2>
+            39..40 's': vec2<i32>
             43..44 'v': ref<vec2<i32>>
             43..47 'v.yx': swizzle<vec2<i32>, 2>
         "#]],
@@ -408,6 +410,23 @@ fn foo() {
             180..185 'robuf': ref<storage, vec4<u32>, read>
             180..188 'robuf.xz': ref<storage, vec2<u32>, read>
             191..198 'vec2u()': vec2<u32>
+        "#]],
+    );
+}
+
+#[test]
+fn concrete_swizzle() {
+    check_infer(
+        "
+// enable swizzle_assignment;
+fn foo() {
+    let v = vec2().xy;
+}
+        ",
+        expect![[r#"
+            49..50 'v': vec2<i32>
+            53..59 'vec2()': vec2<integer>
+            53..62 'vec2().xy': vec2<integer>
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -752,7 +752,7 @@ fn ref_vec_read_swizzle() {
             41..42 'v': ref<storage, vec3<f32>, read>
             75..76 'x': vec2<f32>
             79..80 'v': ref<storage, vec3<f32>, read>
-            79..83 'v.yx': ref<storage, vec2<f32>, read>
+            79..83 'v.yx': vec2<f32>
         "#]],
     );
 }
@@ -2693,6 +2693,25 @@ const NONE = 0x0;
         expect![[r#"
             6..10 'NONE': integer
             13..16 '0x0': integer
+        "#]],
+    );
+}
+
+#[test]
+fn assignment_not_writable() {
+    check_infer(
+        "
+@group(0) @binding(0) var<storage> x: vec2u;
+
+fn foo() {
+    x = vec2u();
+}
+",
+        expect![[r#"
+            35..36 'x': ref<storage, vec2<u32>, read>
+            61..62 'x': ref<storage, vec2<u32>, read>
+            65..72 'vec2u()': vec2<u32>
+            61..62 'x': cannot assign to value with `read` access mode
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -1,7 +1,10 @@
 use expect_test::expect;
 use syntax::Capabilities;
 
-use crate::tests::{check_infer, check_infer_with_capabilities};
+use crate::{
+    tests::{check_infer, check_infer_with_capabilities, check_infer_with_verbosity},
+    ty::pretty::TypeVerbosity,
+};
 
 #[test]
 fn type_alias_in_struct() {
@@ -628,24 +631,170 @@ fn f() {
 }
 
 #[test]
-fn vec_xy_is_not_ref() {
+fn vec_swizzle_too_high_one() {
     check_infer(
         "
         fn foo() {
-            var v = vec2(1, 2);
-            v.xy = v.yx;
+            let x = vec2();
+            let s = x.z;
         }
         ",
         expect![[r#"
-            19..20 'v': ref<function, vec2<i32>, read_write>
-            23..33 'vec2(1, 2)': vec2<integer>
-            28..29 '1': integer
-            31..32 '2': integer
-            39..40 'v': ref<function, vec2<i32>, read_write>
-            39..43 'v.xy': vec2<i32>
-            46..47 'v': ref<function, vec2<i32>, read_write>
-            46..50 'v.yx': vec2<i32>
-            39..43 'v.xy': cannot assign to non-reference `vec2<i32>`
+            19..20 'x': vec2<i32>
+            23..29 'vec2()': vec2<integer>
+            39..40 's': [error]
+            43..44 'x': vec2<i32>
+            43..46 'x.z': [error]
+            43..46 'x.z': no such field `z` on type `vec2<i32>`
+        "#]],
+    );
+}
+
+#[test]
+fn vec_swizzle_too_high_multiple() {
+    check_infer(
+        "
+        fn foo() {
+            let x = vec2();
+            let s = x.zz;
+        }
+        ",
+        expect![[r#"
+            19..20 'x': vec2<i32>
+            23..29 'vec2()': vec2<integer>
+            39..40 's': [error]
+            43..44 'x': vec2<i32>
+            43..47 'x.zz': [error]
+            43..47 'x.zz': no such field `zz` on type `vec2<i32>`
+        "#]],
+    );
+}
+
+#[test]
+fn vec_swizzle_bad() {
+    check_infer(
+        "
+        fn foo() {
+            let v = vec2();
+            let s = v.c;
+        }
+        ",
+        expect![[r#"
+            19..20 'v': vec2<i32>
+            23..29 'vec2()': vec2<integer>
+            39..40 's': [error]
+            43..44 'v': vec2<i32>
+            43..46 'v.c': [error]
+            43..46 'v.c': no such field `c` on type `vec2<i32>`
+        "#]],
+    );
+}
+
+#[test]
+fn mixing_swizzles() {
+    check_infer(
+        "
+fn foo() {
+    let v = vec2().rx;
+}
+        ",
+        expect![[r#"
+            19..20 'v': [error]
+            23..29 'vec2()': vec2<integer>
+            23..32 'vec2().rx': [error]
+            23..32 'vec2().rx': no such field `rx` on type `vec2<integer>`
+        "#]],
+    );
+}
+
+#[test]
+fn more_than_four_swizzle_components() {
+    check_infer(
+        "
+fn foo() {
+    let v = vec2().rrrrr;
+}
+        ",
+        expect![[r#"
+            19..20 'v': [error]
+            23..29 'vec2()': vec2<integer>
+            23..35 'vec2().rrrrr': [error]
+            23..35 'vec2().rrrrr': no such field `rrrrr` on type `vec2<integer>`
+        "#]],
+    );
+}
+
+#[test]
+fn coverage_vec4_r() {
+    check_infer(
+        "
+        fn foo() {
+            let v = vec4().rrrr;
+        }
+        ",
+        expect![[r#"
+            19..20 'v': vec4<i32>
+            23..29 'vec4()': vec4<integer>
+            23..34 'vec4().rrrr': vec4<integer>
+        "#]],
+    );
+}
+
+#[test]
+fn ref_vec_read_swizzle() {
+    check_infer(
+        "
+        @group(0) @binding(0)
+        var<storage, read> v: vec3<f32>;
+
+        fn foo() {
+            let x = v.yx;
+        }
+        ",
+        expect![[r#"
+            41..42 'v': ref<storage, vec3<f32>, read>
+            75..76 'x': vec2<f32>
+            79..80 'v': ref<storage, vec3<f32>, read>
+            79..83 'v.yx': ref<storage, vec2<f32>, read>
+        "#]],
+    );
+}
+
+#[test]
+fn bad_swizzle_assignment() {
+    check_infer(
+        "
+        fn foo() {
+            var x = vec2();
+            x.xy = true;
+        }
+        ",
+        expect![[r#"
+            19..20 'x': ref<function, vec2<i32>, read_write>
+            23..29 'vec2()': vec2<integer>
+            35..36 'x': ref<function, vec2<i32>, read_write>
+            35..39 'x.xy': swizzle<function, i32, 2, 2>
+            42..46 'true': bool
+            42..46 'true': expected vec2<i32> but got bool
+        "#]],
+    );
+}
+
+#[test]
+fn assign_to_error() {
+    check_infer(
+        "
+        var x: Foo;
+
+        fn foo() {
+            x = x;
+        }
+        ",
+        expect![[r#"
+            4..5 'x': ref<handle, [error], read>
+            7..10 'Foo': `Foo` not found in scope
+            28..29 'x': ref<handle, [error], read>
+            32..33 'x': ref<handle, [error], read>
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -1,10 +1,7 @@
 use expect_test::expect;
 use syntax::Capabilities;
 
-use crate::{
-    tests::{check_infer, check_infer_with_capabilities, check_infer_with_verbosity},
-    ty::pretty::TypeVerbosity,
-};
+use crate::tests::{check_infer, check_infer_with_capabilities};
 
 #[test]
 fn type_alias_in_struct() {

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -781,17 +781,17 @@ fn bad_swizzle_assignment() {
 fn assign_to_error() {
     check_infer(
         "
-        var x: Foo;
+        var<workgroup> x: Foo;
 
         fn foo() {
             x = x;
         }
         ",
         expect![[r#"
-            4..5 'x': ref<handle, [error], read>
-            7..10 'Foo': `Foo` not found in scope
-            28..29 'x': ref<handle, [error], read>
-            32..33 'x': ref<handle, [error], read>
+            15..16 'x': ref<workgroup, [error], read_write>
+            18..21 'Foo': `Foo` not found in scope
+            39..40 'x': ref<workgroup, [error], read_write>
+            43..44 'x': ref<workgroup, [error], read_write>
         "#]],
     );
 }

--- a/crates/hir_ty/src/ty.rs
+++ b/crates/hir_ty/src/ty.rs
@@ -3,7 +3,7 @@ pub mod pretty;
 use std::{borrow::Cow, fmt, hash, num::NonZeroU32};
 
 use base_db::{Intern as _, Lookup as _, impl_intern_key, impl_intern_lookup};
-use hir_def::db::StructId;
+use hir_def::{db::StructId, item_tree::Name};
 use wgsl_types::{
     syntax::{AccessMode, AddressSpace, TexelFormat},
     tplt::AccelerationStructureTags,
@@ -35,6 +35,7 @@ impl Type {
             | TypeKind::Texture(_)
             | TypeKind::RayQuery(_)
             | TypeKind::AccelerationStructure(_)
+            | TypeKind::SwizzleView(_)
             | TypeKind::Sampler(_) => false,
             TypeKind::Atomic(atomic_type) => atomic_type.inner.is_err(db),
             TypeKind::Vector(vector_type) => vector_type.component_type.is_err(db),
@@ -139,9 +140,10 @@ impl Type {
             | TypeKind::Texture(_)
             | TypeKind::Sampler(_)
             | TypeKind::Reference(_)
+            | TypeKind::Pointer(_)
             | TypeKind::RayQuery(_)
-            | TypeKind::AccelerationStructure(_)
-            | TypeKind::Pointer(_) => false,
+            | TypeKind::SwizzleView(_)
+            | TypeKind::AccelerationStructure(_) => false,
         }
     }
 }
@@ -172,6 +174,7 @@ pub enum TypeKind {
     Sampler(SamplerType),
     Reference(Reference),
     Pointer(Pointer),
+    SwizzleView(SwizzleView),
     RayQuery(Option<AccelerationStructureTags>),
     AccelerationStructure(Option<AccelerationStructureTags>),
     // internal
@@ -208,6 +211,7 @@ impl TypeKind {
             | Self::Scalar(_)
             | Self::Atomic(_)
             | Self::Vector(_)
+            | Self::SwizzleView(_)
             | Self::Matrix(_)
             | Self::Struct(_)
             | Self::BuiltinStruct(_)
@@ -254,6 +258,8 @@ impl TypeKind {
                 inner: inner.kind(db).concretize(db)?.intern(db),
             }),
             Self::Error
+            // `S` is a concrete scalar type
+            | Self::SwizzleView(_)
             | Self::Scalar(_)
             | Self::Atomic(_)
             | Self::Struct(_)
@@ -275,6 +281,7 @@ impl TypeKind {
             Self::Error => true,
             Self::Atomic(_)
             | Self::Vector(_)
+            | Self::SwizzleView(_)
             | Self::Matrix(_)
             | Self::Struct(_)
             | Self::BuiltinStruct(_)
@@ -288,6 +295,7 @@ impl TypeKind {
         }
     }
 
+    /// The index expression must be of integer scalar type.
     #[must_use]
     pub const fn is_index(&self) -> bool {
         match self {
@@ -298,6 +306,7 @@ impl TypeKind {
             | Self::Atomic(_)
             | Self::BuiltinStruct(_)
             | Self::Vector(_)
+            | Self::SwizzleView(_)
             | Self::Matrix(_)
             | Self::Struct(_)
             | Self::Array(_)
@@ -339,6 +348,7 @@ impl TypeKind {
             | Self::Reference(_)
             | Self::Pointer(_)
             | Self::RayQuery(_)
+            | Self::SwizzleView(_)
             | Self::AccelerationStructure(_)
             | Self::Error => false,
         }
@@ -416,6 +426,7 @@ impl TypeKind {
             | Self::Sampler(_)
             | Self::Reference(_)
             | Self::Pointer(_)
+            | Self::SwizzleView(_)
             | Self::RayQuery(_)
             | Self::AccelerationStructure(_) => false,
         }
@@ -440,6 +451,7 @@ impl TypeKind {
             Self::Scalar(_)
             | Self::Atomic(_)
             | Self::Vector(_)
+            | Self::SwizzleView(_)
             | Self::Matrix(_)
             | Self::Array(_)
             | Self::BuiltinStruct(_)
@@ -489,6 +501,7 @@ impl TypeKind {
             }) => inner.contains_struct(db, r#struct),
             Self::Scalar(_)
             | Self::Vector(_)
+            | Self::SwizzleView(_)
             | Self::Matrix(_)
             | Self::Sampler(_)
             | Self::Texture(_)

--- a/crates/hir_ty/src/ty.rs
+++ b/crates/hir_ty/src/ty.rs
@@ -568,6 +568,20 @@ fn conversion_rank(
                 component_type: ty2,
             }),
         ) if n1 == n2 => conversion_rank(&ty1.kind(db), &ty2.kind(db), db),
+        // Apply the Swizzle View Load Rule to load a vector value from a swizzle view.
+        // https://www.w3.org/TR/WGSL/#swizzle-view-load-rule
+        (
+            TypeKind::SwizzleView(SwizzleView {
+                address_space,
+                component_type: ty1,
+                vector_size,
+                index_list: IndexList { indices, length },
+            }),
+            TypeKind::Vector(VectorType {
+                size: n2,
+                component_type: ty2,
+            }),
+        ) if length == n2 && ty1.kind(db) == ty2.kind(db) => Some(0),
         (
             TypeKind::Matrix(MatrixType {
                 columns: c1,
@@ -727,6 +741,20 @@ impl VecSize {
     /// Panics if self is the [`BoundVariable`] variant.
     #[must_use]
     pub const fn as_u8(self) -> u8 {
+        match self {
+            Self::Two => 2,
+            Self::Three => 3,
+            Self::Four => 4,
+        }
+    }
+
+    /// Get the dimensionality of the vector (can be `2`, `3`, or `4`) as a [`usize`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if self is the [`BoundVariable`] variant.
+    #[must_use]
+    pub const fn as_usize(self) -> usize {
         match self {
             Self::Two => 2,
             Self::Three => 3,
@@ -899,5 +927,149 @@ impl fmt::Display for TextureDimensionality {
             Self::D3 => formatter.write_str("3d"),
             Self::Cube => formatter.write_str("cube"),
         }
+    }
+}
+
+#[expect(clippy::doc_paragraphs_missing_punctuation, reason = "false positive")]
+/// <https://www.w3.org/TR/WGSL/#swizzle-view-types>
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SwizzleView {
+    /// `ptr<AS,vecN<S>,read_write>` is a valid pointer type.
+    pub address_space: AddressSpace,
+    /// `S` is a concrete scalar type.
+    pub component_type: Type,
+    /// `N` and `K` are integers such that both `vecN<S>` and `vecK<S>` are valid vector types.
+    pub vector_size: VecSize,
+    /// `IndexList = « Idx0, ..., IdxK−1 »`
+    pub index_list: IndexList,
+}
+
+impl SwizzleView {
+    #[must_use]
+    pub const fn vector(&self) -> VectorType {
+        VectorType {
+            size: self.index_list.length,
+            component_type: self.component_type,
+        }
+    }
+
+    #[expect(clippy::doc_paragraphs_missing_punctuation, reason = "false positive")]
+    /// <https://www.w3.org/TR/WGSL/#swizzle-view-load-rule>
+    #[must_use]
+    pub fn loaded(
+        &self,
+        db: &dyn HirDatabase,
+    ) -> Type {
+        TypeKind::Vector(self.vector()).intern(db)
+    }
+}
+
+#[expect(
+    clippy::upper_case_acronyms,
+    reason = "edge case where this is more readable"
+)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum VecIndex {
+    RX,
+    GY,
+    BZ,
+    AW,
+}
+
+impl VecIndex {
+    /// Get the dimensionality of the vector (can be `2`, `3`, or `4`) as a [`u8`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if self is the [`BoundVariable`] variant.
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        match self {
+            Self::RX => 1,
+            Self::GY => 2,
+            Self::BZ => 3,
+            Self::AW => 4,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IndexList {
+    pub indices: [VecIndex; 4],
+    pub length: VecSize,
+}
+
+impl<'il> IntoIterator for &'il IndexList {
+    type Item = &'il VecIndex;
+    type IntoIter = std::slice::Iter<'il, VecIndex>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SwizzleSet {
+    Rgba,
+    Xyzw,
+}
+
+const fn parse_component(character: char) -> Option<(SwizzleSet, VecIndex)> {
+    match character {
+        'r' => Some((SwizzleSet::Rgba, VecIndex::RX)),
+        'g' => Some((SwizzleSet::Rgba, VecIndex::GY)),
+        'b' => Some((SwizzleSet::Rgba, VecIndex::BZ)),
+        'a' => Some((SwizzleSet::Rgba, VecIndex::AW)),
+
+        'x' => Some((SwizzleSet::Xyzw, VecIndex::RX)),
+        'y' => Some((SwizzleSet::Xyzw, VecIndex::GY)),
+        'z' => Some((SwizzleSet::Xyzw, VecIndex::BZ)),
+        'w' => Some((SwizzleSet::Xyzw, VecIndex::AW)),
+
+        _ => None,
+    }
+}
+
+pub enum ParseIndexListError {
+    One(VecIndex),
+    MoreThanFour,
+    InvalidLetter,
+    MixingSwizzles,
+}
+
+impl IndexList {
+    pub fn parse_name(value: &Name) -> Result<Self, ParseIndexListError> {
+        let characters: Vec<_> = value.as_str().chars().collect();
+
+        let (set, first) =
+            parse_component(characters[0]).ok_or(ParseIndexListError::InvalidLetter)?;
+
+        let length = match characters.len() {
+            1 => return Err(ParseIndexListError::One(first)),
+            2 => VecSize::Two,
+            3 => VecSize::Three,
+            4 => VecSize::Four,
+            _ => return Err(ParseIndexListError::MoreThanFour),
+        };
+
+        let mut indices = [VecIndex::RX; 4];
+        indices[0] = first;
+
+        for (destination, &source) in indices[1..].iter_mut().zip(&characters[1..]) {
+            let (other_set, index) =
+                parse_component(source).ok_or(ParseIndexListError::InvalidLetter)?;
+
+            if other_set != set {
+                return Err(ParseIndexListError::MixingSwizzles);
+            }
+
+            *destination = index;
+        }
+
+        Ok(Self { indices, length })
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, VecIndex> {
+        self.indices[..self.length.as_usize()].iter()
     }
 }

--- a/crates/hir_ty/src/ty.rs
+++ b/crates/hir_ty/src/ty.rs
@@ -257,9 +257,8 @@ impl TypeKind {
                 rows: *rows,
                 inner: inner.kind(db).concretize(db)?.intern(db),
             }),
+            Self::SwizzleView(swizzle_view) => swizzle_view.loaded(),
             Self::Error
-            // `S` is a concrete scalar type
-            | Self::SwizzleView(_)
             | Self::Scalar(_)
             | Self::Atomic(_)
             | Self::Struct(_)
@@ -956,11 +955,8 @@ impl SwizzleView {
     #[expect(clippy::doc_paragraphs_missing_punctuation, reason = "false positive")]
     /// <https://www.w3.org/TR/WGSL/#swizzle-view-load-rule>
     #[must_use]
-    pub fn loaded(
-        &self,
-        db: &dyn HirDatabase,
-    ) -> Type {
-        TypeKind::Vector(self.vector()).intern(db)
+    pub const fn loaded(&self) -> TypeKind {
+        TypeKind::Vector(self.vector())
     }
 }
 

--- a/crates/hir_ty/src/ty/pretty.rs
+++ b/crates/hir_ty/src/ty/pretty.rs
@@ -204,6 +204,38 @@ fn write_type(
             write!(formatter, ">")?;
             Ok(())
         },
+        TypeKind::SwizzleView(swizzle_type) => {
+            match verbosity {
+                TypeVerbosity::Full => {
+                    write!(
+                        formatter,
+                        "swizzle<{}, {}, {}, {}>",
+                        swizzle_type.address_space,
+                        pretty_type_with_verbosity(db, swizzle_type.component_type, verbosity),
+                        swizzle_type.vector_size,
+                        swizzle_type.index_list.length,
+                    )?;
+                },
+                TypeVerbosity::Compact => {
+                    write!(
+                        formatter,
+                        "swizzle<vec{}<{}>, {}>",
+                        swizzle_type.vector_size,
+                        pretty_type_with_verbosity(db, swizzle_type.component_type, verbosity),
+                        swizzle_type.index_list.length,
+                    )?;
+                },
+                TypeVerbosity::Inner => {
+                    write!(
+                        formatter,
+                        "vec{}<{}>",
+                        swizzle_type.index_list.length,
+                        pretty_type_with_verbosity(db, swizzle_type.component_type, verbosity),
+                    )?;
+                },
+            }
+            Ok(())
+        },
         TypeKind::Matrix(matrix_type) => {
             write!(
                 formatter,

--- a/crates/hir_ty/src/validate.rs
+++ b/crates/hir_ty/src/validate.rs
@@ -177,6 +177,7 @@ pub fn validate_address_space<DiagnosticBuilder>(
                 TypeKind::Scalar(_)
                 | TypeKind::Atomic(_)
                 | TypeKind::Vector(_)
+                | TypeKind::SwizzleView(_)
                 | TypeKind::Matrix(_)
                 | TypeKind::Array(_)
                 | TypeKind::Struct(_)

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -285,7 +285,7 @@ pub fn diagnostics(
                     let frange = original_file_range(db, left_side.file_id, source.syntax());
                     Diagnostic::new(
                         DiagnosticCode("1"),
-                        "cannot assign to value with access mode `read`".to_owned(),
+                        "cannot assign to value with `read` access mode".to_owned(),
                         frange.range,
                     )
                 },

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -280,6 +280,15 @@ pub fn diagnostics(
                         frange.range,
                     )
                 },
+                AnyDiagnostic::AssignmentNotWritable { left_side } => {
+                    let source = left_side.value.to_node(&root);
+                    let frange = original_file_range(db, left_side.file_id, source.syntax());
+                    Diagnostic::new(
+                        DiagnosticCode("1"),
+                        "cannot assign to value with access mode `read`".to_owned(),
+                        frange.range,
+                    )
+                },
                 AnyDiagnostic::NotConstructible { expression, r#type } => {
                     debug_assert!(!r#type.is_err(db));
                     let source = expression.value.to_node(&root);

--- a/crates/ide-diagnostics/src/tests.rs
+++ b/crates/ide-diagnostics/src/tests.rs
@@ -712,3 +712,19 @@ var<workgroup> c: Foo;
         "#]],
     );
 }
+
+#[test]
+fn assignment_not_writable() {
+    check_diagnostics(
+        "
+@group(0) @binding(0) var<storage> x: vec2u;
+
+fn foo() {
+    x = vec2u();
+}
+",
+        expect![[r#"
+            61..62 wgsl-analyzer Error 1: cannot assign to value with `read` access mode
+        "#]],
+    );
+}

--- a/crates/ide_completion/src/completions/dot.rs
+++ b/crates/ide_completion/src/completions/dot.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use hir_def::signature::StructSignature;
-use hir_ty::ty::TypeKind;
+use hir_ty::ty::{SwizzleView, TypeKind, VectorType};
 
 use super::Completions;
 use crate::{
@@ -15,7 +15,7 @@ pub(crate) fn complete_dot(
 ) -> Option<()> {
     let _p = tracing::info_span!("complete_dot").entered();
     let Some(ImmediateLocation::FieldAccess { expression }) = &context.completion_location else {
-        return Some(());
+        return None;
     };
     match context
         .semantics
@@ -27,8 +27,17 @@ pub(crate) fn complete_dot(
         .type_of_expression(&expression.expression()?)?
         .kind(context.db)
     {
-        TypeKind::Vector(vector) => {
-            vector_completions(accumulator, context, expression, &vector);
+        TypeKind::Vector(VectorType {
+            size,
+            component_type: _,
+        })
+        | TypeKind::SwizzleView(SwizzleView {
+            vector_size: size,
+            address_space: _,
+            component_type: _,
+            index_list: _,
+        }) => {
+            vector_completions(accumulator, context, expression, size);
             Some(())
         },
         TypeKind::Struct(r#struct) => {
@@ -44,8 +53,18 @@ pub(crate) fn complete_dot(
             address_space,
             inner,
             access_mode,
-        }) if let TypeKind::Vector(vector) = inner.kind(context.db) => {
-            vector_completions(accumulator, context, expression, &vector);
+        }) if let TypeKind::Vector(VectorType {
+            size,
+            component_type: _,
+        })
+        | TypeKind::SwizzleView(SwizzleView {
+            vector_size: size,
+            address_space: _,
+            component_type: _,
+            index_list: _,
+        }) = inner.kind(context.db) =>
+        {
+            vector_completions(accumulator, context, expression, size);
             Some(())
         },
         TypeKind::Reference(hir_ty::ty::Reference {
@@ -121,7 +140,7 @@ fn vector_completions(
     accumulator: &mut Completions,
     context: &CompletionContext<'_>,
     expression: &syntax::ast::FieldExpression,
-    vector_type: &hir_ty::ty::VectorType,
+    size: hir_ty::ty::VecSize,
 ) {
     let field_text = expression
         .field()
@@ -130,7 +149,7 @@ fn vector_completions(
         .unwrap_or_default();
 
     if is_swizzleable(&field_text) {
-        let size: usize = vector_type.size.as_u8().into();
+        let size: usize = size.as_u8().into();
         debug_assert!(
             (MIN_VECTOR_SIZE..=MAX_VECTOR_SIZE).contains(&size),
             "Invalid vector size: {size}"

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -67,10 +67,12 @@ pub fn completions(
     let (context) = &CompletionContext::new(db, position, config, trigger_character)?;
     let mut completions = Completions::default();
 
-    completions::dot::complete_dot(&mut completions, context);
-    // TODO: make completions context-sensitive
-    // https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1321
-    completions::expression::complete_names_in_scope(&mut completions, context);
+    let dot = completions::dot::complete_dot(&mut completions, context);
+    if dot.is_none() {
+        // TODO: make completions context-sensitive
+        // https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1321
+        completions::expression::complete_names_in_scope(&mut completions, context);
+    }
 
     Some(completions.into())
 }

--- a/crates/ide_completion/src/tests/module_items.rs
+++ b/crates/ide_completion/src/tests/module_items.rs
@@ -56,6 +56,41 @@ fn complete_vec_field() {
 }
 
 #[test]
+fn complete_swizzle_field() {
+    check(
+        "
+        fn test() {
+            var test = vec2(0);
+            let x = test.xy.r$0;
+        }
+        ",
+        expect![[r#"
+            field r
+            field rg
+            field rr
+        "#]],
+    );
+}
+
+#[test]
+fn complete_ptr_swizzle_field() {
+    check(
+        "
+        fn test() {
+            var test = vec2(0);
+            let p = &test;
+            let x = p.z$0;
+        }
+        ",
+        expect![[r#"
+            field z
+            field zx
+            field zy
+        "#]],
+    );
+}
+
+#[test]
 fn complete_function() {
     (
         completion_list(

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -385,6 +385,7 @@ impl<'source> ParserCallbacks<'source> for Parser<'source> {
             "linear_indexing" => self.context.extensions.linear_indexing = true,
             "immediate_address_space" => self.context.extensions.immediate_address_space = true,
             "buffer_view" => self.context.extensions.buffer_view = true,
+            "swizzle_assignment" => self.context.extensions.swizzle_assignment = true,
             _ => {
                 diagnostics.push(self.create_diagnostic(
                     self.cst.span(node_ref),

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -491,6 +491,7 @@ impl LanguageExtensionName {
             "linear_indexing" => LE::LinearIndexing,
             "immediate_address_space" => LE::ImmediateAddressSpace,
             "buffer_view" => LE::BufferView,
+            "swizzle_assignment" => LE::SwizzleAssignment,
             _ => return Err(UnknownExtension),
         })
     }
@@ -557,6 +558,12 @@ pub enum LanguageExtension {
     /// Enables the use of buffer types and the `buffer_view` built-in functions.
     /// Allow the declaration of variables with an opaque store type that can be reinterpreted as other host-shareable types.
     BufferView,
+
+    /// Supports swizzle view types.
+    ///
+    /// This enables swizzle assignments:
+    /// a single assignment statement can update multiple components of a vector without having to update the entire vector.
+    SwizzleAssignment,
 }
 
 impl HasAttributes for Directive {}

--- a/crates/syntax/src/tests.rs
+++ b/crates/syntax/src/tests.rs
@@ -470,9 +470,9 @@ fn enable_extension_names() {
 fn language_extension_names() {
     let parsed = check_errors(
         "
-        requires readonly_and_readwrite_storage_textures, packed_4x8_integer_dot_product, unrestricted_pointer_parameters, pointer_composite_access, uniform_buffer_standard_layout, subgroup_id, subgroup_uniformity, texture_and_sampler_let, texture_formats_tier1, linear_indexing, immediate_address_space, buffer_view, the_extension_does_not_exist;
+        requires readonly_and_readwrite_storage_textures, packed_4x8_integer_dot_product, unrestricted_pointer_parameters, pointer_composite_access, uniform_buffer_standard_layout, subgroup_id, subgroup_uniformity, texture_and_sampler_let, texture_formats_tier1, linear_indexing, immediate_address_space, buffer_view, swizzle_assignment, the_extension_does_not_exist;
         ",
-        expect!["error at 319..347: unknown extension: `the_extension_does_not_exist`"],
+        expect!["error at 339..367: unknown extension: `the_extension_does_not_exist`"],
     );
     let items = vec![
         Ok(LanguageExtension::ReadonlyAndReadwriteStorageTextures),
@@ -487,6 +487,7 @@ fn language_extension_names() {
         Ok(LanguageExtension::LinearIndexing),
         Ok(LanguageExtension::ImmediateAddressSpace),
         Ok(LanguageExtension::BufferView),
+        Ok(LanguageExtension::SwizzleAssignment),
         Err(UnknownExtension),
     ];
     let map = parsed


### PR DESCRIPTION
# Objective

Add support for the spec change in https://github.com/gpuweb/gpuweb/pull/5268

## Solution

Implement according to the spec (I think)

Left open questions in the spec here: https://github.com/gpuweb/gpuweb/issues/6941

## Testing

See test data change. Added examples as test cases. Language extensions are commented out so that when we add diagnostics for missing language extensions, it shows up as a failed expectation.

## Showcase

<img width="862" height="527" alt="Screenshot_2026-08-26_06-17-24" src="https://github.com/user-attachments/assets/fba0e8f4-4cd4-41f6-a3ba-31d9359f8f89" />
