### PR TITLE
fix unnecessary diagnostic for handle address space validation

### DIFF
--- a/crates/hir_ty/src/validate.rs
+++ b/crates/hir_ty/src/validate.rs
@@ -164,15 +164,16 @@ pub fn validate_address_space<DiagnosticBuilder>(
                 ]));
             }
             match r#type.as_ref() {
-                TypeKind::Sampler(_)
+                // optimistic about using errors
+                TypeKind::Error
+                | TypeKind::Sampler(_)
                 | TypeKind::Texture(_)
                 | TypeKind::Array(ArrayType {
                     binding_array: true,
                     inner: _,
                     size: _,
                 }) => {},
-                TypeKind::Error
-                | TypeKind::Scalar(_)
+                TypeKind::Scalar(_)
                 | TypeKind::Atomic(_)
                 | TypeKind::Vector(_)
                 | TypeKind::Matrix(_)

--- a/crates/ide-diagnostics/src/tests.rs
+++ b/crates/ide-diagnostics/src/tests.rs
@@ -263,7 +263,6 @@ var<storage
             22..25 wgsl-analyzer Error 12: address space is only valid for handle or texture types
             26..33 wgsl-analyzer Error 21: unexpected template argument
             26..33 wgsl-analyzer Error 21: unexpected template argument
-            89..92 wgsl-analyzer Error 12: address space is only valid for handle or texture types
         "#]],
     );
 }
@@ -330,7 +329,6 @@ fn binding_array_invalid() {
 @group(0) @binding(0) var textures: binding_array;
 ",
         expect![[r#"
-            22..25 wgsl-analyzer Error 12: address space is only valid for handle or texture types
             36..49 wgsl-analyzer Error 13: missing template arguments
         "#]],
     );


### PR DESCRIPTION
# Objective

diagnostics stemming from errors that already have diagnostics are not shown

## Solution

validate the handle address space optimistically

## Testing

tests updated
