### PR TITLE
support raytracing naga extensions

### DIFF
--- a/crates/edition/src/lib.rs
+++ b/crates/edition/src/lib.rs
@@ -146,7 +146,7 @@ pub struct ExtensionsConfig {
 
     // TODO: actually implement https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1388
     /// Enables the `wgpu_ray_tracing_pipeline` extension, native only.
-    pub wgpu_ray_tracing_pipelines: bool,
+    pub wgpu_ray_tracing_pipeline: bool,
 
     // TODO: actually implement https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1406
     /// Enables the `wgpu_cooperative_matrix` extension, native only.

--- a/crates/hir/src/definition.rs
+++ b/crates/hir/src/definition.rs
@@ -17,7 +17,7 @@ pub enum Definition {
     BuiltinFunction(Name),
     BuiltinType(Name),
     BuiltinTypeGenerator(Name),
-    // BuiltinTypeConstructor(Name),
+    BuiltinTypeConstructor(Name),
     BuiltinEnumerant(Name),
     BuiltinDeclaration(Name),
 }
@@ -72,7 +72,7 @@ impl From<ResolveKind> for Definition {
             ResolveKind::BuiltinFunction(name) => Self::BuiltinFunction(name),
             ResolveKind::BuiltinType(name) => Self::BuiltinType(name),
             ResolveKind::BuiltinTypeGenerator(name) => Self::BuiltinTypeGenerator(name),
-            // ResolveKind::BuiltinTypeConstructor(name) => Self::BuiltinTypeConstructor(name),
+            ResolveKind::BuiltinTypeConstructor(name) => Self::BuiltinTypeConstructor(name),
             ResolveKind::BuiltinEnumerant(name) => Self::BuiltinEnumerant(name),
             ResolveKind::BuiltinDeclaration(name) => Self::BuiltinDeclaration(name),
         }

--- a/crates/hir/src/diagnostics/global_variable.rs
+++ b/crates/hir/src/diagnostics/global_variable.rs
@@ -11,12 +11,12 @@ pub enum GlobalVariableDiagnostic {
     AddressSpaceError(AddressSpaceError),
 }
 
-pub fn collect<Function>(
+pub fn collect<DiagnosticsBuilder>(
     db: &dyn HirDatabase,
     variable: GlobalVariableId,
-    mut diagnostic_builder: Function,
+    mut diagnostic_builder: DiagnosticsBuilder,
 ) where
-    Function: FnMut(GlobalVariableDiagnostic),
+    DiagnosticsBuilder: FnMut(GlobalVariableDiagnostic),
 {
     let inference = InferenceResult::of(db, DefinitionWithBodyId::GlobalVariable(variable));
     let type_kind = inference.return_type().kind(db);

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -54,7 +54,7 @@ pub enum ResolveKind {
     BuiltinFunction(Name),
     BuiltinType(Name),
     BuiltinTypeGenerator(Name),
-    // BuiltinTypeConstructor(Name),
+    BuiltinTypeConstructor(Name),
     BuiltinEnumerant(Name),
     BuiltinDeclaration(Name),
 }
@@ -336,13 +336,7 @@ impl<'db> Resolver<'db> {
                         Some(ResolveKind::BuiltinTypeGenerator(name.clone()))
                     } else if wgsl_types::idents::BUILTIN_CONSTRUCTOR_NAMES.contains(&name.as_str())
                     {
-                        debug_assert!(
-                            false,
-                            "builtin constructor `{}` is unimplemented in wgsl-analyzer",
-                            name.as_str()
-                        );
-                        None
-                        // Some(ResolveKind::BuiltinTypeConstructor(name.clone()))
+                        Some(ResolveKind::BuiltinTypeConstructor(name.clone()))
                     } else if wgsl_types::idents::BUILTIN_ENUMERANT_NAMES.contains(&name.as_str()) {
                         Some(ResolveKind::BuiltinEnumerant(name.clone()))
                     } else if wgsl_types::idents::BUILTIN_DECLARATION_NAMES.contains(&name.as_str())
@@ -418,4 +412,7 @@ pub enum ResolutionDiagnostic {
     /// Cannot resolve an import statement, because the current file is not a part of a package.
     DetachedFile,
     MissingName,
+    UnsupportedBuiltin {
+        name: Name,
+    },
 }

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -1123,6 +1123,7 @@ impl<'db> InferenceContext<'db> {
                     | TypeKind::BuiltinStruct(_)
                     | TypeKind::Texture(_)
                     | TypeKind::Sampler(_)
+                    | TypeKind::RayQuery(_)
                     | TypeKind::AccelerationStructure(_)
                     | TypeKind::Reference(_)
                     | TypeKind::Pointer(_) => {
@@ -1200,6 +1201,7 @@ impl<'db> InferenceContext<'db> {
             | TypeKind::BuiltinStruct(_)
             | TypeKind::Array(_)
             | TypeKind::Texture(_)
+            | TypeKind::RayQuery(_)
             | TypeKind::AccelerationStructure(_)
             | TypeKind::Sampler(_)) => (kind, None),
         };
@@ -1237,6 +1239,7 @@ impl<'db> InferenceContext<'db> {
             | TypeKind::Array(_)
             | TypeKind::Texture(_)
             | TypeKind::Sampler(_)
+            | TypeKind::RayQuery(_)
             | TypeKind::AccelerationStructure(_)
             | TypeKind::Reference(_)
             | TypeKind::Pointer(_) => {
@@ -1773,6 +1776,7 @@ impl<'db> InferenceContext<'db> {
             | TypeKind::Pointer(_)
             | TypeKind::Atomic(_)
             | TypeKind::BuiltinStruct(_)
+            | TypeKind::RayQuery(_)
             | TypeKind::AccelerationStructure(_)
             | TypeKind::Reference(_) => {
                 debug_assert!(

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -1769,13 +1769,19 @@ impl<'db> InferenceContext<'db> {
             TypeKind::Struct(struct_id) => {
                 self.infer_struct_constructor(store, expression, r#type, arguments, struct_id)
             },
+            TypeKind::BuiltinStruct(builtin_struct) => self.infer_builtin_struct_constructor(
+                store,
+                expression,
+                r#type,
+                arguments,
+                &builtin_struct,
+            ),
 
             // Never constructible
             TypeKind::Texture(_)
             | TypeKind::Sampler(_)
             | TypeKind::Pointer(_)
             | TypeKind::Atomic(_)
-            | TypeKind::BuiltinStruct(_)
             | TypeKind::RayQuery(_)
             | TypeKind::AccelerationStructure(_)
             | TypeKind::Reference(_) => {
@@ -2167,6 +2173,62 @@ impl<'db> InferenceContext<'db> {
         let mut has_errors = false;
         for ((_, field_type), (argument_expression, argument_type)) in
             field_types.iter().zip(arguments.iter())
+        {
+            if !argument_type.is_convertible_to(*field_type, self.db) {
+                self.push_diagnostic(
+                    store.store_source,
+                    InferenceDiagnosticKind::TypeMismatch {
+                        expression: *argument_expression,
+                        expected: TypeExpectation::from_type(*field_type),
+                        actual: *argument_type,
+                    },
+                );
+                has_errors = true;
+            }
+        }
+
+        if has_errors {
+            self.error_type()
+        } else {
+            r#type
+        }
+    }
+
+    fn infer_builtin_struct_constructor(
+        &mut self,
+        store: &ExpressionStore,
+        expression: ExpressionId,
+        r#type: Type,
+        arguments: &[(ExpressionId, Type)],
+        builtin_struct: &BuiltinStruct,
+    ) -> Type {
+        // https://www.w3.org/TR/WGSL/#zero-value-builtin-function
+        if arguments.is_empty() {
+            return r#type;
+        }
+        if arguments.len() != builtin_struct.fields.len() {
+            self.push_diagnostic(
+                store.store_source,
+                InferenceDiagnosticKind::FunctionCallArgCountMismatch {
+                    expression,
+                    n_expected: builtin_struct.fields.len(),
+                    n_actual: arguments.len(),
+                },
+            );
+            return self.error_type();
+        }
+        let argument_types = arguments.iter().map(|(_, r#type)| *r#type).collect_vec();
+        if argument_types.iter().any(|r#type| r#type.is_err(self.db)) {
+            // debug_assert!(
+            //     !self.result.diagnostics.is_empty(),
+            //     "an error type should have a diagnostic already"
+            // );
+            return r#type;
+        }
+
+        let mut has_errors = false;
+        for ((_, field_type), (argument_expression, argument_type)) in
+            builtin_struct.fields.iter().zip(arguments.iter())
         {
             if !argument_type.is_convertible_to(*field_type, self.db) {
                 self.push_diagnostic(

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -33,9 +33,9 @@ use crate::{
     diagnostics::{InferenceDiagnostic, InferenceDiagnosticKind},
     function::FunctionDetails,
     lower::{
-        ConstructibleTypeGenerator, Lowered, LoweredKind, ResolvedCall, TemplateParameter,
-        TemplateParameters, TypeContainer, TypeLoweringContext, TypeLoweringError,
-        WgslTypeConverter, to_wgsl_binary_operator, to_wgsl_unary_operator,
+        ConstructibleTypeGenerator, DefaultTypes, Lowered, LoweredKind, ResolvedCall,
+        TemplateParameter, TemplateParameters, TypeContainer, TypeLoweringContext,
+        TypeLoweringError, WgslTypeConverter, to_wgsl_binary_operator, to_wgsl_unary_operator,
     },
     ty::{
         ArraySize, ArrayType, BuiltinStruct, MatrixType, Pointer, Reference, ScalarType, Type,
@@ -105,7 +105,7 @@ fn infer_cycle_result(
     _: salsa::Id,
     definition: DefinitionWithBodyId,
 ) -> InferenceResult {
-    let mut inference_result = InferenceResult::new(db);
+    let mut inference_result = InferenceResult::new(TypeKind::Error.intern(db));
     let (name, range) = get_name_and_range(db, ModuleDefinitionId::from(definition));
 
     inference_result.diagnostics.push(InferenceDiagnostic {
@@ -152,19 +152,6 @@ pub fn get_name_and_range(
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
-struct InternedStandardTypes {
-    unknown: Type,
-}
-
-impl InternedStandardTypes {
-    fn new(db: &dyn HirDatabase) -> Self {
-        Self {
-            unknown: TypeKind::Error.intern(db),
-        }
-    }
-}
-
 #[derive(PartialEq, Eq, Debug)]
 pub struct InferenceResult {
     pub(crate) type_of_expression: ArenaMap<ExpressionId, Type>,
@@ -173,19 +160,19 @@ pub struct InferenceResult {
     return_type: Type,
     call_resolutions: FxHashMap<ExpressionId, ResolvedCall>,
     field_resolutions: FxHashMap<ExpressionId, FieldId>,
-    standard_types: InternedStandardTypes,
+    error_type: Type,
 }
 
 impl InferenceResult {
-    fn new(db: &dyn HirDatabase) -> Self {
+    fn new(error_type: Type) -> Self {
         Self {
             type_of_expression: ArenaMap::default(),
             type_of_binding: ArenaMap::default(),
             diagnostics: Vec::default(),
-            return_type: TypeKind::Error.intern(db),
+            return_type: error_type,
             call_resolutions: FxHashMap::default(),
             field_resolutions: FxHashMap::default(),
-            standard_types: InternedStandardTypes::new(db),
+            error_type,
         }
     }
 
@@ -234,7 +221,7 @@ impl Index<ExpressionId> for InferenceResult {
     ) -> &Type {
         self.type_of_expression
             .get(index)
-            .unwrap_or(&self.standard_types.unknown)
+            .unwrap_or(&self.error_type)
     }
 }
 
@@ -245,9 +232,7 @@ impl Index<BindingId> for InferenceResult {
         &self,
         index: BindingId,
     ) -> &Type {
-        self.type_of_binding
-            .get(index)
-            .unwrap_or(&self.standard_types.unknown)
+        self.type_of_binding.get(index).unwrap_or(&self.error_type)
     }
 }
 
@@ -268,12 +253,13 @@ impl<'db> InferenceContext<'db> {
         owner: ModuleDefinitionId,
         resolver: Resolver<'db>,
     ) -> Self {
+        let types = DefaultTypes::new(db);
         Self {
             db,
             owner,
             resolver,
-            result: InferenceResult::new(db),
-            return_type: TypeKind::Error.intern(db),
+            result: InferenceResult::new(types.error),
+            return_type: types.error,
             converter: WgslTypeConverter::new(db),
         }
     }
@@ -2308,7 +2294,7 @@ impl InferenceContext<'_> {
     }
 
     const fn error_type(&self) -> Type {
-        self.result.standard_types.unknown
+        self.result.error_type
     }
 
     fn bool_type(&self) -> Type {

--- a/crates/hir_ty/src/layout.rs
+++ b/crates/hir_ty/src/layout.rs
@@ -152,6 +152,7 @@ impl TypeKind {
             | Self::BuiltinStruct(_)
             | Self::Texture(_)
             | Self::Sampler(_)
+            | Self::RayQuery(_)
             | Self::AccelerationStructure(_)
             | Self::Reference(_)
             | Self::Pointer(_) => None,
@@ -252,6 +253,7 @@ impl TypeKind {
             | Self::Vector(_)
             | Self::Texture(_)
             | Self::Sampler(_)
+            | Self::RayQuery(_)
             | Self::AccelerationStructure(_)
             | Self::Reference(_)
             | Self::Pointer(_) => None,

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -155,6 +155,12 @@ impl TypeLoweringErrorKind {
             Self::Resolution(ResolutionDiagnostic::UnresolvedPackage { name }) => {
                 format!("package `{}` not found", name.as_str())
             },
+            Self::Resolution(ResolutionDiagnostic::UnsupportedBuiltin { name }) => {
+                format!(
+                    "builtin type `{}` not yet supported in wgsl-analyzer",
+                    name.as_str()
+                )
+            },
             Self::WgslError(error) => error.clone(),
             Self::UnexpectedTemplateArgument(expected, actual) => {
                 format!(
@@ -359,7 +365,7 @@ impl<'db> TypeLoweringContext<'db> {
             Ok(ResolveKind::BuiltinFunction(name)) => {
                 Ok(Lowered::BuiltinFunction(name, Some(template_parameters)))
             },
-            Ok(ResolveKind::BuiltinType(name)) => {
+            Ok(ResolveKind::BuiltinType(name) | ResolveKind::BuiltinTypeConstructor(name)) => {
                 self.lower_builtin_type(name, type_container, &mut template_parameters)
             },
             Ok(ResolveKind::BuiltinTypeGenerator(name)) => {
@@ -372,14 +378,6 @@ impl<'db> TypeLoweringContext<'db> {
                     Either::Right(r#type) => Ok(Lowered::Type(r#type)),
                 }
             },
-            // Ok(ResolveKind::BuiltinTypeConstructor(name)) => self
-            //     .lower_builtin_type(type_container, &name, &template_parameters)?
-            //     .ok_or_else(|| TypeLoweringError {
-            //         container: type_container,
-            //         kind: TypeLoweringErrorKind::Resolution(ResolutionDiagnostic::UnresolvedName {
-            //             name,
-            //         }),
-            //     }),
             Ok(ResolveKind::BuiltinEnumerant(name)) => {
                 self.expect_no_template(&template_parameters);
                 self.lower_builtin_enumerant(&name)

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -626,6 +626,7 @@ impl<'db> WgslTypeConverter<'db> {
                 Box::new(self.to_wgsl_types(inner)),
                 access_mode,
             ),
+            TypeKind::RayQuery(tags) => wgsl_types::Type::RayQuery(tags),
             TypeKind::AccelerationStructure(tags) => wgsl_types::Type::AccelerationStructure(tags),
         }
     }
@@ -771,7 +772,7 @@ impl<'db> WgslTypeConverter<'db> {
             wgsl_types::Type::Sampler(sampler_type) => {
                 TypeKind::Sampler(sampler_type).intern(self.db)
             },
-            wgsl_types::Type::RayQuery(_) => todo!("naga extension"),
+            wgsl_types::Type::RayQuery(tags) => TypeKind::RayQuery(tags).intern(self.db),
             wgsl_types::Type::AccelerationStructure(tags) => {
                 TypeKind::AccelerationStructure(tags).intern(self.db)
             },
@@ -1006,6 +1007,7 @@ impl<'db> WgslTypeConverter<'db> {
             | TypeKind::Array(_)
             | TypeKind::Texture(_)
             | TypeKind::Sampler(_)
+            | TypeKind::RayQuery(_)
             | TypeKind::AccelerationStructure(_)
             | TypeKind::Reference(_)
             | TypeKind::Pointer(_)) => panic!("invalid sampled type {kind:?}"),

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -39,8 +39,121 @@ pub struct TypeLoweringContext<'db> {
     /// Make sure to set the correct resolver when going into function scopes.
     resolver: &'db Resolver<'db>,
     store: &'db ExpressionStore,
+    types: DefaultTypes,
 
     pub(crate) diagnostics: Vec<TypeLoweringError>,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct DefaultTypes {
+    pub error: Type,
+    pub ray_desc: BuiltinStruct,
+    pub ray_intersection: BuiltinStruct,
+}
+
+impl DefaultTypes {
+    pub fn new(db: &dyn HirDatabase) -> Self {
+        Self {
+            error: TypeKind::Error.intern(db),
+            ray_desc: BuiltinStruct {
+                name: "RayDesc".to_owned(),
+                fields: vec![
+                    (
+                        "flags".to_owned(),
+                        TypeKind::Scalar(ScalarType::U32).intern(db),
+                    ),
+                    (
+                        "cull_mask".to_owned(),
+                        TypeKind::Scalar(ScalarType::U32).intern(db),
+                    ),
+                    (
+                        "t_min".to_owned(),
+                        TypeKind::Scalar(ScalarType::F32).intern(db),
+                    ),
+                    (
+                        "t_max".to_owned(),
+                        TypeKind::Scalar(ScalarType::F32).intern(db),
+                    ),
+                    (
+                        "origin".to_owned(),
+                        TypeKind::Vector(VectorType {
+                            size: VecSize::Three,
+                            component_type: TypeKind::Scalar(ScalarType::F32).intern(db),
+                        })
+                        .intern(db),
+                    ),
+                    (
+                        "dir".to_owned(),
+                        TypeKind::Vector(VectorType {
+                            size: VecSize::Three,
+                            component_type: TypeKind::Scalar(ScalarType::F32).intern(db),
+                        })
+                        .intern(db),
+                    ),
+                ],
+            },
+            ray_intersection: BuiltinStruct {
+                name: "RayIntersection".to_owned(),
+                fields: vec![
+                    (
+                        "kind".to_owned(),
+                        TypeKind::Scalar(ScalarType::U32).intern(db),
+                    ),
+                    ("t".to_owned(), TypeKind::Scalar(ScalarType::F32).intern(db)),
+                    (
+                        "instance_custom_data".to_owned(),
+                        TypeKind::Scalar(ScalarType::U32).intern(db),
+                    ),
+                    (
+                        "instance_index".to_owned(),
+                        TypeKind::Scalar(ScalarType::U32).intern(db),
+                    ),
+                    (
+                        "sbt_record_offset".to_owned(),
+                        TypeKind::Scalar(ScalarType::U32).intern(db),
+                    ),
+                    (
+                        "geometry_index".to_owned(),
+                        TypeKind::Scalar(ScalarType::U32).intern(db),
+                    ),
+                    (
+                        "primitive_index".to_owned(),
+                        TypeKind::Scalar(ScalarType::U32).intern(db),
+                    ),
+                    (
+                        "barycentrics".to_owned(),
+                        TypeKind::Vector(VectorType {
+                            size: VecSize::Two,
+                            component_type: TypeKind::Scalar(ScalarType::F32).intern(db),
+                        })
+                        .intern(db),
+                    ),
+                    (
+                        "front_face".to_owned(),
+                        TypeKind::Scalar(ScalarType::Bool).intern(db),
+                    ),
+                    (
+                        "object_to_world".to_owned(),
+                        TypeKind::Matrix(MatrixType {
+                            columns: VecSize::Four,
+                            rows: VecSize::Three,
+                            inner: TypeKind::Scalar(ScalarType::F32).intern(db),
+                        })
+                        .intern(db),
+                    ),
+                    (
+                        "world_to_object".to_owned(),
+                        TypeKind::Matrix(MatrixType {
+                            columns: VecSize::Four,
+                            rows: VecSize::Three,
+                            inner: TypeKind::Scalar(ScalarType::F32).intern(db),
+                        })
+                        .intern(db),
+                    ),
+                ],
+            },
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -301,6 +414,7 @@ impl<'db> TypeLoweringContext<'db> {
             db,
             resolver,
             store,
+            types: DefaultTypes::new(db),
             diagnostics: Vec::new(),
         }
     }

--- a/crates/hir_ty/src/lower/builtin.rs
+++ b/crates/hir_ty/src/lower/builtin.rs
@@ -16,8 +16,8 @@ use crate::{
         TypeLoweringError, TypeLoweringErrorKind, generics::TemplateParameters,
     },
     ty::{
-        ArraySize, ArrayType, AtomicType, BuiltinStruct, MatrixType, Pointer, ScalarType,
-        TextureDimensionality, TextureKind, TextureType, Type, TypeKind, VecSize, VectorType,
+        ArraySize, ArrayType, AtomicType, MatrixType, Pointer, ScalarType, TextureDimensionality,
+        TextureKind, TextureType, Type, TypeKind, VecSize, VectorType,
     },
 };
 
@@ -357,59 +357,8 @@ impl TypeLoweringContext<'_> {
             "acceleration_structure" => {
                 lower_acceleration_structure(type_container, template_parameters)?
             },
-
-            // struct RayDesc {
-            //     // Contains flags to use for this ray (e.g. consider all `Blas`es opaque)
-            //     flags: u32,
-            //     // If the bitwise and of this and any `TlasInstance`'s `mask` is not zero then the object inside
-            //     // the `Blas` contained within that `TlasInstance` may be hit.
-            //     cull_mask: u32,
-            //     // Only points on the ray whose t is greater than this may be hit.
-            //     t_min: f32,
-            //     // Only points on the ray whose t is less than this may be hit.
-            //     t_max: f32,
-            //     // The origin of the ray.
-            //     origin: vec3<f32>,
-            //     // The direction of the ray, t is calculated as the length down the ray divided by the length of `dir`.
-            //     dir: vec3<f32>,
-            // }
-            "RayDesc" => TypeKind::BuiltinStruct(BuiltinStruct {
-                name: "RayDesc".to_owned(),
-                fields: vec![
-                    (
-                        "flags".to_owned(),
-                        TypeKind::Scalar(ScalarType::U32).intern(self.db),
-                    ),
-                    (
-                        "cull_mask".to_owned(),
-                        TypeKind::Scalar(ScalarType::U32).intern(self.db),
-                    ),
-                    (
-                        "t_min".to_owned(),
-                        TypeKind::Scalar(ScalarType::F32).intern(self.db),
-                    ),
-                    (
-                        "t_max".to_owned(),
-                        TypeKind::Scalar(ScalarType::F32).intern(self.db),
-                    ),
-                    (
-                        "origin".to_owned(),
-                        TypeKind::Vector(VectorType {
-                            size: VecSize::Three,
-                            component_type: TypeKind::Scalar(ScalarType::F32).intern(self.db),
-                        })
-                        .intern(self.db),
-                    ),
-                    (
-                        "dir".to_owned(),
-                        TypeKind::Vector(VectorType {
-                            size: VecSize::Three,
-                            component_type: TypeKind::Scalar(ScalarType::F32).intern(self.db),
-                        })
-                        .intern(self.db),
-                    ),
-                ],
-            }),
+            "RayDesc" => TypeKind::BuiltinStruct(self.types.ray_desc.clone()),
+            "RayIntersection" => TypeKind::BuiltinStruct(self.types.ray_intersection.clone()),
             _ => {
                 // if you reached here, then you found something known in wgsl-types that is unknown in wgsl-analyzer
                 // open a feature request!

--- a/crates/hir_ty/src/lower/builtin.rs
+++ b/crates/hir_ty/src/lower/builtin.rs
@@ -353,6 +353,7 @@ impl TypeLoweringContext<'_> {
                 self.expect_no_template(template_parameters);
                 TypeKind::Sampler(wgsl_types::ty::SamplerType::SamplerComparison)
             },
+            "ray_query" => lower_ray_query(type_container, template_parameters)?,
             "acceleration_structure" => {
                 lower_acceleration_structure(type_container, template_parameters)?
             },
@@ -974,6 +975,7 @@ impl TypeLoweringContext<'_> {
                     | TypeKind::Array(_)
                     | TypeKind::Texture(_)
                     | TypeKind::Sampler(_)
+                    | TypeKind::RayQuery(_)
                     | TypeKind::AccelerationStructure(_)
                     | TypeKind::Reference(_)
                     | TypeKind::Pointer(_) => {
@@ -1108,6 +1110,17 @@ impl TypeLoweringContext<'_> {
     }
 }
 
+fn lower_ray_query(
+    type_container: TypeContainer,
+    template_parameters: &mut TemplateParameters,
+) -> Result<TypeKind, TypeLoweringError> {
+    if !template_parameters.has_next() {
+        return Ok(TypeKind::RayQuery(None));
+    }
+    let acceleration_structure_tags = lower_tags_template(type_container, template_parameters)?;
+    Ok(TypeKind::RayQuery(Some(acceleration_structure_tags)))
+}
+
 fn lower_acceleration_structure(
     type_container: TypeContainer,
     template_parameters: &mut TemplateParameters,
@@ -1115,6 +1128,16 @@ fn lower_acceleration_structure(
     if !template_parameters.has_next() {
         return Ok(TypeKind::AccelerationStructure(None));
     }
+    let acceleration_structure_tags = lower_tags_template(type_container, template_parameters)?;
+    Ok(TypeKind::AccelerationStructure(Some(
+        acceleration_structure_tags,
+    )))
+}
+
+fn lower_tags_template(
+    type_container: TypeContainer,
+    template_parameters: &mut TemplateParameters,
+) -> Result<AccelerationStructureTags, TypeLoweringError> {
     let mut acceleration_structure_tags = vec![];
     while let Some((template_parameter, _)) = template_parameters.take_next() {
         match template_parameter {
@@ -1161,9 +1184,7 @@ fn lower_acceleration_structure(
                 });
             },
         };
-    Ok(TypeKind::AccelerationStructure(Some(
-        acceleration_structure_tags,
-    )))
+    Ok(acceleration_structure_tags)
 }
 
 struct ArrayTemplate {

--- a/crates/hir_ty/src/lower/builtin.rs
+++ b/crates/hir_ty/src/lower/builtin.rs
@@ -16,8 +16,8 @@ use crate::{
         TypeLoweringError, TypeLoweringErrorKind, generics::TemplateParameters,
     },
     ty::{
-        ArraySize, ArrayType, AtomicType, MatrixType, Pointer, ScalarType, TextureDimensionality,
-        TextureKind, TextureType, Type, TypeKind, VecSize, VectorType,
+        ArraySize, ArrayType, AtomicType, BuiltinStruct, MatrixType, Pointer, ScalarType,
+        TextureDimensionality, TextureKind, TextureType, Type, TypeKind, VecSize, VectorType,
     },
 };
 
@@ -362,9 +362,9 @@ impl TypeLoweringContext<'_> {
                 // open a feature request!
                 return Err(TypeLoweringError {
                     container: type_container,
-                    kind: TypeLoweringErrorKind::Resolution(ResolutionDiagnostic::UnresolvedName {
-                        name,
-                    }),
+                    kind: TypeLoweringErrorKind::Resolution(
+                        ResolutionDiagnostic::UnsupportedBuiltin { name },
+                    ),
                 });
             },
         };
@@ -682,15 +682,13 @@ impl TypeLoweringContext<'_> {
             //     unimplemented!()
             // },
             _ => {
-                debug_assert!(
-                    false,
-                    "reaching this means that this function needs to be updated to handle a new builtin defined in wgsl-types"
-                );
+                // if you reached here, then you found something known in wgsl-types that is unknown in wgsl-analyzer
+                // open a feature request!
                 Err(TypeLoweringError {
                     container: type_container,
-                    kind: TypeLoweringErrorKind::Resolution(ResolutionDiagnostic::UnresolvedName {
-                        name: name.clone(),
-                    }),
+                    kind: TypeLoweringErrorKind::Resolution(
+                        ResolutionDiagnostic::UnsupportedBuiltin { name: name.clone() },
+                    ),
                 })
             },
         }

--- a/crates/hir_ty/src/lower/builtin.rs
+++ b/crates/hir_ty/src/lower/builtin.rs
@@ -357,6 +357,59 @@ impl TypeLoweringContext<'_> {
             "acceleration_structure" => {
                 lower_acceleration_structure(type_container, template_parameters)?
             },
+
+            // struct RayDesc {
+            //     // Contains flags to use for this ray (e.g. consider all `Blas`es opaque)
+            //     flags: u32,
+            //     // If the bitwise and of this and any `TlasInstance`'s `mask` is not zero then the object inside
+            //     // the `Blas` contained within that `TlasInstance` may be hit.
+            //     cull_mask: u32,
+            //     // Only points on the ray whose t is greater than this may be hit.
+            //     t_min: f32,
+            //     // Only points on the ray whose t is less than this may be hit.
+            //     t_max: f32,
+            //     // The origin of the ray.
+            //     origin: vec3<f32>,
+            //     // The direction of the ray, t is calculated as the length down the ray divided by the length of `dir`.
+            //     dir: vec3<f32>,
+            // }
+            "RayDesc" => TypeKind::BuiltinStruct(BuiltinStruct {
+                name: "RayDesc".to_owned(),
+                fields: vec![
+                    (
+                        "flags".to_owned(),
+                        TypeKind::Scalar(ScalarType::U32).intern(self.db),
+                    ),
+                    (
+                        "cull_mask".to_owned(),
+                        TypeKind::Scalar(ScalarType::U32).intern(self.db),
+                    ),
+                    (
+                        "t_min".to_owned(),
+                        TypeKind::Scalar(ScalarType::F32).intern(self.db),
+                    ),
+                    (
+                        "t_max".to_owned(),
+                        TypeKind::Scalar(ScalarType::F32).intern(self.db),
+                    ),
+                    (
+                        "origin".to_owned(),
+                        TypeKind::Vector(VectorType {
+                            size: VecSize::Three,
+                            component_type: TypeKind::Scalar(ScalarType::F32).intern(self.db),
+                        })
+                        .intern(self.db),
+                    ),
+                    (
+                        "dir".to_owned(),
+                        TypeKind::Vector(VectorType {
+                            size: VecSize::Three,
+                            component_type: TypeKind::Scalar(ScalarType::F32).intern(self.db),
+                        })
+                        .intern(self.db),
+                    ),
+                ],
+            }),
             _ => {
                 // if you reached here, then you found something known in wgsl-types that is unknown in wgsl-analyzer
                 // open a feature request!

--- a/crates/hir_ty/src/tests/big/ray_tracing_pipeline.rs
+++ b/crates/hir_ty/src/tests/big/ray_tracing_pipeline.rs
@@ -3,7 +3,8 @@ use expect_test::expect;
 use crate::tests::check_infer;
 
 #[test]
-#[ignore = "https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1388"]
+#[should_panic = "assertion `left == right` failed\n  left: []\n right: [Diagnostic { message: \"unknown extension: `wgpu_ray_tracing_pipeline`\", range: 7..32 }]"]
+// TODO: https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1388
 fn ray_tracing_pipeline() {
     check_infer(
         "

--- a/crates/hir_ty/src/tests/big/ray_tracing_pipeline.rs
+++ b/crates/hir_ty/src/tests/big/ray_tracing_pipeline.rs
@@ -3,12 +3,10 @@ use expect_test::expect;
 use crate::tests::check_infer;
 
 #[test]
-#[should_panic = "assertion `left == right` failed\n  left: []\n right: [Diagnostic { message: \"unknown extension: `wgpu_ray_tracing_pipeline`\", range: 7..32 }]"]
-// TODO: https://github.com/wgsl-analyzer/wgsl-analyzer/issues/1388
 fn ray_tracing_pipeline() {
     check_infer(
         "
-enable wgpu_ray_tracing_pipeline;
+// enable wgpu_ray_tracing_pipeline;
 
 struct HitCounters {
     hit_num: u32,
@@ -46,18 +44,63 @@ fn any_hit_main(@builtin(instance_custom_data) data: u32, @builtin(geometry_inde
 fn closest_hit_main(@builtin(object_ray_origin) origin: vec3<f32>, @builtin(object_ray_direction) dir: vec3<f32>, @builtin(object_to_world) obj_to_world: mat4x3<f32>, @builtin(world_to_object) world_to_obj: mat4x3<f32>) {}
 ",
         expect![[r#"
-            84..96 'storage_read': ref<storage, S, read>
-            149..159 'storage_rw': ref<storage, S, read_write>
-            182..198 'runtim...adonly': u32
-            201..232 'arrayL....data)': u32
-            213..231 '&stora...d.data': ptr<storage, array<vec4<f32>>, read>
-            214..226 'storage_read': ref<storage, S, read>
-            214..231 'storag...d.data': ref<storage, array<vec4<f32>>, read>
-            242..259 'runtim...dwrite': u32
-            262..291 'arrayL....data)': u32
-            274..290 '&stora...w.data': ptr<storage, array<vec4<f32>>, read_write>
-            275..285 'storage_rw': ref<storage, S, read_write>
-            275..290 'storage_rw.data': ref<storage, array<vec4<f32>>, read_write>
+            120..127 'hit_num': ref<ray_payload, HitCounters, read_write>
+            169..179 'acc_struct': ref<handle, acceleration_structure, read>
+            266..268 'id': vec3<u32>
+            311..326 'num_invocations': vec3<u32>
+            345..352 'hit_num': ref<ray_payload, HitCounters, read_write>
+            355..368 'HitCounters()': HitCounters
+            378..383 'shift': vec3<f32>
+            386..399 'vec3<f32>(id)': vec3<f32>
+            386..428 'vec3<f...tions)': vec3<f32>
+            396..398 'id': vec3<u32>
+            402..428 'vec3<f...tions)': vec3<f32>
+            412..427 'num_invocations': vec3<u32>
+            438..447 'ray_shift': vec3<f32>
+            450..491 '(vec3(... - 1.0': vec3<f32>
+            451..478 'vec3(s...ift.y)': vec3<f32>
+            451..484 'vec3(s... * 2.0': vec3<f32>
+            456..461 'shift': vec3<f32>
+            456..463 'shift.x': f32
+            465..468 '0.0': float
+            470..475 'shift': vec3<f32>
+            470..477 'shift.y': f32
+            481..484 '2.0': float
+            488..491 '1.0': float
+            497..614 'traceR...t_num)': [error]
+            506..516 'acc_struct': ref<handle, acceleration_structure, read>
+            518..603 'RayDes...shift)': RayDesc
+            526..539 'RAY_FLAG_NONE': u32
+            541..545 '0xff': integer
+            547..551 '0.01': float
+            553..558 '100.0': float
+            560..569 'vec3(0.0)': vec3<float>
+            565..568 '0.0': float
+            571..590 'vec3(0..., 0.0)': vec3<float>
+            571..602 'vec3(0..._shift': vec3<f32>
+            576..579 '0.0': float
+            581..584 '1.0': float
+            586..589 '0.0': float
+            593..602 'ray_shift': vec3<f32>
+            605..613 '&hit_num': ptr<ray_payload, HitCounters, read_write>
+            606..613 'hit_num': ref<ray_payload, HitCounters, read_write>
+            645..661 'incomi...it_num': ref<incoming_ray_payload, HitCounters, read_write>
+            754..760 'origin': vec3<f32>
+            803..806 'dir': vec3<f32>
+            839..844 't_min': f32
+            947..951 'data': u32
+            983..990 'geo_idx': u32
+            1025..1028 'max': f32
+            1054..1058 'kind': u32
+            1071..1087 'incomi...it_num': ref<incoming_ray_payload, HitCounters, read_write>
+            1071..1095 'incomi...it_num': ref<incoming_ray_payload, u32, read_write>
+            1103..1119 'incomi...it_num': ref<incoming_ray_payload, HitCounters, read_write>
+            1103..1132 'incomi...ed_hit': ref<incoming_ray_payload, u32, read_write>
+            1135..1139 'data': u32
+            1241..1247 'origin': vec3<f32>
+            1291..1294 'dir': vec3<f32>
+            1333..1345 'obj_to_world': mat4x3<f32>
+            1386..1398 'world_to_obj': mat4x3<f32>
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/language_extensions/ray_query.rs
+++ b/crates/hir_ty/src/tests/language_extensions/ray_query.rs
@@ -4,25 +4,35 @@ use expect_test::expect;
 
 use crate::tests::check_infer;
 
-// TODO support wgpu_ray_query
 #[test]
 fn rayQueryInitialize() {
     check_infer(
         "
+//enable wgpu_ray_query;
 //enable wgpu_ray_query_vertex_return;
-var x: acceleration_structure;
+var a_s: acceleration_structure;
+var r_q: ray_query;
 fn foo() {
-    let z = rayQueryInitialize(1, x, 2);
+    let r_d = todo();
+    rayQueryInitialize(&r_q, a_s, r_d);
+
 }
         ",
         expect![[r#"
-            43..44 'x': ref<handle, acceleration_structure, read>
-            89..90 'z': [error]
-            93..120 'rayQue... x, 2)': [error]
-            112..113 '1': integer
-            115..116 'x': ref<handle, acceleration_structure, read>
-            118..119 '2': integer
-            93..120 'rayQue... x, 2)': `rayQueryInitialize` expects a pointer to `ray_query`, an acceleration structure and a `RayDesc` argument
+            68..71 'a_s': ref<handle, acceleration_structure, read>
+            101..104 'r_q': ref<handle, ray_query, read>
+            136..139 'r_d': [error]
+            142..148 'todo()': [error]
+            154..188 'rayQue..., r_d)': [error]
+            173..177 '&r_q': [error]
+            174..177 'r_q': ref<handle, ray_query, read>
+            179..182 'a_s': ref<handle, acceleration_structure, read>
+            184..187 'r_d': [error]
+            142..148 'todo()': `todo` not found in scope
+            173..177 '&r_q': cannot create a pointer in `handle` address space
         "#]],
     );
 }
+
+// rayQueryInitialize(rq: ptr<function, ray_query>, acceleration_structure: acceleration_structure, ray_desc: RayDesc)
+// rayQueryInitialize(rq: ptr<function, ray_query<vertex_return>>, acceleration_structure: acceleration_structure<vertex_return>, ray_desc: RayDesc)

--- a/crates/hir_ty/src/tests/language_extensions/ray_query.rs
+++ b/crates/hir_ty/src/tests/language_extensions/ray_query.rs
@@ -9,27 +9,56 @@ fn rayQueryInitialize() {
     check_infer(
         "
 //enable wgpu_ray_query;
-//enable wgpu_ray_query_vertex_return;
-var a_s: acceleration_structure;
-var r_q: ray_query;
+var acc_struct: acceleration_structure;
 fn foo() {
-    let r_d = todo();
-    rayQueryInitialize(&r_q, a_s, r_d);
-
+    var rq: ray_query;
+    rayQueryInitialize(&rq, acc_struct, RayDesc(0u, 0xFFu, 0.01, 200.0, vec3(), vec3()));
 }
         ",
         expect![[r#"
-            68..71 'a_s': ref<handle, acceleration_structure, read>
-            101..104 'r_q': ref<handle, ray_query, read>
-            136..139 'r_d': [error]
-            142..148 'todo()': [error]
-            154..188 'rayQue..., r_d)': [error]
-            173..177 '&r_q': [error]
-            174..177 'r_q': ref<handle, ray_query, read>
-            179..182 'a_s': ref<handle, acceleration_structure, read>
-            184..187 'r_d': [error]
-            142..148 'todo()': `todo` not found in scope
-            173..177 '&r_q': cannot create a pointer in `handle` address space
+            29..39 'acc_struct': ref<handle, acceleration_structure, read>
+            84..86 'rq': ref<function, ray_query, read_write>
+            103..187 'rayQue...c3()))': [error]
+            122..125 '&rq': ptr<function, ray_query, read_write>
+            123..125 'rq': ref<function, ray_query, read_write>
+            127..137 'acc_struct': ref<handle, acceleration_structure, read>
+            139..186 'RayDes...ec3())': RayDesc
+            147..149 '0u': u32
+            151..156 '0xFFu': u32
+            158..162 '0.01': float
+            164..169 '200.0': float
+            171..177 'vec3()': vec3<integer>
+            179..185 'vec3()': vec3<integer>
+        "#]],
+    );
+}
+
+#[test]
+fn rayQueryInitialize_vertex_return() {
+    check_infer(
+        "
+//enable wgpu_ray_query;
+//enable wgpu_ray_query_vertex_return;
+var acc_struct: acceleration_structure<vertex_return>;
+fn foo() {
+    var rq: ray_query<vertex_return>;
+    rayQueryInitialize(&rq, acc_struct, RayDesc(0u, 0xFFu, 0.01, 200.0, vec3(), vec3()));
+}
+        ",
+        expect![[r#"
+            68..78 'acc_struct': ref<handle, acceleration_structure<vertex_return>, read>
+            138..140 'rq': ref<function, ray_query<vertex_return>, read_write>
+            172..256 'rayQue...c3()))': [error]
+            191..194 '&rq': ptr<function, ray_query<vertex_return>, read_write>
+            192..194 'rq': ref<function, ray_query<vertex_return>, read_write>
+            196..206 'acc_struct': ref<handle, acceleration_structure<vertex_return>, read>
+            208..255 'RayDes...ec3())': RayDesc
+            216..218 '0u': u32
+            220..225 '0xFFu': u32
+            227..231 '0.01': float
+            233..238 '200.0': float
+            240..246 'vec3()': vec3<integer>
+            248..254 'vec3()': vec3<integer>
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -2523,22 +2523,6 @@ fn foo() {
 }
 
 #[test]
-fn unresolved_builtin_type() {
-    check_infer(
-        "
-fn foo() {
-    let r_i = RayIntersection();
-}
-        ",
-        expect![[r#"
-            19..22 'r_i': [error]
-            25..42 'RayInt...tion()': [error]
-            25..42 'RayInt...tion()': builtin type `RayIntersection` not yet supported in wgsl-analyzer
-        "#]],
-    );
-}
-
-#[test]
 fn unresolved_builtin_type_generator() {
     check_infer(
         "

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -2445,3 +2445,102 @@ var y: acceleration_structure<0>;
         "#]],
     );
 }
+
+#[test]
+fn builtin_struct_zero_value() {
+    check_infer(
+        "
+fn foo() {
+    let r_d = RayDesc();
+}
+        ",
+        expect![[r#"
+            19..22 'r_d': RayDesc
+            25..34 'RayDesc()': RayDesc
+        "#]],
+    );
+}
+
+#[test]
+fn builtin_struct_arguments_len() {
+    check_infer(
+        "
+fn foo() {
+    let r_d = RayDesc(0);
+}
+        ",
+        expect![[r#"
+            19..22 'r_d': [error]
+            25..35 'RayDesc(0)': [error]
+            33..34 '0': integer
+            25..35 'RayDesc(0)': expected `6` arguments, but received `1`
+        "#]],
+    );
+}
+
+#[test]
+fn builtin_struct_arguments_mismatch() {
+    check_infer(
+        "
+fn foo() {
+    let r_d = RayDesc(0i, 0, 0, 0, vec3f(), vec3f());
+}
+        ",
+        expect![[r#"
+            19..22 'r_d': [error]
+            25..63 'RayDes...c3f())': [error]
+            33..35 '0i': i32
+            37..38 '0': integer
+            40..41 '0': integer
+            43..44 '0': integer
+            46..53 'vec3f()': vec3<f32>
+            55..62 'vec3f()': vec3<f32>
+            33..35 '0i': expected u32 but got i32
+        "#]],
+    );
+}
+
+#[test]
+fn unresolved_builtin_type() {
+    check_infer(
+        "
+fn foo() {
+    let r_i = RayIntersection();
+}
+        ",
+        expect![[r#"
+            19..22 'r_i': [error]
+            25..42 'RayInt...tion()': [error]
+            25..42 'RayInt...tion()': builtin type `RayIntersection` not yet supported in wgsl-analyzer
+        "#]],
+    );
+}
+
+#[test]
+fn unresolved_builtin_type_generator() {
+    check_infer(
+        "
+fn foo() {
+    let t = texture_multisampled_2d_array();
+}
+        ",
+        expect![[r#"
+            19..22 'r_i': [error]
+            25..56 'textur...rray()': [error]
+            25..56 'textur...rray()': builtin type `texture_multisampled_2d_array` not yet supported in wgsl-analyzer
+        "#]],
+    );
+}
+
+#[test]
+fn abstract_constant() {
+    check_infer(
+        "
+const NONE = 0x0;
+        ",
+        expect![[r#"
+            6..10 'NONE': integer
+            13..16 '0x0': integer
+        "#]],
+    );
+}

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -2525,9 +2525,9 @@ fn foo() {
 }
         ",
         expect![[r#"
-            19..22 'r_i': [error]
-            25..56 'textur...rray()': [error]
-            25..56 'textur...rray()': builtin type `texture_multisampled_2d_array` not yet supported in wgsl-analyzer
+            19..20 't': [error]
+            23..54 'textur...rray()': [error]
+            23..54 'textur...rray()': builtin type `texture_multisampled_2d_array` not yet supported in wgsl-analyzer
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -2501,6 +2501,28 @@ fn foo() {
 }
 
 #[test]
+fn builtin_struct_arguments_error() {
+    check_infer(
+        "
+fn foo() {
+    let r_d = RayDesc(NONE, 0, 0, 0, vec3f(), vec3f());
+}
+        ",
+        expect![[r#"
+            19..22 'r_d': RayDesc
+            25..65 'RayDes...c3f())': RayDesc
+            33..37 'NONE': [error]
+            39..40 '0': integer
+            42..43 '0': integer
+            45..46 '0': integer
+            48..55 'vec3f()': vec3<f32>
+            57..64 'vec3f()': vec3<f32>
+            33..37 'NONE': `NONE` not found in scope
+        "#]],
+    );
+}
+
+#[test]
 fn unresolved_builtin_type() {
     check_infer(
         "

--- a/crates/hir_ty/src/ty.rs
+++ b/crates/hir_ty/src/ty.rs
@@ -460,6 +460,9 @@ impl TypeKind {
     ) -> bool {
         match self {
             Self::Atomic(atomic) => atomic.inner.contains_struct(db, r#struct),
+            Self::BuiltinStruct(BuiltinStruct { name: _, fields }) => fields
+                .iter()
+                .any(|(_, r#type)| r#type.contains_struct(db, r#struct)),
             Self::Struct(id) => {
                 if *id == r#struct {
                     return true;
@@ -469,15 +472,25 @@ impl TypeKind {
                     .values()
                     .any(|r#type| r#type.contains_struct(db, r#struct))
             },
-            Self::Array(array) => array.inner.contains_struct(db, r#struct),
-            Self::Reference(reference) => reference.inner.contains_struct(db, r#struct),
-            Self::Pointer(pointer) => pointer.inner.contains_struct(db, r#struct),
-
+            Self::Array(ArrayType {
+                inner,
+                binding_array: _,
+                size: _,
+            })
+            | Self::Reference(Reference {
+                address_space: _,
+                inner,
+                access_mode: _,
+            })
+            | Self::Pointer(Pointer {
+                address_space: _,
+                inner,
+                access_mode: _,
+            }) => inner.contains_struct(db, r#struct),
             Self::Scalar(_)
             | Self::Vector(_)
             | Self::Matrix(_)
             | Self::Sampler(_)
-            | Self::BuiltinStruct(_)
             | Self::Texture(_)
             | Self::RayQuery(_)
             | Self::AccelerationStructure(_)

--- a/crates/hir_ty/src/ty.rs
+++ b/crates/hir_ty/src/ty.rs
@@ -33,6 +33,7 @@ impl Type {
             | TypeKind::Struct(_)
             | TypeKind::BuiltinStruct(_)
             | TypeKind::Texture(_)
+            | TypeKind::RayQuery(_)
             | TypeKind::AccelerationStructure(_)
             | TypeKind::Sampler(_) => false,
             TypeKind::Atomic(atomic_type) => atomic_type.inner.is_err(db),
@@ -62,6 +63,7 @@ impl Type {
             | TypeKind::BuiltinStruct(_)
             | TypeKind::Array(_)
             | TypeKind::Texture(_)
+            | TypeKind::RayQuery(_)
             | TypeKind::AccelerationStructure(_)
             | TypeKind::Sampler(_)
             | TypeKind::Pointer(_) => self,
@@ -157,6 +159,7 @@ impl Type {
             | TypeKind::Texture(_)
             | TypeKind::Sampler(_)
             | TypeKind::Reference(_)
+            | TypeKind::RayQuery(_)
             | TypeKind::AccelerationStructure(_)
             | TypeKind::Pointer(_) => false,
         }
@@ -170,23 +173,29 @@ pub struct BuiltinStruct {
     pub fields: Vec<(String, Type)>,
 }
 
+#[expect(clippy::doc_paragraphs_missing_punctuation, reason = "false positive")]
+/// <https://www.w3.org/TR/WGSL/#types>
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeKind {
-    Error,
+    #[expect(clippy::doc_paragraphs_missing_punctuation, reason = "false positive")]
+    /// <https://www.w3.org/TR/WGSL/#scalar-types>
     Scalar(ScalarType),
-    Atomic(AtomicType),
     #[expect(clippy::doc_paragraphs_missing_punctuation, reason = "false positive")]
     /// <https://www.w3.org/TR/WGSL/#vector-types>
     Vector(VectorType),
     Matrix(MatrixType),
+    Atomic(AtomicType),
+    Array(ArrayType),
     Struct(StructId),
     BuiltinStruct(BuiltinStruct),
-    Array(ArrayType),
     Texture(TextureType),
     Sampler(SamplerType),
     Reference(Reference),
     Pointer(Pointer),
+    RayQuery(Option<AccelerationStructureTags>),
     AccelerationStructure(Option<AccelerationStructureTags>),
+    // internal
+    Error,
 }
 
 impl hash::Hash for TypeKind {
@@ -224,6 +233,7 @@ impl TypeKind {
             | Self::BuiltinStruct(_)
             | Self::Array(_)
             | Self::Texture(_)
+            | Self::RayQuery(_)
             | Self::AccelerationStructure(_)
             | Self::Sampler(_)
             | Self::Pointer(_) => Cow::Borrowed(self),
@@ -271,8 +281,9 @@ impl TypeKind {
             | Self::Texture(_)
             | Self::Sampler(_)
             | Self::Reference(_)
-            | Self::AccelerationStructure(_)
-            | Self::Pointer(_) => return None,
+            | Self::Pointer(_)
+            | Self::RayQuery(_)
+            | Self::AccelerationStructure(_) => return None,
         })
     }
 
@@ -280,8 +291,7 @@ impl TypeKind {
     pub const fn is_numeric_scalar(&self) -> bool {
         match self {
             Self::Scalar(scalar) => scalar.is_numeric(),
-            Self::Error
-            | Self::Atomic(_)
+            Self::Atomic(_)
             | Self::Vector(_)
             | Self::Matrix(_)
             | Self::Struct(_)
@@ -290,8 +300,10 @@ impl TypeKind {
             | Self::Texture(_)
             | Self::Sampler(_)
             | Self::Reference(_)
+            | Self::Pointer(_)
+            | Self::RayQuery(_)
             | Self::AccelerationStructure(_)
-            | Self::Pointer(_) => false,
+            | Self::Error => false,
         }
     }
 
@@ -299,7 +311,7 @@ impl TypeKind {
     pub const fn is_index(&self) -> bool {
         match self {
             Self::Scalar(scalar) => scalar.is_index(),
-            Self::Error
+            Self::Pointer(_)
             | Self::Atomic(_)
             | Self::BuiltinStruct(_)
             | Self::Vector(_)
@@ -309,8 +321,9 @@ impl TypeKind {
             | Self::Texture(_)
             | Self::Sampler(_)
             | Self::Reference(_)
+            | Self::RayQuery(_)
             | Self::AccelerationStructure(_)
-            | Self::Pointer(_) => false,
+            | Self::Error => false,
         }
     }
 
@@ -336,15 +349,16 @@ impl TypeKind {
                 rows: _,
             }) => inner.kind(db).is_abstract(db),
             Self::Scalar(_)
-            | Self::Error
             | Self::Atomic(_)
             | Self::Struct(_)
             | Self::BuiltinStruct(_)
             | Self::Texture(_)
             | Self::Sampler(_)
             | Self::Reference(_)
+            | Self::Pointer(_)
+            | Self::RayQuery(_)
             | Self::AccelerationStructure(_)
-            | Self::Pointer(_) => false,
+            | Self::Error => false,
         }
     }
 
@@ -418,8 +432,9 @@ impl TypeKind {
             | Self::Texture(_)
             | Self::Sampler(_)
             | Self::Reference(_)
-            | Self::AccelerationStructure(_)
-            | Self::Pointer(_) => false,
+            | Self::Pointer(_)
+            | Self::RayQuery(_)
+            | Self::AccelerationStructure(_) => false,
         }
     }
 
@@ -438,8 +453,8 @@ impl TypeKind {
                 .0
                 .iter()
                 .any(|(_, r#type)| r#type.kind(db).contains_runtime_sized_array(db)),
-            Self::Error
-            | Self::Scalar(_)
+
+            Self::Scalar(_)
             | Self::Atomic(_)
             | Self::Vector(_)
             | Self::Matrix(_)
@@ -448,8 +463,10 @@ impl TypeKind {
             | Self::Texture(_)
             | Self::Sampler(_)
             | Self::Reference(_)
+            | Self::Pointer(_)
+            | Self::RayQuery(_)
             | Self::AccelerationStructure(_)
-            | Self::Pointer(_) => false,
+            | Self::Error => false,
         }
     }
 
@@ -472,14 +489,16 @@ impl TypeKind {
             Self::Array(array) => array.inner.contains_struct(db, r#struct),
             Self::Reference(reference) => reference.inner.contains_struct(db, r#struct),
             Self::Pointer(pointer) => pointer.inner.contains_struct(db, r#struct),
-            Self::Error
-            | Self::Scalar(_)
+
+            Self::Scalar(_)
             | Self::Vector(_)
             | Self::Matrix(_)
+            | Self::Sampler(_)
             | Self::BuiltinStruct(_)
             | Self::Texture(_)
+            | Self::RayQuery(_)
             | Self::AccelerationStructure(_)
-            | Self::Sampler(_) => false,
+            | Self::Error => false,
         }
     }
 }

--- a/crates/hir_ty/src/ty.rs
+++ b/crates/hir_ty/src/ty.rs
@@ -150,10 +150,15 @@ impl Type {
                 .0
                 .iter()
                 .all(|(_, field_type)| *field_type.is_constructible(db)),
-            TypeKind::BuiltinStruct(builtin_struct) => builtin_struct
-                .fields
-                .iter()
-                .all(|(_, field_type)| *field_type.is_constructible(db)),
+            TypeKind::BuiltinStruct(builtin_struct) => {
+                // This implementation matches naga.
+                // Builtin structs like __atomic_compare_exchange_result are "not constructible" because they are impossible to write in source code.
+                // The reason is that two underscores "__" may not begin an identifier.
+                builtin_struct
+                    .fields
+                    .iter()
+                    .all(|(_, field_type)| *field_type.is_constructible(db))
+            },
             TypeKind::Array(array_type) => array_type.is_constructible(db),
             TypeKind::Atomic(_)
             | TypeKind::Texture(_)

--- a/crates/hir_ty/src/ty.rs
+++ b/crates/hir_ty/src/ty.rs
@@ -45,31 +45,6 @@ impl Type {
         }
     }
 
-    #[expect(clippy::doc_paragraphs_missing_punctuation, reason = "false positive")]
-    /// `T` -> `T`, `vecN<T>` -> `T`
-    #[must_use]
-    pub fn this_or_vec_inner(
-        self,
-        db: &dyn HirDatabase,
-    ) -> Self {
-        match self.kind(db) {
-            TypeKind::Vector(vector) => vector.component_type,
-            TypeKind::Reference(reference) => reference.inner.this_or_vec_inner(db),
-            TypeKind::Error
-            | TypeKind::Scalar(_)
-            | TypeKind::Atomic(_)
-            | TypeKind::Matrix(_)
-            | TypeKind::Struct(_)
-            | TypeKind::BuiltinStruct(_)
-            | TypeKind::Array(_)
-            | TypeKind::Texture(_)
-            | TypeKind::RayQuery(_)
-            | TypeKind::AccelerationStructure(_)
-            | TypeKind::Sampler(_)
-            | TypeKind::Pointer(_) => self,
-        }
-    }
-
     pub fn is_convertible_to(
         self,
         r#type: Self,
@@ -296,6 +271,8 @@ impl TypeKind {
     pub const fn is_numeric_scalar(&self) -> bool {
         match self {
             Self::Scalar(scalar) => scalar.is_numeric(),
+            // be optimistic about errors
+            Self::Error => true,
             Self::Atomic(_)
             | Self::Vector(_)
             | Self::Matrix(_)
@@ -307,8 +284,7 @@ impl TypeKind {
             | Self::Reference(_)
             | Self::Pointer(_)
             | Self::RayQuery(_)
-            | Self::AccelerationStructure(_)
-            | Self::Error => false,
+            | Self::AccelerationStructure(_) => false,
         }
     }
 
@@ -316,6 +292,8 @@ impl TypeKind {
     pub const fn is_index(&self) -> bool {
         match self {
             Self::Scalar(scalar) => scalar.is_index(),
+            // be optimistic about errors
+            Self::Error => true,
             Self::Pointer(_)
             | Self::Atomic(_)
             | Self::BuiltinStruct(_)
@@ -327,8 +305,7 @@ impl TypeKind {
             | Self::Sampler(_)
             | Self::Reference(_)
             | Self::RayQuery(_)
-            | Self::AccelerationStructure(_)
-            | Self::Error => false,
+            | Self::AccelerationStructure(_) => false,
         }
     }
 
@@ -412,6 +389,7 @@ impl TypeKind {
                 | Self::Atomic(_)
                 | Self::Array(_)
                 | Self::Struct(_)
+                | Self::BuiltinStruct(_)
                 | Self::Texture(_)
                 | Self::Sampler(_)
         )

--- a/crates/hir_ty/src/ty/pretty.rs
+++ b/crates/hir_ty/src/ty/pretty.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Write as _};
 use base_db::{CapabilitiesInput, TextRange, TextSize};
 use hir_def::signature::StructSignature;
 use itertools::Itertools as _;
-use wgsl_types::ty::SamplerType;
+use wgsl_types::{tplt::AccelerationStructureTags, ty::SamplerType};
 
 use super::{Type, TypeKind};
 use crate::{
@@ -309,21 +309,25 @@ fn write_type(
         TypeKind::AccelerationStructure(tags) => {
             write!(formatter, "acceleration_structure")?;
             if let Some(tags) = tags {
-                write!(formatter, "<")?;
-                write!(
-                    formatter,
-                    "{}",
-                    tags.tags()
-                        .iter()
-                        .map(|tag| match tag {
-                            wgsl_types::syntax::AccelerationStructureTag::VertexReturn =>
-                                "vertex_return",
-                        })
-                        .join(", ")
-                )?;
-                write!(formatter, ">")?;
+                write!(formatter, "<{}>", display_tags(&tags))?;
+            }
+            Ok(())
+        },
+        TypeKind::RayQuery(tags) => {
+            write!(formatter, "ray_query")?;
+            if let Some(tags) = tags {
+                write!(formatter, "<{}>", display_tags(&tags))?;
             }
             Ok(())
         },
     }
+}
+
+fn display_tags(tags: &AccelerationStructureTags) -> String {
+    tags.tags()
+        .iter()
+        .map(|tag| match tag {
+            wgsl_types::syntax::AccelerationStructureTag::VertexReturn => "vertex_return",
+        })
+        .join(", ")
 }

--- a/crates/hir_ty/src/validate.rs
+++ b/crates/hir_ty/src/validate.rs
@@ -59,7 +59,7 @@ impl fmt::Display for AddressSpaceError {
             },
             Self::Constructable => formatter.write_str("type is not constructable"),
             Self::HostShareable => formatter.write_str("type is not host-shareable"),
-            Self::WorkgroupCompatible => formatter.write_str(""),
+            Self::WorkgroupCompatible => formatter.write_str("type is not workgroup compatible"),
             Self::HandleOrTexture => {
                 formatter.write_str("address space is only valid for handle or texture types")
             },

--- a/crates/hir_ty/src/validate.rs
+++ b/crates/hir_ty/src/validate.rs
@@ -35,7 +35,7 @@ pub enum AddressSpaceError {
     HostShareable,
     /// Plain type, excluding runtime-sized arrays.
     WorkgroupCompatible,
-    HandleOrTexture,
+    HandleCompatible,
     TaskPayloadCompatible,
 }
 
@@ -60,7 +60,7 @@ impl fmt::Display for AddressSpaceError {
             Self::Constructable => formatter.write_str("type is not constructable"),
             Self::HostShareable => formatter.write_str("type is not host-shareable"),
             Self::WorkgroupCompatible => formatter.write_str("type is not workgroup compatible"),
-            Self::HandleOrTexture => {
+            Self::HandleCompatible => {
                 formatter.write_str("address space is only valid for handle or texture types")
             },
             Self::TaskPayloadCompatible => {
@@ -168,6 +168,7 @@ pub fn validate_address_space<DiagnosticBuilder>(
                 TypeKind::Error
                 | TypeKind::Sampler(_)
                 | TypeKind::Texture(_)
+                | TypeKind::AccelerationStructure(_)
                 | TypeKind::Array(ArrayType {
                     binding_array: true,
                     inner: _,
@@ -182,9 +183,8 @@ pub fn validate_address_space<DiagnosticBuilder>(
                 | TypeKind::BuiltinStruct(_)
                 | TypeKind::Reference(_)
                 | TypeKind::Pointer(_)
-                | TypeKind::RayQuery(_)
-                | TypeKind::AccelerationStructure(_) => {
-                    diagnostic_builder(AddressSpaceError::HandleOrTexture);
+                | TypeKind::RayQuery(_) => {
+                    diagnostic_builder(AddressSpaceError::HandleCompatible);
                 },
             }
         },

--- a/crates/hir_ty/src/validate.rs
+++ b/crates/hir_ty/src/validate.rs
@@ -177,12 +177,13 @@ pub fn validate_address_space<DiagnosticBuilder>(
                 | TypeKind::Atomic(_)
                 | TypeKind::Vector(_)
                 | TypeKind::Matrix(_)
+                | TypeKind::Array(_)
                 | TypeKind::Struct(_)
                 | TypeKind::BuiltinStruct(_)
-                | TypeKind::Array(_)
-                | TypeKind::AccelerationStructure(_)
                 | TypeKind::Reference(_)
-                | TypeKind::Pointer(_) => {
+                | TypeKind::Pointer(_)
+                | TypeKind::RayQuery(_)
+                | TypeKind::AccelerationStructure(_) => {
                     diagnostic_builder(AddressSpaceError::HandleOrTexture);
                 },
             }

--- a/crates/ide-diagnostics/src/tests.rs
+++ b/crates/ide-diagnostics/src/tests.rs
@@ -619,3 +619,76 @@ fn foo() {
         "#]],
     );
 }
+
+#[test]
+fn not_host_shareable() {
+    check_diagnostics(
+        "
+@group(0) @binding(0)
+var<storage> x: ray_query;
+
+@group(0) @binding(0)
+var<storage> y: vec2<bool>;
+        ",
+        expect![[r#"
+            22..25 wgsl-analyzer Error 12: type is not host-shareable
+            72..75 wgsl-analyzer Error 12: type is not host-shareable
+        "#]],
+    );
+}
+
+#[test]
+fn not_index_scalar() {
+    check_diagnostics(
+        "
+@group(0) @binding(0)
+var<storage> x: u32 = vec2(1, 2)[1.0];
+        ",
+        expect![[r#"
+            55..58 wgsl-analyzer Error 2: expected i32 or u32, found float
+        "#]],
+    );
+}
+
+#[test]
+fn not_index_other() {
+    check_diagnostics(
+        "
+@group(0) @binding(0)
+var<storage> y: u32 = 1;
+
+@group(0) @binding(0)
+var<storage> x: u32 = vec2(1, 2)[&y];
+        ",
+        expect![[r#"
+            103..105 wgsl-analyzer Error 2: expected i32 or u32, found ptr<u32>
+        "#]],
+    );
+}
+
+#[test]
+fn indeterminate_index() {
+    check_diagnostics(
+        "
+@group(0) @binding(0)
+var<storage> x: u32 = vec2(1, 2)[y];
+        ",
+        expect![[r#"
+            55..56 wgsl-analyzer Error 14: `y` not found in scope
+        "#]],
+    );
+}
+
+#[test]
+fn workgroup_runtime_sized_array() {
+    check_diagnostics(
+        "
+struct Foo { foo: array<u32> }
+
+var<workgroup> x: Foo;
+        ",
+        expect![[r#"
+            32..35 wgsl-analyzer Error 12: type is not workgroup compatible
+        "#]],
+    );
+}

--- a/crates/ide-diagnostics/src/tests.rs
+++ b/crates/ide-diagnostics/src/tests.rs
@@ -625,14 +625,19 @@ fn not_host_shareable() {
     check_diagnostics(
         "
 @group(0) @binding(0)
-var<storage> x: ray_query;
+var<storage> a: ray_query;
 
 @group(0) @binding(0)
-var<storage> y: vec2<bool>;
+var<storage> b: vec2<bool>;
+
+@group(0) @binding(0)
+var<storage> c: vec2<Foo>; // error = optimistic
         ",
         expect![[r#"
             22..25 wgsl-analyzer Error 12: type is not host-shareable
             72..75 wgsl-analyzer Error 12: type is not host-shareable
+            144..147 wgsl-analyzer Error 14: `Foo` not found in scope
+            144..147 wgsl-analyzer Error 14: unexpected template argument, expected a scalar, actual: [error]
         "#]],
     );
 }
@@ -680,7 +685,7 @@ var<storage> x: u32 = vec2(1, 2)[y];
 }
 
 #[test]
-fn workgroup_runtime_sized_array() {
+fn workgroup_runtime_sized_array_struct() {
     check_diagnostics(
         "
 struct Foo { foo: array<u32> }
@@ -689,6 +694,21 @@ var<workgroup> x: Foo;
         ",
         expect![[r#"
             32..35 wgsl-analyzer Error 12: type is not workgroup compatible
+        "#]],
+    );
+}
+
+#[test]
+fn workgroup_runtime_sized_other() {
+    check_diagnostics(
+        "
+var<workgroup> a: array<u32>;
+var<workgroup> b: u32;
+var<workgroup> c: Foo;
+        ",
+        expect![[r#"
+            0..3 wgsl-analyzer Error 12: type is not workgroup compatible
+            71..74 wgsl-analyzer Error 13: `Foo` not found in scope
         "#]],
     );
 }

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -70,7 +70,7 @@ impl TryToNavigationTarget for Definition {
                 Self::BuiltinFunction(name) => None?,
                 Self::BuiltinType(name) => None?,
                 Self::BuiltinTypeGenerator(name) => None?,
-                // Self::BuiltinTypeConstructor(name) => None?,
+                Self::BuiltinTypeConstructor(name) => None?,
                 Self::BuiltinEnumerant(name) => None?,
                 Self::BuiltinDeclaration(name) => None?,
                 Self::Local(local) => local.try_to_navigation_target(db)?,

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -24,6 +24,7 @@ use syntax::{AstChildren, AstNode as _, HasName as _, SyntaxNode, ast};
 
 use crate::RootDatabase;
 
+#[derive(Clone, Debug, Default)]
 pub struct InlayHintsConfig {
     pub render_colons: bool,
     pub enabled: bool,
@@ -712,7 +713,7 @@ fn get_string_representation(expression: &AstExpression) -> Option<String> {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub struct InlayFieldsToResolve {
     pub resolve_text_edits: bool,
     pub resolve_hint_tooltip: bool,
@@ -742,5 +743,69 @@ impl InlayFieldsToResolve {
             resolve_label_location: false,
             resolve_label_command: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_db::EditionedFileId;
+    use expect_test::expect;
+    use hir::Semantics;
+    use stdx::itertools::Itertools as _;
+
+    use crate::{
+        InlayHintsConfig, fixture,
+        inlay_hints::{StructLayoutHints, get_struct_layout_hints},
+    };
+
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "easier to use with expect! macro"
+    )]
+    fn check(
+        source: &str,
+        expect: expect_test::Expect,
+    ) {
+        let (analysis, file_id) = fixture::single_file_db(source);
+        let mut buffer = Vec::new();
+        let semantics = Semantics::new(&analysis.db);
+        let file_id = EditionedFileId::from_file(&analysis.db, file_id);
+        get_struct_layout_hints(
+            &mut buffer,
+            file_id,
+            &semantics,
+            &InlayHintsConfig {
+                struct_layout_hints: Some(StructLayoutHints::Offset),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let lines = buffer
+            .iter()
+            .map(|inlay_hint| format!("{inlay_hint:?}"))
+            .join("\n");
+        expect.assert_eq(&lines);
+    }
+
+    #[test]
+    fn struct_layout_hints() {
+        check(
+            "
+struct Foo { foo1: bool, foo2: array<u32, 3>, foo3: bool, foo4: bool }
+var<uniform> x: Foo;
+
+struct Bar { bar1: bool, bar2: array<u32, 3>, bar3: bool, bar4: bool }
+var<storage> x: Bar;
+            ",
+            expect![[r#"
+                InlayHint { range: 13..23, position: After, pad_left: false, pad_right: false, kind: StructLayout, label: ["0"], text_edit: None, resolve_parent: Some(13..23) }
+                InlayHint { range: 25..44, position: After, pad_left: false, pad_right: false, kind: StructLayout, label: ["4"], text_edit: None, resolve_parent: Some(25..44) }
+                InlayHint { range: 46..56, position: After, pad_left: false, pad_right: false, kind: StructLayout, label: ["64"], text_edit: None, resolve_parent: Some(46..56) }
+                InlayHint { range: 58..68, position: After, pad_left: false, pad_right: false, kind: StructLayout, label: ["68"], text_edit: None, resolve_parent: Some(58..68) }
+                InlayHint { range: 106..116, position: After, pad_left: false, pad_right: false, kind: StructLayout, label: ["0"], text_edit: None, resolve_parent: Some(106..116) }
+                InlayHint { range: 118..137, position: After, pad_left: false, pad_right: false, kind: StructLayout, label: ["4"], text_edit: None, resolve_parent: Some(118..137) }
+                InlayHint { range: 139..149, position: After, pad_left: false, pad_right: false, kind: StructLayout, label: ["16"], text_edit: None, resolve_parent: Some(139..149) }
+                InlayHint { range: 151..161, position: After, pad_left: false, pad_right: false, kind: StructLayout, label: ["20"], text_edit: None, resolve_parent: Some(151..161) }"#]],
+        );
     }
 }

--- a/crates/ide_completion/src/completions/dot.rs
+++ b/crates/ide_completion/src/completions/dot.rs
@@ -65,16 +65,18 @@ pub(crate) fn complete_dot(
             builtin_struct_completions(accumulator, context, &builtin_struct);
             Some(())
         },
-        TypeKind::Error
-        | TypeKind::Scalar(_)
+
+        TypeKind::Scalar(_)
         | TypeKind::Atomic(_)
         | TypeKind::Matrix(_)
         | TypeKind::Array(_)
         | TypeKind::Texture(_)
         | TypeKind::Sampler(_)
-        | TypeKind::AccelerationStructure(_)
         | TypeKind::Reference(_)
-        | TypeKind::Pointer(_) => None,
+        | TypeKind::Pointer(_)
+        | TypeKind::RayQuery(_)
+        | TypeKind::AccelerationStructure(_)
+        | TypeKind::Error => None,
     }
 }
 

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -341,9 +341,7 @@ impl<'source> ParserCallbacks<'source> for Parser<'source> {
             "wgpu_ray_query_vertex_return" => {
                 self.context.extensions.wgpu_ray_query_vertex_return = true
             },
-            "wgpu_ray_tracing_pipelines" => {
-                self.context.extensions.wgpu_ray_tracing_pipelines = true
-            },
+            "wgpu_ray_tracing_pipeline" => self.context.extensions.wgpu_ray_tracing_pipeline = true,
             "wgpu_int16" => self.context.extensions.wgpu_int16 = true,
             "wgpu_cooperative_matrix" => self.context.extensions.wgpu_cooperative_matrix = true,
             "per_vertex" => self.context.extensions.per_vertex = true,

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -430,7 +430,7 @@ impl EnableExtensionName {
             "wgpu_mesh_shader" => Ok(EnableExtension::WgpuMeshShader),
             "wgpu_ray_query" => Ok(EnableExtension::WgpuRayQuery),
             "wgpu_ray_query_vertex_return" => Ok(EnableExtension::WgpuRayQueryVertexReturn),
-            "wgpu_ray_tracing_pipelines" => Ok(EnableExtension::WgpuRayTracingPipelines),
+            "wgpu_ray_tracing_pipeline" => Ok(EnableExtension::WgpuRayTracingPipelines),
             "wgpu_int16" => Ok(EnableExtension::WgpuInt16),
             "wgpu_cooperative_matrix" => Ok(EnableExtension::WgpuCooperativeMatrix),
             "per_vertex" => Ok(EnableExtension::PerVertex),

--- a/crates/syntax/src/tests.rs
+++ b/crates/syntax/src/tests.rs
@@ -427,10 +427,10 @@ fn enable_extension_names() {
     let parsed = check_errors(
         "
         enable f16, clip_distances, dual_source_blending, subgroups, primitive_index, subgroup_size_control;
-        enable wgpu_mesh_shader, wgpu_ray_query, wgpu_ray_query_vertex_return, wgpu_ray_tracing_pipelines, wgpu_int16, wgpu_cooperative_matrix, per_vertex, draw_index, wgpu_binding_array;
+        enable wgpu_mesh_shader, wgpu_ray_query, wgpu_ray_query_vertex_return, wgpu_ray_tracing_pipeline, wgpu_int16, wgpu_cooperative_matrix, per_vertex, draw_index, wgpu_binding_array;
         enable unknown_nonsense;
         ",
-        expect!["error at 313..329: unknown extension: `unknown_nonsense`"],
+        expect!["error at 312..328: unknown extension: `unknown_nonsense`"],
     );
     let items = vec![
         Ok(EnableExtension::F16),

--- a/typos.toml
+++ b/typos.toml
@@ -69,3 +69,4 @@ extend-ignore-identifiers-re = []
 "sep" = "separator"
 "tok" = "token"
 # "expr" = "expression" # rust macro keyword
+"sharable" = "shareable"


### PR DESCRIPTION
# Objective

Adds support for `ray_query`, `RayDesc`, and `RayIntersection` types.
Support for builtin functions naturally follows thanks to wgsl-types.

Fixes #1388
Fixes #1399 

## Solution

Support built-in constructors, lower these types.

## Testing

Many tests added. Add coverage for misc affected functions.

## Showcase

<img width="1107" height="1220" alt="Screenshot_2026-08-27_18-04-58" src="https://github.com/user-attachments/assets/3989a38e-552a-4b73-a4bd-e4dddfc3e469" />

