### PR TITLE
remove dependency on rust-analyzer git

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,10 @@
 [alias]
 xtask = "run --package xtask --bin xtask --"
-lint = "clippy --all-targets -- --cap-lints warn"
+lint = "clippy --all-targets --all-features -- --cap-lints warn"
 codegen = "run --package xtask --bin xtask -- codegen"
 dist = "run --package xtask --bin xtask -- dist"
+l = "llvm-cov --lcov --output-path lcov.info"
+c = "clippy --all-targets --all-features -- --cap-lints warn"
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +55,21 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
 
 [[package]]
 name = "base-db"
@@ -92,6 +116,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d87354e4229f54a44f7bf2435906a4656dba36026ab6eaca629a2c436a691c"
+dependencies = [
+ "bit-vec 0.10.1",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +135,12 @@ name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
+name = "bit-vec"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5727b15fa97d4f4fee0a3b7c3d550ed0269f54329207b86388de918604e31269"
 
 [[package]]
 name = "bitflags"
@@ -172,9 +211,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
@@ -445,6 +484,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,7 +577,7 @@ dependencies = [
  "either",
  "expect-test",
  "indexmap",
- "itertools 0.15.0",
+ "itertools",
  "la-arena",
  "rowan",
  "rustc-hash 2.1.3",
@@ -554,7 +599,7 @@ dependencies = [
  "either",
  "expect-test",
  "hir-def",
- "itertools 0.15.0",
+ "itertools",
  "la-arena",
  "rustc-hash 2.1.3",
  "salsa",
@@ -582,7 +627,7 @@ dependencies = [
  "ide-completion",
  "ide-db",
  "ide-diagnostics",
- "itertools 0.15.0",
+ "itertools",
  "line-index",
  "rowan",
  "rustc-hash 2.1.3",
@@ -609,7 +654,7 @@ dependencies = [
  "hir-def",
  "hir-ty",
  "ide-db",
- "itertools 0.15.0",
+ "itertools",
  "rustc-hash 2.1.3",
  "smallvec",
  "smol_str",
@@ -625,7 +670,7 @@ name = "ide-db"
 version = "0.0.0"
 dependencies = [
  "base-db",
- "itertools 0.15.0",
+ "itertools",
  "line-index",
  "rowan",
  "rustc-hash 2.1.3",
@@ -646,12 +691,12 @@ dependencies = [
  "hir-def",
  "hir-ty",
  "ide-db",
- "itertools 0.15.0",
+ "itertools",
  "line-index",
- "naga 27.0.3",
  "naga 28.0.0",
- "naga 29.0.0",
  "naga 29.0.3",
+ "naga 30.0.0",
+ "naga 30.0.1",
  "paths",
  "rowan",
  "serde",
@@ -704,15 +749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -875,32 +911,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "naga"
-version = "27.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
-dependencies = [
- "arrayvec",
- "bit-set 0.8.0",
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "codespan-reporting 0.12.0",
- "half",
- "hashbrown 0.16.1",
- "hexf-parse",
- "indexmap",
- "libm",
- "log",
- "num-traits",
- "once_cell",
- "rustc-hash 1.1.0",
- "thiserror",
- "unicode-ident",
+ "windows-sys",
 ]
 
 [[package]]
@@ -918,29 +929,6 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
- "indexmap",
- "libm",
- "log",
- "num-traits",
- "once_cell",
- "rustc-hash 1.1.0",
- "thiserror",
- "unicode-ident",
-]
-
-[[package]]
-name = "naga"
-version = "29.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=ff438f3cadb8a25e0f36409566a6fb50f6707e02#ff438f3cadb8a25e0f36409566a6fb50f6707e02"
-dependencies = [
- "arrayvec",
- "bit-set 0.10.0",
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "codespan-reporting 0.13.1",
- "half",
- "hashbrown 0.16.1",
  "indexmap",
  "libm",
  "log",
@@ -977,6 +965,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "naga"
+version = "30.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=5887663c8ea23f31408e4b9dc89bede6f6ee6c36#5887663c8ea23f31408e4b9dc89bede6f6ee6c36"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.11.1",
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting 0.13.1",
+ "half",
+ "hashbrown 0.17.0",
+ "indexmap",
+ "libm",
+ "log",
+ "naga-types 30.0.0",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "thiserror",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a616d2fb8c89516ac2723a581f69d6c18576046bed761bd6b305e5618e6ae130"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting 0.13.1",
+ "half",
+ "hashbrown 0.17.0",
+ "indexmap",
+ "libm",
+ "log",
+ "naga-types 30.0.1",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "thiserror",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=5887663c8ea23f31408e4b9dc89bede6f6ee6c36#5887663c8ea23f31408e4b9dc89bede6f6ee6c36"
+dependencies = [
+ "hashbrown 0.17.0",
+ "indexmap",
+ "rustc-hash 1.1.0",
+ "thiserror",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49"
+dependencies = [
+ "hashbrown 0.17.0",
+ "indexmap",
+ "rustc-hash 1.1.0",
+ "thiserror",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,7 +1048,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1024,6 +1084,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1082,7 +1151,6 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "paths"
 version = "0.0.0"
-source = "git+https://github.com/rust-lang/rust-analyzer?rev=b42b63f390a4dab14e6efa34a70e67f5b087cc62#b42b63f390a4dab14e6efa34a70e67f5b087cc62"
 dependencies = [
  "camino",
 ]
@@ -1156,7 +1224,7 @@ dependencies = [
  "libc",
  "perf-event",
  "tikv-jemalloc-ctl",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1241,6 +1309,12 @@ dependencies = [
  "rustc-hash 1.1.0",
  "text-size",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -1430,16 +1504,16 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stdx"
 version = "0.0.0"
-source = "git+https://github.com/rust-lang/rust-analyzer?rev=b42b63f390a4dab14e6efa34a70e67f5b087cc62#b42b63f390a4dab14e6efa34a70e67f5b087cc62"
 dependencies = [
+ "backtrace",
  "crossbeam-channel",
  "crossbeam-utils",
- "itertools 0.14.0",
+ "itertools",
  "jod-thread",
  "libc",
  "miow",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1470,7 +1544,7 @@ version = "0.0.0"
 dependencies = [
  "either",
  "expect-test",
- "itertools 0.15.0",
+ "itertools",
  "parser",
  "rowan",
  "smol_str",
@@ -1881,7 +1955,7 @@ dependencies = [
  "ide-db",
  "ide-diagnostics",
  "idna_adapter",
- "itertools 0.15.0",
+ "itertools",
  "line-index",
  "lsp-server",
  "memchr",
@@ -1903,7 +1977,7 @@ dependencies = [
  "triomphe",
  "vfs",
  "vfs-notify",
- "windows-sys 0.61.2",
+ "windows-sys",
  "xflags",
 ]
 
@@ -1925,7 +1999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfc32acf991054fb0290c5fb03d9dae60be8cbc9245c9c26e4420e11e8c0045"
 dependencies = [
  "half",
- "itertools 0.15.0",
+ "itertools",
  "num-traits",
 ]
 
@@ -1950,7 +2024,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1961,86 +2035,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,12 +573,12 @@ name = "hir-def"
 version = "0.0.0"
 dependencies = [
  "base-db",
- "camino",
  "either",
  "expect-test",
  "indexmap",
  "itertools",
  "la-arena",
+ "paths",
  "rowan",
  "rustc-hash 2.1.3",
  "salsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,8 @@ vfs = { path = "./crates/vfs", version = "0.0.0" }
 vfs-notify = { path = "./crates/vfs-notify", version = "0.0.0" }
 wgsl-formatter = { path = "./crates/wgsl_formatter", version = "0.0.0" }
 edition = { path = "./crates/edition", version = "0.0.0" }
-#
-# rust-analyzer crates
-stdx = { git = "https://github.com/rust-lang/rust-analyzer", rev = "b42b63f390a4dab14e6efa34a70e67f5b087cc62", version = "0.0.0" }
-paths = { git = "https://github.com/rust-lang/rust-analyzer", rev = "b42b63f390a4dab14e6efa34a70e67f5b087cc62", version = "0.0.0" }
+stdx = { path = "./crates/stdx", version = "0.0.0" }
+paths = { path = "./crates/paths", version = "0.0.0" }
 #
 # crates from rust-analyzer that are published separately
 line-index = "0.1.2"

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -12,11 +12,11 @@ doctest = false
 
 [dependencies]
 base-db.workspace = true
-camino.workspace = true
 either.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 la-arena.workspace = true
+paths.workspace = true
 rowan.workspace = true
 rustc-hash.workspace = true
 salsa.workspace = true

--- a/crates/hir_def/src/mod_path.rs
+++ b/crates/hir_def/src/mod_path.rs
@@ -3,7 +3,7 @@
 use std::{fmt, iter};
 
 use base_db::{EditionedFileId, Package, SourceDatabase};
-use camino::Utf8Component;
+use paths::Utf8Component;
 use smallvec::SmallVec;
 use syntax::ast::{self, ImportRelative};
 

--- a/crates/ide-diagnostics/Cargo.toml
+++ b/crates/ide-diagnostics/Cargo.toml
@@ -20,14 +20,14 @@ hir-ty.workspace = true
 ide-db.workspace = true
 itertools.workspace = true
 line-index.workspace = true
-naga27 = { package = "naga", version = "27.0.3", features = ["wgsl-in"] }
 naga28 = { package = "naga", version = "28.0.0", features = ["wgsl-in"] }
 naga29 = { package = "naga", version = "29.0.1", features = ["wgsl-in"] }
+naga30 = { package = "naga", version = "30.0.1", features = ["wgsl-in"] }
 nagamain = {
 	package = "naga",
 	git = "https://github.com/gfx-rs/wgpu",
-	rev = "ff438f3cadb8a25e0f36409566a6fb50f6707e02",
-	version = "29.0.0",
+	rev = "5887663c8ea23f31408e4b9dc89bede6f6ee6c36",
+	version = "30.0.0",
 	features = [
 		"wgsl-in",
 	]

--- a/crates/ide-diagnostics/src/lib.rs
+++ b/crates/ide-diagnostics/src/lib.rs
@@ -23,16 +23,16 @@ use syntax::{AstNode as _, Edition};
 use vfs::FileId;
 
 use crate::{
-    naga::{Naga27, Naga28, Naga29, NagaMain, naga_diagnostics},
+    naga::{Naga28, Naga29, Naga30, NagaMain, naga_diagnostics},
     tint::tint_diagnostics,
 };
 
 #[derive(Clone, Copy, Debug, Default)]
 pub enum NagaVersion {
-    Naga27,
     Naga28,
-    #[default]
     Naga29,
+    #[default]
+    Naga30,
     NagaMain,
 }
 
@@ -197,14 +197,14 @@ pub fn diagnostics(
     let edition = file_id.edition(db);
     if edition == Edition::Wgsl && (config.naga_parsing_enabled || config.naga_validation_enabled) {
         match &config.naga_version {
-            NagaVersion::Naga27 => {
-                naga_diagnostics::<Naga27>(db, file_id, config, &mut diagnostics);
-            },
             NagaVersion::Naga28 => {
                 naga_diagnostics::<Naga28>(db, file_id, config, &mut diagnostics);
             },
             NagaVersion::Naga29 => {
                 naga_diagnostics::<Naga29>(db, file_id, config, &mut diagnostics);
+            },
+            NagaVersion::Naga30 => {
+                naga_diagnostics::<Naga30>(db, file_id, config, &mut diagnostics);
             },
             NagaVersion::NagaMain => {
                 naga_diagnostics::<NagaMain>(db, file_id, config, &mut diagnostics);

--- a/crates/ide-diagnostics/src/naga.rs
+++ b/crates/ide-diagnostics/src/naga.rs
@@ -1,16 +1,16 @@
-mod naga27;
 mod naga28;
 mod naga29;
+mod naga30;
 mod naga_main;
 
-use std::{error, range::Range};
+use std::{error, ops::Deref, range::Range};
 
 use base_db::{EditionedFileId, FileRange};
 use hir::{HirDatabase, diagnostics::AnyDiagnostic};
 pub(crate) use naga_main::NagaMain;
-pub(crate) use naga27::Naga27;
 pub(crate) use naga28::Naga28;
 pub(crate) use naga29::Naga29;
+pub(crate) use naga30::Naga30;
 use rowan::{TextRange, TextSize};
 
 use crate::DiagnosticsConfig;
@@ -21,7 +21,7 @@ pub(crate) trait Naga {
     type ValidationError: NagaError;
 
     fn parse(source: &str) -> Result<Self::Module, Self::ParseError>;
-    fn validate(module: &Self::Module) -> Result<(), Self::ValidationError>;
+    fn validate(module: &Self::Module) -> Result<(), Box<Self::ValidationError>>;
 }
 
 pub(crate) trait NagaError: error::Error {
@@ -89,7 +89,7 @@ pub(crate) fn naga_diagnostics<Naga>(
                 return;
             }
             if let Err(error) = Naga::validate(&module) {
-                emit(db, &error, file_id, full_range, accumulator);
+                emit(db, &*error, file_id, full_range, accumulator);
             }
         },
         Err(error) => {

--- a/crates/ide-diagnostics/src/naga/naga28.rs
+++ b/crates/ide-diagnostics/src/naga/naga28.rs
@@ -11,11 +11,11 @@ impl Naga for Naga28 {
         naga28::front::wgsl::parse_str(source)
     }
 
-    fn validate(module: &Self::Module) -> Result<(), Self::ValidationError> {
+    fn validate(module: &Self::Module) -> Result<(), Box<Self::ValidationError>> {
         let flags = naga28::valid::ValidationFlags::all();
         let capabilities = naga28::valid::Capabilities::all();
         let mut validator = naga28::valid::Validator::new(flags, capabilities);
-        validator.validate(module).map(drop)
+        Ok(validator.validate(module).map(drop)?)
     }
 }
 

--- a/crates/ide-diagnostics/src/naga/naga29.rs
+++ b/crates/ide-diagnostics/src/naga/naga29.rs
@@ -11,11 +11,11 @@ impl Naga for Naga29 {
         naga29::front::wgsl::parse_str(source)
     }
 
-    fn validate(module: &Self::Module) -> Result<(), Self::ValidationError> {
+    fn validate(module: &Self::Module) -> Result<(), Box<Self::ValidationError>> {
         let flags = naga29::valid::ValidationFlags::all();
         let capabilities = naga29::valid::Capabilities::all();
         let mut validator = naga29::valid::Validator::new(flags, capabilities);
-        validator.validate(module).map(drop)
+        Ok(validator.validate(module).map(drop)?)
     }
 }
 

--- a/crates/ide-diagnostics/src/naga/naga30.rs
+++ b/crates/ide-diagnostics/src/naga/naga30.rs
@@ -1,25 +1,25 @@
 use super::{Naga, NagaError, Range};
 
-pub struct Naga27;
+pub struct Naga30;
 
-impl Naga for Naga27 {
-    type Module = naga27::Module;
-    type ParseError = naga27::front::wgsl::ParseError;
-    type ValidationError = naga27::WithSpan<naga27::valid::ValidationError>;
+impl Naga for Naga30 {
+    type Module = naga30::Module;
+    type ParseError = naga30::front::wgsl::ParseError;
+    type ValidationError = naga30::WithSpan<naga30::valid::ValidationError>;
 
     fn parse(source: &str) -> Result<Self::Module, Self::ParseError> {
-        naga27::front::wgsl::parse_str(source)
+        naga30::front::wgsl::parse_str(source)
     }
 
-    fn validate(module: &Self::Module) -> Result<(), Self::ValidationError> {
-        let flags = naga27::valid::ValidationFlags::all();
-        let capabilities = naga27::valid::Capabilities::all();
-        let mut validator = naga27::valid::Validator::new(flags, capabilities);
-        validator.validate(module).map(drop)
+    fn validate(module: &Self::Module) -> Result<(), Box<Self::ValidationError>> {
+        let flags = naga30::valid::ValidationFlags::all();
+        let capabilities = naga30::valid::Capabilities::all();
+        let mut validator = naga30::valid::Validator::new(flags, capabilities);
+        Ok(validator.validate(module).map(drop)?)
     }
 }
 
-impl NagaError for naga27::front::wgsl::ParseError {
+impl NagaError for naga30::front::wgsl::ParseError {
     fn spans(&self) -> Box<dyn Iterator<Item = (Option<Range<usize>>, String)> + '_> {
         Box::new(
             self.labels()
@@ -33,7 +33,7 @@ impl NagaError for naga27::front::wgsl::ParseError {
     }
 }
 
-impl NagaError for naga27::WithSpan<naga27::valid::ValidationError> {
+impl NagaError for naga30::WithSpan<naga30::valid::ValidationError> {
     fn spans(&self) -> Box<dyn Iterator<Item = (Option<Range<usize>>, String)> + '_> {
         Box::new(
             self.spans()
@@ -46,6 +46,6 @@ impl NagaError for naga27::WithSpan<naga27::valid::ValidationError> {
     }
 }
 
-fn to_range(span: naga27::Span) -> Option<Range<usize>> {
+fn to_range(span: naga30::Span) -> Option<Range<usize>> {
     span.to_range().map(Range::from)
 }

--- a/crates/ide-diagnostics/src/naga/naga_main.rs
+++ b/crates/ide-diagnostics/src/naga/naga_main.rs
@@ -11,7 +11,7 @@ impl Naga for NagaMain {
         nagamain::front::wgsl::parse_str(source)
     }
 
-    fn validate(module: &Self::Module) -> Result<(), Self::ValidationError> {
+    fn validate(module: &Self::Module) -> Result<(), Box<Self::ValidationError>> {
         let flags = nagamain::valid::ValidationFlags::all();
         let capabilities = nagamain::valid::Capabilities::all();
         let mut validator = nagamain::valid::Validator::new(flags, capabilities);

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "paths"
 version = "0.0.0"
-repository.workspace = true
 description = "Path wrappers for absolute and relative paths wgsl-analyzer."
+repository.workspace = true
 
 edition.workspace = true
-license.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "paths"
+version = "0.0.0"
+repository.workspace = true
+description = "Path wrappers for absolute and relative paths wgsl-analyzer."
+
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+camino.workspace = true
+
+[features]
+serde1 = ["camino/serde1"]
+
+[lints]
+workspace = true

--- a/crates/paths/src/absolute.rs
+++ b/crates/paths/src/absolute.rs
@@ -1,0 +1,605 @@
+use std::{
+    borrow::Borrow,
+    ffi::OsStr,
+    fmt, ops,
+    path::{Path, PathBuf},
+};
+
+use camino::{Utf8Components, Utf8Path, Utf8PathBuf};
+
+use crate::{RelPath, normalize_path};
+
+/// A [`Utf8PathBuf`] that is guaranteed to be absolute.
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, Hash)]
+pub struct AbsPathBuf(pub(crate) Utf8PathBuf);
+
+impl From<AbsPathBuf> for Utf8PathBuf {
+    fn from(AbsPathBuf(path_buf): AbsPathBuf) -> Self {
+        path_buf
+    }
+}
+
+impl From<AbsPathBuf> for PathBuf {
+    fn from(AbsPathBuf(path_buf): AbsPathBuf) -> Self {
+        path_buf.into()
+    }
+}
+
+impl ops::Deref for AbsPathBuf {
+    type Target = AbsPath;
+
+    fn deref(&self) -> &AbsPath {
+        self.as_path()
+    }
+}
+
+impl AsRef<Utf8Path> for AbsPathBuf {
+    fn as_ref(&self) -> &Utf8Path {
+        self.0.as_path()
+    }
+}
+
+impl AsRef<OsStr> for AbsPathBuf {
+    fn as_ref(&self) -> &OsStr {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<Path> for AbsPathBuf {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<AbsPath> for AbsPathBuf {
+    fn as_ref(&self) -> &AbsPath {
+        self.as_path()
+    }
+}
+
+impl Borrow<AbsPath> for AbsPathBuf {
+    fn borrow(&self) -> &AbsPath {
+        self.as_path()
+    }
+}
+
+impl TryFrom<Utf8PathBuf> for AbsPathBuf {
+    type Error = Utf8PathBuf;
+    fn try_from(path_buf: Utf8PathBuf) -> Result<Self, Utf8PathBuf> {
+        if !path_buf.is_absolute() {
+            return Err(path_buf);
+        }
+        Ok(Self(path_buf))
+    }
+}
+
+impl TryFrom<&str> for AbsPathBuf {
+    type Error = Utf8PathBuf;
+    fn try_from(path: &str) -> Result<Self, Utf8PathBuf> {
+        Self::try_from(Utf8PathBuf::from(path))
+    }
+}
+
+impl<P: AsRef<Path> + ?Sized> PartialEq<P> for AbsPathBuf {
+    fn eq(
+        &self,
+        other: &P,
+    ) -> bool {
+        self.0.as_std_path() == other.as_ref()
+    }
+}
+
+impl AbsPathBuf {
+    /// Wrap the given absolute path in [`AbsPathBuf`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `path` is not absolute.
+    #[must_use]
+    pub fn assert(path: Utf8PathBuf) -> Self {
+        Self::try_from(path).unwrap_or_else(|path| panic!("expected absolute path, got {path}"))
+    }
+
+    /// Wrap the given absolute path in [`AbsPathBuf`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `path` is not absolute.
+    #[must_use]
+    pub fn assert_utf8(path: PathBuf) -> Self {
+        Self::assert(
+            Utf8PathBuf::from_path_buf(path)
+                .unwrap_or_else(|path| panic!("expected utf8 path, got {}", path.display())),
+        )
+    }
+
+    /// Coerces to an [`AbsPath`] slice.
+    ///
+    /// Equivalent of [`Utf8PathBuf::as_path`] for [`AbsPathBuf`].
+    #[must_use]
+    pub fn as_path(&self) -> &AbsPath {
+        // SAFETY: the path is already known to be absolute
+        unsafe { AbsPath::new_unchecked(self.0.as_path()) }
+    }
+
+    /// Equivalent of [`Utf8PathBuf::pop`] for [`AbsPathBuf`].
+    ///
+    /// Note that this won't remove the root component, so `self` will still be
+    /// absolute.
+    pub fn pop(&mut self) -> bool {
+        self.0.pop()
+    }
+
+    /// Equivalent of [`PathBuf::push`] for [`AbsPathBuf`].
+    ///
+    /// Extends `self` with `path`.
+    ///
+    /// If `path` is absolute, it replaces the current path.
+    ///
+    /// On Windows:
+    ///
+    /// * if `path` has a root but no prefix (e.g., `\windows`), it
+    ///   replaces everything except for the prefix (if any) of `self`.
+    /// * if `path` has a prefix but no root, it replaces `self`.
+    /// * if `self` has a verbatim prefix (e.g. `\\?\C:\windows`)
+    ///   and `path` is not empty, the new path is normalized: all references
+    ///   to `.` and `..` are removed.
+    pub fn push<Path>(
+        &mut self,
+        suffix: Path,
+    ) where
+        Path: AsRef<Utf8Path>,
+    {
+        self.0.push(suffix);
+    }
+
+    #[must_use]
+    pub fn join<Path>(
+        &self,
+        path: Path,
+    ) -> Self
+    where
+        Path: AsRef<Utf8Path>,
+    {
+        Self(self.0.join(path))
+    }
+}
+
+impl fmt::Display for AbsPathBuf {
+    fn fmt(
+        &self,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
+/// Wrapper around an absolute [`Utf8Path`].
+#[derive(Debug, Ord, PartialOrd, Eq, Hash)]
+#[repr(transparent)]
+pub struct AbsPath(Utf8Path);
+
+impl<P: AsRef<Path> + ?Sized> PartialEq<P> for AbsPath {
+    fn eq(
+        &self,
+        other: &P,
+    ) -> bool {
+        self.0.as_std_path() == other.as_ref()
+    }
+}
+
+impl AsRef<Utf8Path> for AbsPath {
+    fn as_ref(&self) -> &Utf8Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for AbsPath {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<OsStr> for AbsPath {
+    fn as_ref(&self) -> &OsStr {
+        self.0.as_ref()
+    }
+}
+
+impl ToOwned for AbsPath {
+    type Owned = AbsPathBuf;
+
+    fn to_owned(&self) -> Self::Owned {
+        AbsPathBuf(self.0.to_owned())
+    }
+}
+
+impl<'path> TryFrom<&'path Utf8Path> for &'path AbsPath {
+    type Error = &'path Utf8Path;
+
+    fn try_from(path: &'path Utf8Path) -> Result<&'path AbsPath, &'path Utf8Path> {
+        AbsPath::new(path)
+    }
+}
+
+impl AbsPath {
+    /// Creates a new [`AbsPath`] from `path`.
+    pub fn new(path: &Utf8Path) -> Result<&Self, &Utf8Path> {
+        if !path.is_absolute() {
+            return Err(path);
+        }
+        // SAFETY: invariant is checked
+        let new = unsafe { Self::new_unchecked(path) };
+        Ok(new)
+    }
+
+    /// Creates a new [`AbsPath`] from `path` without checking whether it is absolute.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `path` is not absolute.
+    ///
+    /// # Safety
+    ///
+    /// Calling this method on a relative path is *[undefined behavior]*.
+    ///
+    /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
+    #[must_use]
+    #[expect(clippy::as_conversions, reason = "necessary here")]
+    pub unsafe fn new_unchecked(path: &Utf8Path) -> &Self {
+        debug_assert!(path.is_absolute(), "{path} is not absolute");
+        // SAFETY: pointer is guaranteed to be valid
+        unsafe { &*(std::ptr::from_ref::<Utf8Path>(path) as *const Self) }
+    }
+
+    /// Equivalent of [`Utf8Path::parent`] for [`AbsPath`].
+    #[must_use]
+    pub fn parent(&self) -> Option<&Self> {
+        // SAFETY: the parent of an absolute path is an absolute path
+        self.0
+            .parent()
+            .map(|parent| unsafe { Self::new_unchecked(parent) })
+    }
+
+    /// Equivalent of [`Utf8Path::join`] for [`AbsPath`] with an additional normalize step afterwards.
+    pub fn absolutize<Path>(
+        &self,
+        path: Path,
+    ) -> AbsPathBuf
+    where
+        Path: AsRef<Utf8Path>,
+    {
+        self.join(path).normalize()
+    }
+
+    /// Equivalent of [`Utf8Path::join`] for [`AbsPath`].
+    pub fn join<Path>(
+        &self,
+        path: Path,
+    ) -> AbsPathBuf
+    where
+        Path: AsRef<Utf8Path>,
+    {
+        AbsPathBuf(Utf8Path::join(self.as_ref(), path))
+    }
+
+    /// Normalize the given path:
+    /// - Removes repeated separators: `/a//b` becomes `/a/b`
+    /// - Removes occurrences of `.` and resolves `..`.
+    /// - Removes trailing slashes: `/a/b/` becomes `/a/b`.
+    ///
+    /// # Example
+    /// ```ignore
+    /// # use paths::AbsPathBuf;
+    /// let abs_path_buf = AbsPathBuf::assert("/a/../../b/.//c//".into());
+    /// let normalized = abs_path_buf.normalize();
+    /// assert_eq!(normalized, AbsPathBuf::assert("/b/c".into()));
+    /// ```
+    #[must_use]
+    pub fn normalize(&self) -> AbsPathBuf {
+        AbsPathBuf(normalize_path(&self.0))
+    }
+
+    /// Equivalent of [`Utf8Path::to_path_buf`] for [`AbsPath`].
+    #[must_use]
+    pub fn to_path_buf(&self) -> AbsPathBuf {
+        AbsPathBuf(self.0.to_path_buf())
+    }
+
+    #[must_use]
+    pub fn as_utf8_path(&self) -> &Utf8Path {
+        self.as_ref()
+    }
+
+    /// # Panics
+    ///
+    /// Do not use.
+    #[deprecated]
+    #[expect(clippy::unused_self, reason = "intentional API")]
+    pub fn canonicalize(&self) -> ! {
+        panic!(
+            "We explicitly do not provide canonicalization API, as that is almost always a wrong solution, see #14430"
+        )
+    }
+
+    /// Equivalent of [`Utf8Path::strip_prefix`] for [`AbsPath`].
+    ///
+    /// Returns a relative path.
+    #[must_use]
+    pub fn strip_prefix(
+        &self,
+        base: &Self,
+    ) -> Option<&RelPath> {
+        // SAFETY: stripping the prefix of any path ensures that it is a relative path
+        self.0
+            .strip_prefix(base)
+            .ok()
+            .map(|stripped| unsafe { RelPath::new_unchecked(stripped) })
+    }
+
+    #[must_use]
+    pub fn starts_with(
+        &self,
+        base: &Self,
+    ) -> bool {
+        self.0.starts_with(&base.0)
+    }
+
+    #[must_use]
+    pub fn ends_with(
+        &self,
+        suffix: &RelPath,
+    ) -> bool {
+        self.0.ends_with(&suffix.0)
+    }
+
+    #[must_use]
+    pub fn name_and_extension(&self) -> Option<(&str, Option<&str>)> {
+        Some((self.file_stem()?, self.extension()))
+    }
+
+    // region:delegate-methods
+
+    // Note that we deliberately don't implement `Deref<Target = Utf8Path>` here.
+    //
+    // The problem with `Utf8Path` is that it directly exposes convenience IO-ing
+    // methods. For example, `Utf8Path::exists` delegates to `fs::metadata`.
+    //
+    // For `AbsPath`, we want to make sure that this is a POD type, and that all
+    // IO goes via `fs`. That way, it becomes easier to mock IO when we need it.
+
+    #[must_use]
+    pub fn file_name(&self) -> Option<&str> {
+        self.0.file_name()
+    }
+
+    #[must_use]
+    pub fn extension(&self) -> Option<&str> {
+        self.0.extension()
+    }
+
+    #[must_use]
+    pub fn file_stem(&self) -> Option<&str> {
+        self.0.file_stem()
+    }
+
+    #[must_use]
+    pub fn as_os_str(&self) -> &OsStr {
+        self.0.as_os_str()
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    #[expect(clippy::unimplemented, reason = "on purpose")]
+    #[deprecated(note = "use Display instead")]
+    pub fn display(&self) -> ! {
+        unimplemented!("use Display instead")
+    }
+
+    #[expect(clippy::unimplemented, reason = "on purpose")]
+    #[deprecated(note = "use std::fs::metadata().is_ok() instead")]
+    pub fn exists(&self) -> ! {
+        unimplemented!("use std::fs::metadata().is_ok() instead")
+    }
+
+    pub fn components(&self) -> Utf8Components<'_> {
+        self.0.components()
+    }
+    // endregion:delegate-methods
+}
+
+impl fmt::Display for AbsPath {
+    fn fmt(
+        &self,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{ffi::OsStr, path::PathBuf};
+
+    #[test]
+    fn utf_from_absbuf() {
+        let path: PathBuf = "/".into();
+        let absbuf = AbsPathBuf::assert_utf8(path.clone());
+        let utf8: Utf8PathBuf = absbuf.into();
+        assert_eq!(path, utf8);
+    }
+
+    #[test]
+    fn path_from_absbuf() {
+        let path: PathBuf = "/".into();
+        let absbuf = AbsPathBuf::assert_utf8(path.clone());
+        let utf8: PathBuf = absbuf.into();
+        assert_eq!(path, utf8);
+    }
+
+    #[test]
+    fn absbuf_asref_utf8() {
+        let utf8_expect: &Utf8Path = "/".into();
+        let absbuf = AbsPathBuf::assert("/".into());
+        let utf8: &Utf8Path = absbuf.as_ref();
+        assert_eq!(utf8_expect, utf8);
+    }
+
+    #[test]
+    fn absbuf_asref_abs() {
+        let abs_expect: &AbsPath = AbsPath::new("/".into()).unwrap();
+        let absbuf = AbsPathBuf::assert("/".into());
+        let abs: &AbsPath = absbuf.as_ref();
+        assert_eq!(abs_expect, abs);
+    }
+
+    #[test]
+    fn absbuf_borrow_abs() {
+        let owned = AbsPathBuf::assert("/".into());
+        let borrowed: &AbsPath = owned.borrow();
+        assert_eq!(AbsPath::new("/".into()).unwrap(), borrowed);
+    }
+
+    #[test]
+    fn absbuf_partialeq() {
+        let path: PathBuf = "/".into();
+        let absbuf = AbsPathBuf::assert("/".into());
+        assert_eq!(absbuf, path);
+    }
+
+    #[test]
+    fn absbuf_try_from_utf8_fail() {
+        let path: Utf8PathBuf = ".".into();
+        let absbuf = AbsPathBuf::try_from(path.clone());
+        assert_eq!(Err(path), absbuf);
+    }
+
+    #[test]
+    fn absbuf_pop() {
+        let mut absbuf = AbsPathBuf::assert("/test".into());
+        let expected = AbsPathBuf::assert("/".into());
+        absbuf.pop();
+        assert_eq!(expected, absbuf);
+    }
+
+    #[test]
+    fn absbuf_push() {
+        let mut absbuf = AbsPathBuf::assert("/test".into());
+        let expected = AbsPathBuf::assert("/test/push".into());
+        absbuf.push("push");
+        assert_eq!(expected, absbuf);
+    }
+
+    #[test]
+    fn absbuf_display() {
+        let absbuf = AbsPathBuf::assert("/test".into());
+        let display = format!("{absbuf:#}");
+        assert_eq!("/test", display);
+    }
+
+    #[test]
+    fn abs_toowned() {
+        let abs = AbsPath::new("/test".into()).unwrap();
+        let absbuf = AbsPathBuf::assert("/test".into());
+        let owned: AbsPathBuf = abs.to_owned();
+        assert_eq!(absbuf, owned);
+    }
+
+    #[test]
+    fn absolutize_works() {
+        let abs1 = AbsPath::new("/test".into()).unwrap();
+        let abs2 = abs1.absolutize("relative");
+        let expect = AbsPath::new("/test/relative".into()).unwrap();
+        assert_eq!(expect, &abs2);
+    }
+
+    #[test]
+    #[should_panic = "We explicitly do not provide canonicalization API, as that is almost always a wrong solution, see #14430"]
+    #[expect(clippy::diverging_sub_expression, deprecated, reason = "test")]
+    fn canonicalize_panics() {
+        let abs1 = AbsPath::new("/test".into()).unwrap();
+        _ = abs1.canonicalize();
+    }
+
+    #[test]
+    fn abs_starts_with() {
+        let abs1 = AbsPath::new("/test/path".into()).unwrap();
+        let abs2 = AbsPath::new("/test".into()).unwrap();
+        let abs3 = AbsPath::new("/wrong".into()).unwrap();
+        assert!(abs1.starts_with(abs2));
+        assert!(!abs1.starts_with(abs3));
+    }
+
+    #[test]
+    fn abs_ends_with() {
+        let abs = AbsPath::new("/test/path".into()).unwrap();
+        let rel1 = RelPath::new("path".into()).unwrap();
+        let rel2 = RelPath::new("wrong".into()).unwrap();
+        assert!(abs.ends_with(rel1));
+        assert!(!abs.ends_with(rel2));
+    }
+
+    #[test]
+    fn abs_asref_abs() {
+        let absbuf: &AbsPath = AbsPath::new("/".into()).unwrap();
+        let osstr: &OsStr = absbuf.as_ref();
+        assert_eq!(OsStr::new("/"), osstr);
+    }
+
+    #[test]
+    fn abs_tryfrom_utf8() {
+        let expect: &AbsPath = AbsPath::new("/".into()).unwrap();
+        let abs: &AbsPath = Utf8Path::new("/").try_into().unwrap();
+        assert_eq!(expect, abs);
+    }
+
+    #[test]
+    fn abs_tryfrom_utf8_err() {
+        let utf8 = Utf8Path::new(".");
+        let result: Result<&AbsPath, _> = utf8.try_into();
+        assert_eq!(Err(utf8), result);
+    }
+
+    #[test]
+    fn abs_name_and_extension() {
+        let abs = AbsPath::new("/name.extension".into()).unwrap();
+        let (name, extension) = abs.name_and_extension().unwrap();
+        assert_eq!("name", name);
+        assert_eq!(Some("extension"), extension);
+    }
+
+    #[test]
+    #[should_panic = "not implemented: use Display instead"]
+    #[expect(clippy::diverging_sub_expression, deprecated, reason = "test")]
+    fn abs_display_panics() {
+        let abs = AbsPath::new("/name.extension".into()).unwrap();
+        _ = abs.display();
+    }
+
+    #[test]
+    #[should_panic = "not implemented: use std::fs::metadata().is_ok() instead"]
+    #[expect(clippy::diverging_sub_expression, deprecated, reason = "test")]
+    fn abs_exists() {
+        let abs = AbsPath::new("/name.extension".into()).unwrap();
+        _ = abs.exists();
+    }
+
+    #[test]
+    fn abs_components() {
+        let abs = AbsPath::new("/name.extension".into()).unwrap();
+        let components = abs.components();
+        let vec: Vec<_> = components.map(|component| component.to_string()).collect();
+        assert_eq!(vec!["/", "name.extension"], vec);
+    }
+
+    #[test]
+    fn abs_display() {
+        let abs = AbsPath::new("/test".into()).unwrap();
+        let display = format!("{abs:#}");
+        assert_eq!("/test", display);
+    }
+}

--- a/crates/paths/src/absolute.rs
+++ b/crates/paths/src/absolute.rs
@@ -223,6 +223,20 @@ impl<'path> TryFrom<&'path Utf8Path> for &'path AbsPath {
 }
 
 impl AbsPath {
+    #[must_use]
+    pub fn root() -> &'static Self {
+        #[cfg(windows)]
+        {
+            // SAFETY: static value known to be safe
+            unsafe { Self::new_unchecked(r#"C:\"#.into()) }
+        }
+        #[cfg(not(windows))]
+        {
+            // SAFETY: static value known to be safe
+            unsafe { Self::new_unchecked("/".into()) }
+        }
+    }
+
     /// Creates a new [`AbsPath`] from `path`.
     pub fn new(path: &Utf8Path) -> Result<&Self, &Utf8Path> {
         if !path.is_absolute() {
@@ -273,12 +287,12 @@ impl AbsPath {
     }
 
     /// Equivalent of [`Utf8Path::join`] for [`AbsPath`].
-    pub fn join<Path>(
+    pub fn join<Pathy>(
         &self,
-        path: Path,
+        path: Pathy,
     ) -> AbsPathBuf
     where
-        Path: AsRef<Utf8Path>,
+        Pathy: AsRef<Utf8Path>,
     {
         AbsPathBuf(Utf8Path::join(self.as_ref(), path))
     }
@@ -425,9 +439,13 @@ mod tests {
     use super::*;
     use std::{ffi::OsStr, path::PathBuf};
 
+    fn root_utf8() -> &'static Utf8Path {
+        super::AbsPath::root().as_utf8_path()
+    }
+
     #[test]
     fn utf_from_absbuf() {
-        let path: PathBuf = "/".into();
+        let path: PathBuf = root_utf8().into();
         let absbuf = AbsPathBuf::assert_utf8(path.clone());
         let utf8: Utf8PathBuf = absbuf.into();
         assert_eq!(path, utf8);
@@ -435,7 +453,7 @@ mod tests {
 
     #[test]
     fn path_from_absbuf() {
-        let path: PathBuf = "/".into();
+        let path: PathBuf = root_utf8().into();
         let absbuf = AbsPathBuf::assert_utf8(path.clone());
         let utf8: PathBuf = absbuf.into();
         assert_eq!(path, utf8);
@@ -443,31 +461,31 @@ mod tests {
 
     #[test]
     fn absbuf_asref_utf8() {
-        let utf8_expect: &Utf8Path = "/".into();
-        let absbuf = AbsPathBuf::assert("/".into());
+        let utf8_expect: &Utf8Path = root_utf8();
+        let absbuf = AbsPathBuf::assert(root_utf8().into());
         let utf8: &Utf8Path = absbuf.as_ref();
         assert_eq!(utf8_expect, utf8);
     }
 
     #[test]
     fn absbuf_asref_abs() {
-        let abs_expect: &AbsPath = AbsPath::new("/".into()).unwrap();
-        let absbuf = AbsPathBuf::assert("/".into());
+        let abs_expect: &AbsPath = &AbsPath::root().join("");
+        let absbuf = AbsPathBuf::assert(root_utf8().into());
         let abs: &AbsPath = absbuf.as_ref();
         assert_eq!(abs_expect, abs);
     }
 
     #[test]
     fn absbuf_borrow_abs() {
-        let owned = AbsPathBuf::assert("/".into());
+        let owned = AbsPathBuf::assert(root_utf8().into());
         let borrowed: &AbsPath = owned.borrow();
-        assert_eq!(AbsPath::new("/".into()).unwrap(), borrowed);
+        assert_eq!(AbsPath::root().join(""), borrowed);
     }
 
     #[test]
     fn absbuf_partialeq() {
-        let path: PathBuf = "/".into();
-        let absbuf = AbsPathBuf::assert("/".into());
+        let path: PathBuf = root_utf8().into();
+        let absbuf = AbsPathBuf::assert(root_utf8().into());
         assert_eq!(absbuf, path);
     }
 
@@ -480,63 +498,70 @@ mod tests {
 
     #[test]
     fn absbuf_pop() {
-        let mut absbuf = AbsPathBuf::assert("/test".into());
-        let expected = AbsPathBuf::assert("/".into());
+        let mut absbuf = AbsPathBuf::assert(root_utf8().join("test"));
+        let expected = AbsPathBuf::assert(root_utf8().into());
         absbuf.pop();
         assert_eq!(expected, absbuf);
     }
 
     #[test]
     fn absbuf_push() {
-        let mut absbuf = AbsPathBuf::assert("/test".into());
-        let expected = AbsPathBuf::assert("/test/push".into());
+        let mut absbuf = AbsPathBuf::assert(root_utf8().join("test"));
+        let expected = AbsPathBuf::assert(root_utf8().join("test/push"));
         absbuf.push("push");
         assert_eq!(expected, absbuf);
     }
 
     #[test]
     fn absbuf_display() {
-        let absbuf = AbsPathBuf::assert("/test".into());
+        let absbuf = AbsPathBuf::assert(root_utf8().join("test"));
         let display = format!("{absbuf:#}");
         assert_eq!("/test", display);
     }
 
     #[test]
     fn abs_toowned() {
-        let abs = AbsPath::new("/test".into()).unwrap();
-        let absbuf = AbsPathBuf::assert("/test".into());
+        let abs: &AbsPath = &AbsPath::root().join("test");
+        let absbuf = AbsPathBuf::assert(root_utf8().join("test"));
         let owned: AbsPathBuf = abs.to_owned();
         assert_eq!(absbuf, owned);
     }
 
     #[test]
     fn absolutize_works() {
-        let abs1 = AbsPath::new("/test".into()).unwrap();
+        let abs1 = AbsPath::root().join("test");
         let abs2 = abs1.absolutize("relative");
-        let expect = AbsPath::new("/test/relative".into()).unwrap();
+        let expect = AbsPath::root().join("test/relative");
         assert_eq!(expect, &abs2);
+    }
+
+    #[test]
+    fn abs_as_utf8_path() {
+        let abs1 = AbsPath::root().join("test");
+        let utf8 = Utf8Path::new(root_utf8()).join("test");
+        assert_eq!(utf8, abs1.as_utf8_path());
     }
 
     #[test]
     #[should_panic = "We explicitly do not provide canonicalization API, as that is almost always a wrong solution, see #14430"]
     #[expect(clippy::diverging_sub_expression, deprecated, reason = "test")]
     fn canonicalize_panics() {
-        let abs1 = AbsPath::new("/test".into()).unwrap();
+        let abs1 = AbsPath::root().join("test");
         _ = abs1.canonicalize();
     }
 
     #[test]
     fn abs_starts_with() {
-        let abs1 = AbsPath::new("/test/path".into()).unwrap();
-        let abs2 = AbsPath::new("/test".into()).unwrap();
-        let abs3 = AbsPath::new("/wrong".into()).unwrap();
+        let abs1: &AbsPath = &AbsPath::root().join("test/path");
+        let abs2: &AbsPath = &AbsPath::root().join("test");
+        let abs3: &AbsPath = &AbsPath::root().join("wrong");
         assert!(abs1.starts_with(abs2));
         assert!(!abs1.starts_with(abs3));
     }
 
     #[test]
     fn abs_ends_with() {
-        let abs = AbsPath::new("/test/path".into()).unwrap();
+        let abs: &AbsPath = &AbsPath::root().join("test/path");
         let rel1 = RelPath::new("path".into()).unwrap();
         let rel2 = RelPath::new("wrong".into()).unwrap();
         assert!(abs.ends_with(rel1));
@@ -545,15 +570,15 @@ mod tests {
 
     #[test]
     fn abs_asref_abs() {
-        let absbuf: &AbsPath = AbsPath::new("/".into()).unwrap();
+        let absbuf: &AbsPath = &AbsPath::root().join("");
         let osstr: &OsStr = absbuf.as_ref();
-        assert_eq!(OsStr::new("/"), osstr);
+        assert_eq!(OsStr::new(root_utf8()), osstr);
     }
 
     #[test]
     fn abs_tryfrom_utf8() {
-        let expect: &AbsPath = AbsPath::new("/".into()).unwrap();
-        let abs: &AbsPath = Utf8Path::new("/").try_into().unwrap();
+        let expect: &AbsPath = &AbsPath::root().join("");
+        let abs: &AbsPath = Utf8Path::new(root_utf8()).try_into().unwrap();
         assert_eq!(expect, abs);
     }
 
@@ -566,7 +591,7 @@ mod tests {
 
     #[test]
     fn abs_name_and_extension() {
-        let abs = AbsPath::new("/name.extension".into()).unwrap();
+        let abs: &AbsPath = &AbsPath::root().join("name.extension");
         let (name, extension) = abs.name_and_extension().unwrap();
         assert_eq!("name", name);
         assert_eq!(Some("extension"), extension);
@@ -576,7 +601,7 @@ mod tests {
     #[should_panic = "not implemented: use Display instead"]
     #[expect(clippy::diverging_sub_expression, deprecated, reason = "test")]
     fn abs_display_panics() {
-        let abs = AbsPath::new("/name.extension".into()).unwrap();
+        let abs: &AbsPath = &AbsPath::root().join("name.extension");
         _ = abs.display();
     }
 
@@ -584,22 +609,22 @@ mod tests {
     #[should_panic = "not implemented: use std::fs::metadata().is_ok() instead"]
     #[expect(clippy::diverging_sub_expression, deprecated, reason = "test")]
     fn abs_exists() {
-        let abs = AbsPath::new("/name.extension".into()).unwrap();
+        let abs: &AbsPath = &AbsPath::root().join("name.extension");
         _ = abs.exists();
     }
 
     #[test]
     fn abs_components() {
-        let abs = AbsPath::new("/name.extension".into()).unwrap();
+        let abs: &AbsPath = &AbsPath::root().join("name.extension");
         let components = abs.components();
         let vec: Vec<_> = components.map(|component| component.to_string()).collect();
-        assert_eq!(vec!["/", "name.extension"], vec);
+        assert_eq!(vec![root_utf8().as_str(), "name.extension"], vec);
     }
 
     #[test]
     fn abs_display() {
-        let abs = AbsPath::new("/test".into()).unwrap();
+        let abs: &AbsPath = &AbsPath::root().join("test");
         let display = format!("{abs:#}");
-        assert_eq!("/test", display);
+        assert_eq!(format!("{}test", root_utf8()), display);
     }
 }

--- a/crates/paths/src/absolute.rs
+++ b/crates/paths/src/absolute.rs
@@ -228,7 +228,7 @@ impl AbsPath {
         #[cfg(windows)]
         {
             // SAFETY: static value known to be safe
-            unsafe { Self::new_unchecked(r#"C:\"#.into()) }
+            unsafe { Self::new_unchecked(r#"C:"#.into()) }
         }
         #[cfg(not(windows))]
         {
@@ -516,7 +516,7 @@ mod tests {
     fn absbuf_display() {
         let absbuf = AbsPathBuf::assert(root_utf8().join("test"));
         let display = format!("{absbuf:#}");
-        assert_eq!("/test", display);
+        assert_eq!(root_utf8().join("test"), display);
     }
 
     #[test]
@@ -625,6 +625,6 @@ mod tests {
     fn abs_display() {
         let abs: &AbsPath = &AbsPath::root().join("test");
         let display = format!("{abs:#}");
-        assert_eq!(format!("{}test", root_utf8()), display);
+        assert_eq!(root_utf8().join("test"), display);
     }
 }

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -1,0 +1,522 @@
+//! Thin wrappers around [`camino::Utf8PathBuf`], distinguishing between absolute and relative paths.
+
+use std::{
+    borrow::Borrow,
+    ffi::OsStr,
+    fmt, ops,
+    path::{Path, PathBuf},
+};
+
+pub use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf, Utf8Prefix};
+
+/// A [`Utf8PathBuf`] that is guaranteed to be absolute.
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, Hash)]
+pub struct AbsPathBuf(Utf8PathBuf);
+
+impl From<AbsPathBuf> for Utf8PathBuf {
+    fn from(AbsPathBuf(path_buf): AbsPathBuf) -> Self {
+        path_buf
+    }
+}
+
+impl From<AbsPathBuf> for PathBuf {
+    fn from(AbsPathBuf(path_buf): AbsPathBuf) -> Self {
+        path_buf.into()
+    }
+}
+
+impl ops::Deref for AbsPathBuf {
+    type Target = AbsPath;
+    fn deref(&self) -> &AbsPath {
+        self.as_path()
+    }
+}
+
+impl AsRef<Utf8Path> for AbsPathBuf {
+    fn as_ref(&self) -> &Utf8Path {
+        self.0.as_path()
+    }
+}
+
+impl AsRef<OsStr> for AbsPathBuf {
+    fn as_ref(&self) -> &OsStr {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<Path> for AbsPathBuf {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<AbsPath> for AbsPathBuf {
+    fn as_ref(&self) -> &AbsPath {
+        self.as_path()
+    }
+}
+
+impl Borrow<AbsPath> for AbsPathBuf {
+    fn borrow(&self) -> &AbsPath {
+        self.as_path()
+    }
+}
+
+impl TryFrom<Utf8PathBuf> for AbsPathBuf {
+    type Error = Utf8PathBuf;
+    fn try_from(path_buf: Utf8PathBuf) -> Result<Self, Utf8PathBuf> {
+        if !path_buf.is_absolute() {
+            return Err(path_buf);
+        }
+        Ok(Self(path_buf))
+    }
+}
+
+impl TryFrom<&str> for AbsPathBuf {
+    type Error = Utf8PathBuf;
+    fn try_from(path: &str) -> Result<Self, Utf8PathBuf> {
+        Self::try_from(Utf8PathBuf::from(path))
+    }
+}
+
+impl<P: AsRef<Path> + ?Sized> PartialEq<P> for AbsPathBuf {
+    fn eq(
+        &self,
+        other: &P,
+    ) -> bool {
+        self.0.as_std_path() == other.as_ref()
+    }
+}
+
+impl AbsPathBuf {
+    /// Wrap the given absolute path in `AbsPathBuf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `path` is not absolute.
+    #[must_use]
+    pub fn assert(path: Utf8PathBuf) -> Self {
+        Self::try_from(path).unwrap_or_else(|path| panic!("expected absolute path, got {path}"))
+    }
+
+    /// Wrap the given absolute path in `AbsPathBuf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `path` is not absolute.
+    #[must_use]
+    pub fn assert_utf8(path: PathBuf) -> Self {
+        Self::assert(
+            Utf8PathBuf::from_path_buf(path)
+                .unwrap_or_else(|path| panic!("expected utf8 path, got {}", path.display())),
+        )
+    }
+
+    /// Coerces to an `AbsPath` slice.
+    ///
+    /// Equivalent of [`Utf8PathBuf::as_path`] for `AbsPathBuf`.
+    #[must_use]
+    pub fn as_path(&self) -> &AbsPath {
+        AbsPath::assert(self.0.as_path())
+    }
+
+    /// Equivalent of [`Utf8PathBuf::pop`] for `AbsPathBuf`.
+    ///
+    /// Note that this won't remove the root component, so `self` will still be
+    /// absolute.
+    pub fn pop(&mut self) -> bool {
+        self.0.pop()
+    }
+
+    /// Equivalent of [`PathBuf::push`] for `AbsPathBuf`.
+    ///
+    /// Extends `self` with `path`.
+    ///
+    /// If `path` is absolute, it replaces the current path.
+    ///
+    /// On Windows:
+    ///
+    /// * if `path` has a root but no prefix (e.g., `\windows`), it
+    ///   replaces everything except for the prefix (if any) of `self`.
+    /// * if `path` has a prefix but no root, it replaces `self`.
+    /// * if `self` has a verbatim prefix (e.g. `\\?\C:\windows`)
+    ///   and `path` is not empty, the new path is normalized: all references
+    ///   to `.` and `..` are removed.
+    pub fn push<Path>(
+        &mut self,
+        suffix: Path,
+    ) where
+        Path: AsRef<Utf8Path>,
+    {
+        self.0.push(suffix);
+    }
+
+    #[must_use]
+    pub fn join<Path>(
+        &self,
+        path: Path,
+    ) -> Self
+    where
+        Path: AsRef<Utf8Path>,
+    {
+        Self(self.0.join(path))
+    }
+}
+
+impl fmt::Display for AbsPathBuf {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+/// Wrapper around an absolute [`Utf8Path`].
+#[derive(Debug, Ord, PartialOrd, Eq, Hash)]
+#[repr(transparent)]
+pub struct AbsPath(Utf8Path);
+
+impl<P: AsRef<Path> + ?Sized> PartialEq<P> for AbsPath {
+    fn eq(
+        &self,
+        other: &P,
+    ) -> bool {
+        self.0.as_std_path() == other.as_ref()
+    }
+}
+
+impl AsRef<Utf8Path> for AbsPath {
+    fn as_ref(&self) -> &Utf8Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for AbsPath {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<OsStr> for AbsPath {
+    fn as_ref(&self) -> &OsStr {
+        self.0.as_ref()
+    }
+}
+
+impl ToOwned for AbsPath {
+    type Owned = AbsPathBuf;
+
+    fn to_owned(&self) -> Self::Owned {
+        AbsPathBuf(self.0.to_owned())
+    }
+}
+
+impl<'path> TryFrom<&'path Utf8Path> for &'path AbsPath {
+    type Error = &'path Utf8Path;
+    fn try_from(path: &'path Utf8Path) -> Result<&'path AbsPath, &'path Utf8Path> {
+        if !path.is_absolute() {
+            return Err(path);
+        }
+        Ok(AbsPath::assert(path))
+    }
+}
+
+impl AbsPath {
+    /// Wrap the given absolute path in `AbsPath`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `path` is not absolute.
+    #[must_use]
+    #[expect(clippy::as_conversions, reason = "necessary here")]
+    pub fn assert(path: &Utf8Path) -> &Self {
+        assert!(path.is_absolute(), "{path} is not absolute");
+        // SAFETY: pointer is guaranteed to be valid
+        unsafe { &*(std::ptr::from_ref::<Utf8Path>(path) as *const Self) }
+    }
+
+    /// Equivalent of [`Utf8Path::parent`] for `AbsPath`.
+    pub fn parent(&self) -> Option<&Self> {
+        self.0.parent().map(Self::assert)
+    }
+
+    /// Equivalent of [`Utf8Path::join`] for `AbsPath` with an additional normalize step afterwards.
+    pub fn absolutize<Path>(
+        &self,
+        path: Path,
+    ) -> AbsPathBuf
+    where
+        Path: AsRef<Utf8Path>,
+    {
+        self.join(path).normalize()
+    }
+
+    /// Equivalent of [`Utf8Path::join`] for `AbsPath`.
+    pub fn join<Path>(
+        &self,
+        path: Path,
+    ) -> AbsPathBuf
+    where
+        Path: AsRef<Utf8Path>,
+    {
+        AbsPathBuf(Utf8Path::join(self.as_ref(), path))
+    }
+
+    /// Normalize the given path:
+    /// - Removes repeated separators: `/a//b` becomes `/a/b`
+    /// - Removes occurrences of `.` and resolves `..`.
+    /// - Removes trailing slashes: `/a/b/` becomes `/a/b`.
+    ///
+    /// # Example
+    /// ```ignore
+    /// # use paths::AbsPathBuf;
+    /// let abs_path_buf = AbsPathBuf::assert("/a/../../b/.//c//".into());
+    /// let normalized = abs_path_buf.normalize();
+    /// assert_eq!(normalized, AbsPathBuf::assert("/b/c".into()));
+    /// ```
+    #[must_use]
+    pub fn normalize(&self) -> AbsPathBuf {
+        AbsPathBuf(normalize_path(&self.0))
+    }
+
+    /// Equivalent of [`Utf8Path::to_path_buf`] for `AbsPath`.
+    #[must_use]
+    pub fn to_path_buf(&self) -> AbsPathBuf {
+        AbsPathBuf(self.0.to_path_buf())
+    }
+
+    /// # Panics
+    ///
+    /// Do not use.
+    #[deprecated]
+    #[expect(clippy::unused_self, reason = "intentional API")]
+    pub fn canonicalize(&self) -> ! {
+        panic!(
+            "We explicitly do not provide canonicalization API, as that is almost always a wrong solution, see #14430"
+        )
+    }
+
+    /// Equivalent of [`Utf8Path::strip_prefix`] for `AbsPath`.
+    ///
+    /// Returns a relative path.
+    pub fn strip_prefix(
+        &self,
+        base: &Self,
+    ) -> Option<&RelPath> {
+        self.0.strip_prefix(base).ok().map(RelPath::new_unchecked)
+    }
+
+    #[must_use]
+    pub fn starts_with(
+        &self,
+        base: &Self,
+    ) -> bool {
+        self.0.starts_with(&base.0)
+    }
+
+    #[must_use]
+    pub fn ends_with(
+        &self,
+        suffix: &RelPath,
+    ) -> bool {
+        self.0.ends_with(&suffix.0)
+    }
+
+    #[must_use]
+    pub fn name_and_extension(&self) -> Option<(&str, Option<&str>)> {
+        Some((self.file_stem()?, self.extension()))
+    }
+
+    // region:delegate-methods
+
+    // Note that we deliberately don't implement `Deref<Target = Utf8Path>` here.
+    //
+    // The problem with `Utf8Path` is that it directly exposes convenience IO-ing
+    // methods. For example, `Utf8Path::exists` delegates to `fs::metadata`.
+    //
+    // For `AbsPath`, we want to make sure that this is a POD type, and that all
+    // IO goes via `fs`. That way, it becomes easier to mock IO when we need it.
+    #[must_use]
+    pub fn file_name(&self) -> Option<&str> {
+        self.0.file_name()
+    }
+
+    #[must_use]
+    pub fn extension(&self) -> Option<&str> {
+        self.0.extension()
+    }
+
+    #[must_use]
+    pub fn file_stem(&self) -> Option<&str> {
+        self.0.file_stem()
+    }
+
+    #[must_use]
+    pub fn as_os_str(&self) -> &OsStr {
+        self.0.as_os_str()
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    #[expect(clippy::unimplemented, reason = "on purpose")]
+    #[deprecated(note = "use Display instead")]
+    pub fn display(&self) -> ! {
+        unimplemented!()
+    }
+
+    #[expect(clippy::unimplemented, reason = "on purpose")]
+    #[deprecated(note = "use std::fs::metadata().is_ok() instead")]
+    pub fn exists(&self) -> ! {
+        unimplemented!()
+    }
+
+    pub fn components(&self) -> Utf8Components<'_> {
+        self.0.components()
+    }
+    // endregion:delegate-methods
+}
+
+impl fmt::Display for AbsPath {
+    fn fmt(
+        &self,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
+/// Wrapper around a relative [`Utf8PathBuf`].
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct RelPathBuf(Utf8PathBuf);
+
+impl From<RelPathBuf> for Utf8PathBuf {
+    fn from(RelPathBuf(path_buf): RelPathBuf) -> Self {
+        path_buf
+    }
+}
+
+impl ops::Deref for RelPathBuf {
+    type Target = RelPath;
+    fn deref(&self) -> &RelPath {
+        self.as_path()
+    }
+}
+
+impl AsRef<Utf8Path> for RelPathBuf {
+    fn as_ref(&self) -> &Utf8Path {
+        self.0.as_path()
+    }
+}
+
+impl AsRef<Path> for RelPathBuf {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}
+
+impl TryFrom<Utf8PathBuf> for RelPathBuf {
+    type Error = Utf8PathBuf;
+    fn try_from(path_buf: Utf8PathBuf) -> Result<Self, Utf8PathBuf> {
+        if !path_buf.is_relative() {
+            return Err(path_buf);
+        }
+        Ok(Self(path_buf))
+    }
+}
+
+impl TryFrom<&str> for RelPathBuf {
+    type Error = Utf8PathBuf;
+    fn try_from(path: &str) -> Result<Self, Utf8PathBuf> {
+        Self::try_from(Utf8PathBuf::from(path))
+    }
+}
+
+impl RelPathBuf {
+    /// Coerces to a `RelPath` slice.
+    ///
+    /// Equivalent of [`Utf8PathBuf::as_path`] for `RelPathBuf`.
+    #[must_use]
+    pub fn as_path(&self) -> &RelPath {
+        RelPath::new_unchecked(self.0.as_path())
+    }
+}
+
+/// Wrapper around a relative [`Utf8Path`].
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[repr(transparent)]
+pub struct RelPath(Utf8Path);
+
+impl AsRef<Utf8Path> for RelPath {
+    fn as_ref(&self) -> &Utf8Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for RelPath {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}
+
+impl RelPath {
+    /// Creates a new `RelPath` from `path`, without checking if it is relative.
+    #[must_use]
+    #[expect(clippy::as_conversions, reason = "necessary here")]
+    pub const fn new_unchecked(path: &Utf8Path) -> &Self {
+        // SAFETY: pointer is guaranteed to be valid
+        unsafe { &*(std::ptr::from_ref::<Utf8Path>(path) as *const Self) }
+    }
+
+    /// Equivalent of [`Utf8Path::to_path_buf`] for `RelPath`.
+    #[must_use]
+    pub fn to_path_buf(&self) -> RelPathBuf {
+        // SAFETY: invariant of the type that this is already relative
+        unsafe { RelPathBuf::try_from(self.0.to_path_buf()).unwrap_unchecked() }
+    }
+
+    #[must_use]
+    pub fn as_utf8_path(&self) -> &Utf8Path {
+        self.as_ref()
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+/// Taken from <https://github.com/rust-lang/cargo/blob/79c769c3d7b4c2cf6a93781575b7f592ef974255/src/cargo/util/paths.rs#L60-L85>.
+fn normalize_path(path: &Utf8Path) -> Utf8PathBuf {
+    let mut components = path.components().peekable();
+    let mut return_value =
+        if let Some(prefix @ Utf8Component::Prefix(..)) = components.peek().copied() {
+            components.next();
+            Utf8PathBuf::from(prefix.as_str())
+        } else {
+            Utf8PathBuf::new()
+        };
+
+    #[expect(clippy::unreachable, reason = "best way to write it")]
+    for component in components {
+        match component {
+            Utf8Component::Prefix(..) => {
+                unreachable!("prefixes may only be at the beginning and it was already consumed")
+            },
+            Utf8Component::RootDir => {
+                return_value.push(component.as_str());
+            },
+            Utf8Component::CurDir => {},
+            Utf8Component::ParentDir => {
+                return_value.pop();
+            },
+            Utf8Component::Normal(component) => {
+                return_value.push(component);
+            },
+        }
+    }
+    return_value
+}

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -2,494 +2,13 @@
 
 #![warn(unused)]
 
-use std::{
-    borrow::Borrow,
-    ffi::OsStr,
-    fmt, ops,
-    path::{Path, PathBuf},
-};
-
 pub use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf, Utf8Prefix};
 
-/// A [`Utf8PathBuf`] that is guaranteed to be absolute.
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, Hash)]
-pub struct AbsPathBuf(Utf8PathBuf);
+mod absolute;
+mod relative;
 
-impl From<AbsPathBuf> for Utf8PathBuf {
-    fn from(AbsPathBuf(path_buf): AbsPathBuf) -> Self {
-        path_buf
-    }
-}
-
-impl From<AbsPathBuf> for PathBuf {
-    fn from(AbsPathBuf(path_buf): AbsPathBuf) -> Self {
-        path_buf.into()
-    }
-}
-
-impl ops::Deref for AbsPathBuf {
-    type Target = AbsPath;
-    fn deref(&self) -> &AbsPath {
-        self.as_path()
-    }
-}
-
-impl AsRef<Utf8Path> for AbsPathBuf {
-    fn as_ref(&self) -> &Utf8Path {
-        self.0.as_path()
-    }
-}
-
-impl AsRef<OsStr> for AbsPathBuf {
-    fn as_ref(&self) -> &OsStr {
-        self.0.as_ref()
-    }
-}
-
-impl AsRef<Path> for AbsPathBuf {
-    fn as_ref(&self) -> &Path {
-        self.0.as_ref()
-    }
-}
-
-impl AsRef<AbsPath> for AbsPathBuf {
-    fn as_ref(&self) -> &AbsPath {
-        self.as_path()
-    }
-}
-
-impl Borrow<AbsPath> for AbsPathBuf {
-    fn borrow(&self) -> &AbsPath {
-        self.as_path()
-    }
-}
-
-impl TryFrom<Utf8PathBuf> for AbsPathBuf {
-    type Error = Utf8PathBuf;
-    fn try_from(path_buf: Utf8PathBuf) -> Result<Self, Utf8PathBuf> {
-        if !path_buf.is_absolute() {
-            return Err(path_buf);
-        }
-        Ok(Self(path_buf))
-    }
-}
-
-impl TryFrom<&str> for AbsPathBuf {
-    type Error = Utf8PathBuf;
-    fn try_from(path: &str) -> Result<Self, Utf8PathBuf> {
-        Self::try_from(Utf8PathBuf::from(path))
-    }
-}
-
-impl<P: AsRef<Path> + ?Sized> PartialEq<P> for AbsPathBuf {
-    fn eq(
-        &self,
-        other: &P,
-    ) -> bool {
-        self.0.as_std_path() == other.as_ref()
-    }
-}
-
-impl AbsPathBuf {
-    /// Wrap the given absolute path in `AbsPathBuf`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `path` is not absolute.
-    #[must_use]
-    pub fn assert(path: Utf8PathBuf) -> Self {
-        Self::try_from(path).unwrap_or_else(|path| panic!("expected absolute path, got {path}"))
-    }
-
-    /// Wrap the given absolute path in `AbsPathBuf`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `path` is not absolute.
-    #[must_use]
-    pub fn assert_utf8(path: PathBuf) -> Self {
-        Self::assert(
-            Utf8PathBuf::from_path_buf(path)
-                .unwrap_or_else(|path| panic!("expected utf8 path, got {}", path.display())),
-        )
-    }
-
-    /// Coerces to an `AbsPath` slice.
-    ///
-    /// Equivalent of [`Utf8PathBuf::as_path`] for `AbsPathBuf`.
-    #[must_use]
-    pub fn as_path(&self) -> &AbsPath {
-        AbsPath::assert(self.0.as_path())
-    }
-
-    /// Equivalent of [`Utf8PathBuf::pop`] for `AbsPathBuf`.
-    ///
-    /// Note that this won't remove the root component, so `self` will still be
-    /// absolute.
-    pub fn pop(&mut self) -> bool {
-        self.0.pop()
-    }
-
-    /// Equivalent of [`PathBuf::push`] for `AbsPathBuf`.
-    ///
-    /// Extends `self` with `path`.
-    ///
-    /// If `path` is absolute, it replaces the current path.
-    ///
-    /// On Windows:
-    ///
-    /// * if `path` has a root but no prefix (e.g., `\windows`), it
-    ///   replaces everything except for the prefix (if any) of `self`.
-    /// * if `path` has a prefix but no root, it replaces `self`.
-    /// * if `self` has a verbatim prefix (e.g. `\\?\C:\windows`)
-    ///   and `path` is not empty, the new path is normalized: all references
-    ///   to `.` and `..` are removed.
-    pub fn push<Path>(
-        &mut self,
-        suffix: Path,
-    ) where
-        Path: AsRef<Utf8Path>,
-    {
-        self.0.push(suffix);
-    }
-
-    #[must_use]
-    pub fn join<Path>(
-        &self,
-        path: Path,
-    ) -> Self
-    where
-        Path: AsRef<Utf8Path>,
-    {
-        Self(self.0.join(path))
-    }
-}
-
-impl fmt::Display for AbsPathBuf {
-    fn fmt(
-        &self,
-        f: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
-    }
-}
-
-/// Wrapper around an absolute [`Utf8Path`].
-#[derive(Debug, Ord, PartialOrd, Eq, Hash)]
-#[repr(transparent)]
-pub struct AbsPath(Utf8Path);
-
-impl<P: AsRef<Path> + ?Sized> PartialEq<P> for AbsPath {
-    fn eq(
-        &self,
-        other: &P,
-    ) -> bool {
-        self.0.as_std_path() == other.as_ref()
-    }
-}
-
-impl AsRef<Utf8Path> for AbsPath {
-    fn as_ref(&self) -> &Utf8Path {
-        &self.0
-    }
-}
-
-impl AsRef<Path> for AbsPath {
-    fn as_ref(&self) -> &Path {
-        self.0.as_ref()
-    }
-}
-
-impl AsRef<OsStr> for AbsPath {
-    fn as_ref(&self) -> &OsStr {
-        self.0.as_ref()
-    }
-}
-
-impl ToOwned for AbsPath {
-    type Owned = AbsPathBuf;
-
-    fn to_owned(&self) -> Self::Owned {
-        AbsPathBuf(self.0.to_owned())
-    }
-}
-
-impl<'path> TryFrom<&'path Utf8Path> for &'path AbsPath {
-    type Error = &'path Utf8Path;
-    fn try_from(path: &'path Utf8Path) -> Result<&'path AbsPath, &'path Utf8Path> {
-        if !path.is_absolute() {
-            return Err(path);
-        }
-        Ok(AbsPath::assert(path))
-    }
-}
-
-impl AbsPath {
-    /// Wrap the given absolute path in `AbsPath`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `path` is not absolute.
-    #[must_use]
-    #[expect(clippy::as_conversions, reason = "necessary here")]
-    pub fn assert(path: &Utf8Path) -> &Self {
-        assert!(path.is_absolute(), "{path} is not absolute");
-        // SAFETY: pointer is guaranteed to be valid
-        unsafe { &*(std::ptr::from_ref::<Utf8Path>(path) as *const Self) }
-    }
-
-    /// Equivalent of [`Utf8Path::parent`] for `AbsPath`.
-    pub fn parent(&self) -> Option<&Self> {
-        self.0.parent().map(Self::assert)
-    }
-
-    /// Equivalent of [`Utf8Path::join`] for `AbsPath` with an additional normalize step afterwards.
-    pub fn absolutize<Path>(
-        &self,
-        path: Path,
-    ) -> AbsPathBuf
-    where
-        Path: AsRef<Utf8Path>,
-    {
-        self.join(path).normalize()
-    }
-
-    /// Equivalent of [`Utf8Path::join`] for `AbsPath`.
-    pub fn join<Path>(
-        &self,
-        path: Path,
-    ) -> AbsPathBuf
-    where
-        Path: AsRef<Utf8Path>,
-    {
-        AbsPathBuf(Utf8Path::join(self.as_ref(), path))
-    }
-
-    /// Normalize the given path:
-    /// - Removes repeated separators: `/a//b` becomes `/a/b`
-    /// - Removes occurrences of `.` and resolves `..`.
-    /// - Removes trailing slashes: `/a/b/` becomes `/a/b`.
-    ///
-    /// # Example
-    /// ```ignore
-    /// # use paths::AbsPathBuf;
-    /// let abs_path_buf = AbsPathBuf::assert("/a/../../b/.//c//".into());
-    /// let normalized = abs_path_buf.normalize();
-    /// assert_eq!(normalized, AbsPathBuf::assert("/b/c".into()));
-    /// ```
-    #[must_use]
-    pub fn normalize(&self) -> AbsPathBuf {
-        AbsPathBuf(normalize_path(&self.0))
-    }
-
-    /// Equivalent of [`Utf8Path::to_path_buf`] for `AbsPath`.
-    #[must_use]
-    pub fn to_path_buf(&self) -> AbsPathBuf {
-        AbsPathBuf(self.0.to_path_buf())
-    }
-
-    /// # Panics
-    ///
-    /// Do not use.
-    #[deprecated]
-    #[expect(clippy::unused_self, reason = "intentional API")]
-    pub fn canonicalize(&self) -> ! {
-        panic!(
-            "We explicitly do not provide canonicalization API, as that is almost always a wrong solution, see #14430"
-        )
-    }
-
-    /// Equivalent of [`Utf8Path::strip_prefix`] for `AbsPath`.
-    ///
-    /// Returns a relative path.
-    pub fn strip_prefix(
-        &self,
-        base: &Self,
-    ) -> Option<&RelPath> {
-        self.0.strip_prefix(base).ok().map(RelPath::new_unchecked)
-    }
-
-    #[must_use]
-    pub fn starts_with(
-        &self,
-        base: &Self,
-    ) -> bool {
-        self.0.starts_with(&base.0)
-    }
-
-    #[must_use]
-    pub fn ends_with(
-        &self,
-        suffix: &RelPath,
-    ) -> bool {
-        self.0.ends_with(&suffix.0)
-    }
-
-    #[must_use]
-    pub fn name_and_extension(&self) -> Option<(&str, Option<&str>)> {
-        Some((self.file_stem()?, self.extension()))
-    }
-
-    // region:delegate-methods
-
-    // Note that we deliberately don't implement `Deref<Target = Utf8Path>` here.
-    //
-    // The problem with `Utf8Path` is that it directly exposes convenience IO-ing
-    // methods. For example, `Utf8Path::exists` delegates to `fs::metadata`.
-    //
-    // For `AbsPath`, we want to make sure that this is a POD type, and that all
-    // IO goes via `fs`. That way, it becomes easier to mock IO when we need it.
-    #[must_use]
-    pub fn file_name(&self) -> Option<&str> {
-        self.0.file_name()
-    }
-
-    #[must_use]
-    pub fn extension(&self) -> Option<&str> {
-        self.0.extension()
-    }
-
-    #[must_use]
-    pub fn file_stem(&self) -> Option<&str> {
-        self.0.file_stem()
-    }
-
-    #[must_use]
-    pub fn as_os_str(&self) -> &OsStr {
-        self.0.as_os_str()
-    }
-
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
-    #[expect(clippy::unimplemented, reason = "on purpose")]
-    #[deprecated(note = "use Display instead")]
-    pub fn display(&self) -> ! {
-        unimplemented!()
-    }
-
-    #[expect(clippy::unimplemented, reason = "on purpose")]
-    #[deprecated(note = "use std::fs::metadata().is_ok() instead")]
-    pub fn exists(&self) -> ! {
-        unimplemented!()
-    }
-
-    pub fn components(&self) -> Utf8Components<'_> {
-        self.0.components()
-    }
-    // endregion:delegate-methods
-}
-
-impl fmt::Display for AbsPath {
-    fn fmt(
-        &self,
-        formatter: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        fmt::Display::fmt(&self.0, formatter)
-    }
-}
-
-/// Wrapper around a relative [`Utf8PathBuf`].
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub struct RelPathBuf(Utf8PathBuf);
-
-impl From<RelPathBuf> for Utf8PathBuf {
-    fn from(RelPathBuf(path_buf): RelPathBuf) -> Self {
-        path_buf
-    }
-}
-
-impl ops::Deref for RelPathBuf {
-    type Target = RelPath;
-    fn deref(&self) -> &RelPath {
-        self.as_path()
-    }
-}
-
-impl AsRef<Utf8Path> for RelPathBuf {
-    fn as_ref(&self) -> &Utf8Path {
-        self.0.as_path()
-    }
-}
-
-impl AsRef<Path> for RelPathBuf {
-    fn as_ref(&self) -> &Path {
-        self.0.as_ref()
-    }
-}
-
-impl TryFrom<Utf8PathBuf> for RelPathBuf {
-    type Error = Utf8PathBuf;
-    fn try_from(path_buf: Utf8PathBuf) -> Result<Self, Utf8PathBuf> {
-        if !path_buf.is_relative() {
-            return Err(path_buf);
-        }
-        Ok(Self(path_buf))
-    }
-}
-
-impl TryFrom<&str> for RelPathBuf {
-    type Error = Utf8PathBuf;
-    fn try_from(path: &str) -> Result<Self, Utf8PathBuf> {
-        Self::try_from(Utf8PathBuf::from(path))
-    }
-}
-
-impl RelPathBuf {
-    /// Coerces to a `RelPath` slice.
-    ///
-    /// Equivalent of [`Utf8PathBuf::as_path`] for `RelPathBuf`.
-    #[must_use]
-    pub fn as_path(&self) -> &RelPath {
-        RelPath::new_unchecked(self.0.as_path())
-    }
-}
-
-/// Wrapper around a relative [`Utf8Path`].
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
-#[repr(transparent)]
-pub struct RelPath(Utf8Path);
-
-impl AsRef<Utf8Path> for RelPath {
-    fn as_ref(&self) -> &Utf8Path {
-        &self.0
-    }
-}
-
-impl AsRef<Path> for RelPath {
-    fn as_ref(&self) -> &Path {
-        self.0.as_ref()
-    }
-}
-
-impl RelPath {
-    /// Creates a new `RelPath` from `path`, without checking if it is relative.
-    #[must_use]
-    #[expect(clippy::as_conversions, reason = "necessary here")]
-    pub const fn new_unchecked(path: &Utf8Path) -> &Self {
-        // SAFETY: pointer is guaranteed to be valid
-        unsafe { &*(std::ptr::from_ref::<Utf8Path>(path) as *const Self) }
-    }
-
-    /// Equivalent of [`Utf8Path::to_path_buf`] for `RelPath`.
-    #[must_use]
-    pub fn to_path_buf(&self) -> RelPathBuf {
-        // SAFETY: invariant of the type that this is already relative
-        unsafe { RelPathBuf::try_from(self.0.to_path_buf()).unwrap_unchecked() }
-    }
-
-    #[must_use]
-    pub fn as_utf8_path(&self) -> &Utf8Path {
-        self.as_ref()
-    }
-
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-}
+pub use absolute::{AbsPath, AbsPathBuf};
+pub use relative::{RelPath, RelPathBuf};
 
 /// Taken from <https://github.com/rust-lang/cargo/blob/79c769c3d7b4c2cf6a93781575b7f592ef974255/src/cargo/util/paths.rs#L60-L85>.
 fn normalize_path(path: &Utf8Path) -> Utf8PathBuf {
@@ -521,4 +40,60 @@ fn normalize_path(path: &Utf8Path) -> Utf8PathBuf {
         }
     }
     return_value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_path;
+
+    #[test]
+    fn normalize_path_normal() {
+        let utf8 = "test/path".into();
+        let normalized = normalize_path(utf8);
+        assert_eq!("test/path", normalized);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn normalize_path_prefix() {
+        let verbatim = r"\\?\pictures\kittens";
+        let verbatim_unc = r"\\?\UNC\server\share";
+        let verbatim_disk = r"\\?\C:\";
+        let device_ns = r"\\.\BrainInterface";
+        let unc = r"\\server\share";
+        let disk = r"C:\Users\Rust\Pictures\Ferris";
+        assert_eq!(r#"\\?\pictures\kittens"#, normalize_path(verbatim.into()));
+        assert_eq!(
+            r#"\\?\UNC\server\share"#,
+            normalize_path(verbatim_unc.into())
+        );
+        assert_eq!(r#"\\?\C:\"#, normalize_path(verbatim_disk.into()));
+        assert_eq!(r#"\\.\BrainInterface"#, normalize_path(device_ns.into()));
+        assert_eq!(r#"\\server\share"#, normalize_path(unc.into()));
+        assert_eq!(
+            r#"C:\Users\Rust\Pictures\Ferris"#,
+            normalize_path(disk.into())
+        );
+    }
+
+    #[test]
+    fn normalize_path_cur_dir() {
+        let utf8 = r#"./normalize/./current/./dir/."#.into();
+        let normalized = normalize_path(utf8);
+        assert_eq!(r#"normalize/current/dir"#, normalized);
+    }
+
+    #[test]
+    fn normalize_path_root() {
+        let utf8 = r#"/normalize/root"#.into();
+        let normalized = normalize_path(utf8);
+        assert_eq!(r#"/normalize/root"#, normalized);
+    }
+
+    #[test]
+    fn normalize_path_trailing_slash() {
+        let utf8 = r#"trailing/slash/"#.into();
+        let normalized = normalize_path(utf8);
+        assert_eq!(r#"trailing/slash"#, normalized);
+    }
 }

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -1,5 +1,7 @@
 //! Thin wrappers around [`camino::Utf8PathBuf`], distinguishing between absolute and relative paths.
 
+#![warn(unused)]
+
 use std::{
     borrow::Borrow,
     ffi::OsStr,

--- a/crates/paths/src/relative.rs
+++ b/crates/paths/src/relative.rs
@@ -1,0 +1,569 @@
+use std::{
+    borrow::Borrow,
+    ffi::OsStr,
+    fmt, ops,
+    path::{Path, PathBuf},
+};
+
+use camino::{Utf8Components, Utf8Path, Utf8PathBuf};
+
+use crate::normalize_path;
+
+/// Wrapper around a relative [`Utf8PathBuf`].
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, Hash)]
+pub struct RelPathBuf(Utf8PathBuf);
+
+impl From<RelPathBuf> for Utf8PathBuf {
+    fn from(RelPathBuf(path_buf): RelPathBuf) -> Self {
+        path_buf
+    }
+}
+
+impl From<RelPathBuf> for PathBuf {
+    fn from(RelPathBuf(path_buf): RelPathBuf) -> Self {
+        path_buf.into()
+    }
+}
+
+impl ops::Deref for RelPathBuf {
+    type Target = RelPath;
+
+    fn deref(&self) -> &RelPath {
+        self.as_path()
+    }
+}
+
+impl AsRef<Utf8Path> for RelPathBuf {
+    fn as_ref(&self) -> &Utf8Path {
+        self.0.as_path()
+    }
+}
+
+impl AsRef<OsStr> for RelPathBuf {
+    fn as_ref(&self) -> &OsStr {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<Path> for RelPathBuf {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<RelPath> for RelPathBuf {
+    fn as_ref(&self) -> &RelPath {
+        self.as_path()
+    }
+}
+
+impl Borrow<RelPath> for RelPathBuf {
+    fn borrow(&self) -> &RelPath {
+        self.as_path()
+    }
+}
+
+impl TryFrom<Utf8PathBuf> for RelPathBuf {
+    type Error = Utf8PathBuf;
+    fn try_from(path_buf: Utf8PathBuf) -> Result<Self, Utf8PathBuf> {
+        if !path_buf.is_relative() {
+            return Err(path_buf);
+        }
+        Ok(Self(path_buf))
+    }
+}
+
+impl TryFrom<&str> for RelPathBuf {
+    type Error = Utf8PathBuf;
+    fn try_from(path: &str) -> Result<Self, Utf8PathBuf> {
+        Self::try_from(Utf8PathBuf::from(path))
+    }
+}
+
+impl<P: AsRef<Path> + ?Sized> PartialEq<P> for RelPathBuf {
+    fn eq(
+        &self,
+        other: &P,
+    ) -> bool {
+        self.0.as_std_path() == other.as_ref()
+    }
+}
+
+impl RelPathBuf {
+    /// Wrap the given relative path in [`RelPathBuf`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `path` is not relative.
+    #[must_use]
+    pub fn assert(path: Utf8PathBuf) -> Self {
+        Self::try_from(path).unwrap_or_else(|path| panic!("expected relative path, got {path}"))
+    }
+
+    /// Wrap the given relative path in [`RelPathBuf`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `path` is not relative.
+    #[must_use]
+    pub fn assert_utf8(path: PathBuf) -> Self {
+        Self::assert(
+            Utf8PathBuf::from_path_buf(path)
+                .unwrap_or_else(|path| panic!("expected utf8 path, got {}", path.display())),
+        )
+    }
+
+    /// Coerces to a [`RelPath`] slice.
+    ///
+    /// Equivalent of [`Utf8PathBuf::as_path`] for [`RelPathBuf`].
+    #[must_use]
+    pub fn as_path(&self) -> &RelPath {
+        // SAFETY: The path is already known to be a relative path
+        unsafe { RelPath::new_unchecked(self.0.as_path()) }
+    }
+
+    /// Equivalent of [`Utf8PathBuf::pop`] for [`RelPathBuf`].
+    ///
+    /// Note that this won't remove the root component, so `self` will still be
+    /// relative.
+    pub fn pop(&mut self) -> bool {
+        self.0.pop()
+    }
+
+    /// Equivalent of [`PathBuf::push`] for [`RelPathBuf`].
+    ///
+    /// Extends `self` with `path`.
+    ///
+    /// If `path` is relative, it replaces the current path.
+    ///
+    /// On Windows:
+    ///
+    /// * if `path` has a root but no prefix (e.g., `\windows`), it
+    ///   replaces everything except for the prefix (if any) of `self`.
+    /// * if `path` has a prefix but no root, it replaces `self`.
+    /// * if `self` has a verbatim prefix (e.g. `\\?\C:\windows`)
+    ///   and `path` is not empty, the new path is normalized: all references
+    ///   to `.` and `..` are removed.
+    pub fn push<Path>(
+        &mut self,
+        suffix: Path,
+    ) where
+        Path: AsRef<Utf8Path>,
+    {
+        self.0.push(suffix);
+    }
+
+    #[must_use]
+    pub fn join<Path>(
+        &self,
+        path: Path,
+    ) -> Self
+    where
+        Path: AsRef<Utf8Path>,
+    {
+        Self(self.0.join(path))
+    }
+}
+
+impl fmt::Display for RelPathBuf {
+    fn fmt(
+        &self,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
+/// Wrapper around a relative [`Utf8Path`].
+#[derive(Debug, Ord, PartialOrd, Eq, Hash)]
+#[repr(transparent)]
+pub struct RelPath(pub(crate) Utf8Path);
+
+impl AsRef<Utf8Path> for RelPath {
+    fn as_ref(&self) -> &Utf8Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for RelPath {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}
+
+impl<P: AsRef<Path> + ?Sized> PartialEq<P> for RelPath {
+    fn eq(
+        &self,
+        other: &P,
+    ) -> bool {
+        self.0.as_std_path() == other.as_ref()
+    }
+}
+
+impl AsRef<OsStr> for RelPath {
+    fn as_ref(&self) -> &OsStr {
+        self.0.as_ref()
+    }
+}
+
+impl ToOwned for RelPath {
+    type Owned = RelPathBuf;
+
+    fn to_owned(&self) -> Self::Owned {
+        RelPathBuf(self.0.to_owned())
+    }
+}
+
+impl<'path> TryFrom<&'path Utf8Path> for &'path RelPath {
+    type Error = &'path Utf8Path;
+
+    fn try_from(path: &'path Utf8Path) -> Result<&'path RelPath, &'path Utf8Path> {
+        RelPath::new(path)
+    }
+}
+
+impl RelPath {
+    /// Creates a new [`RelPath`] from `path`.
+    pub fn new(path: &Utf8Path) -> Result<&Self, &Utf8Path> {
+        if !path.is_relative() {
+            return Err(path);
+        }
+        // SAFETY: invariant is checked
+        let new = unsafe { Self::new_unchecked(path) };
+        Ok(new)
+    }
+
+    /// Creates a new [`RelPath`] from `path` without checking whether it is relative.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `path` is not relative.
+    ///
+    /// # Safety
+    ///
+    /// Calling this method on an absolute path is *[undefined behavior]*.
+    ///
+    /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
+    #[expect(clippy::as_conversions, reason = "necessary here")]
+    #[must_use]
+    pub const unsafe fn new_unchecked(path: &Utf8Path) -> &Self {
+        //
+        // debug_assert!(path.is_relative(), "{path} is not relative");
+        // SAFETY: pointer is guaranteed to be valid
+        unsafe { &*(std::ptr::from_ref::<Utf8Path>(path) as *const Self) }
+    }
+
+    /// Normalize the given path:
+    /// - Removes repeated separators: `a//b` becomes `a/b`
+    /// - Removes occurrences of `.` and resolves `..`.
+    /// - Removes trailing slashes: `a/b/` becomes `a/b`.
+    ///
+    /// # Example
+    /// ```ignore
+    /// # use paths::RelPathBuf;
+    /// let rel_path_buf = RelPathBuf::assert("a/../../b/.//c//".into());
+    /// let normalized = rel_path_buf.normalize();
+    /// assert_eq!(normalized, RelPathBuf::assert("b/c".into()));
+    /// ```
+    #[must_use]
+    pub fn normalize(&self) -> RelPathBuf {
+        RelPathBuf(normalize_path(&self.0))
+    }
+
+    /// Equivalent of [`Utf8Path::to_path_buf`] for [`RelPath`].
+    #[must_use]
+    pub fn to_path_buf(&self) -> RelPathBuf {
+        RelPathBuf(self.0.to_path_buf())
+    }
+
+    #[must_use]
+    pub fn as_utf8_path(&self) -> &Utf8Path {
+        self.as_ref()
+    }
+
+    /// # Panics
+    ///
+    /// Do not use.
+    #[deprecated]
+    #[expect(clippy::unused_self, reason = "intentional API")]
+    pub fn canonicalize(&self) -> ! {
+        panic!(
+            "We explicitly do not provide canonicalization API, as that is almost always a wrong solution, see #14430"
+        )
+    }
+
+    /// Equivalent of [`Utf8Path::strip_prefix`] for [`RelPath`].
+    ///
+    /// Returns a relative path.
+    pub fn strip_prefix<Pathy>(
+        &self,
+        base: Pathy,
+    ) -> Option<&Self>
+    where
+        Pathy: AsRef<Path>,
+    {
+        // SAFETY: stripping the prefix of any path ensures that it is a relative path
+        self.0
+            .strip_prefix(base)
+            .ok()
+            .map(|stripped| unsafe { Self::new_unchecked(stripped) })
+    }
+
+    #[must_use]
+    pub fn starts_with(
+        &self,
+        base: &Self,
+    ) -> bool {
+        self.0.starts_with(&base.0)
+    }
+
+    #[must_use]
+    pub fn ends_with(
+        &self,
+        suffix: &Self,
+    ) -> bool {
+        self.0.ends_with(&suffix.0)
+    }
+
+    #[must_use]
+    pub fn name_and_extension(&self) -> Option<(&str, Option<&str>)> {
+        Some((self.file_stem()?, self.extension()))
+    }
+
+    // region:delegate-methods
+
+    // Note that we deliberately don't implement `Deref<Target = Utf8Path>` here.
+    //
+    // The problem with `Utf8Path` is that it directly exposes convenience IO-ing
+    // methods. For example, `Utf8Path::exists` delegates to `fs::metadata`.
+    //
+    // For `RelPath`, we want to make sure that this is a POD type, and that all
+    // IO goes via `fs`. That way, it becomes easier to mock IO when we need it.
+
+    #[must_use]
+    pub fn file_name(&self) -> Option<&str> {
+        self.0.file_name()
+    }
+
+    #[must_use]
+    pub fn extension(&self) -> Option<&str> {
+        self.0.extension()
+    }
+
+    #[must_use]
+    pub fn file_stem(&self) -> Option<&str> {
+        self.0.file_stem()
+    }
+
+    #[must_use]
+    pub fn as_os_str(&self) -> &OsStr {
+        self.0.as_os_str()
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    #[expect(clippy::unimplemented, reason = "on purpose")]
+    #[deprecated(note = "use Display instead")]
+    pub fn display(&self) -> ! {
+        unimplemented!("use Display instead")
+    }
+
+    #[expect(clippy::unimplemented, reason = "on purpose")]
+    #[deprecated(note = "use std::fs::metadata().is_ok() instead")]
+    pub fn exists(&self) -> ! {
+        unimplemented!("use std::fs::metadata().is_ok() instead")
+    }
+
+    pub fn components(&self) -> Utf8Components<'_> {
+        self.0.components()
+    }
+    // endregion:delegate-methods
+}
+
+impl fmt::Display for RelPath {
+    fn fmt(
+        &self,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{ffi::OsStr, path::PathBuf};
+
+    #[test]
+    fn utf_from_relbuf() {
+        let path: PathBuf = "test".into();
+        let relbuf = RelPathBuf::assert_utf8(path.clone());
+        let utf8: Utf8PathBuf = relbuf.into();
+        assert_eq!(path, utf8);
+    }
+
+    #[test]
+    fn path_from_relbuf() {
+        let path: PathBuf = "test".into();
+        let relbuf = RelPathBuf::assert_utf8(path.clone());
+        let utf8: PathBuf = relbuf.into();
+        assert_eq!(path, utf8);
+    }
+
+    #[test]
+    fn relbuf_asref_utf8() {
+        let utf8_expect: &Utf8Path = "test".into();
+        let relbuf = RelPathBuf::assert("test".into());
+        let utf8: &Utf8Path = relbuf.as_ref();
+        assert_eq!(utf8_expect, utf8);
+    }
+
+    #[test]
+    fn relbuf_asref_rel() {
+        let rel_expect: &RelPath = RelPath::new("test".into()).unwrap();
+        let relbuf = RelPathBuf::assert("test".into());
+        let rel: &RelPath = relbuf.as_ref();
+        assert_eq!(rel_expect, rel);
+    }
+
+    #[test]
+    fn relbuf_borrow_rel() {
+        let owned = RelPathBuf::assert("test".into());
+        let borrowed: &RelPath = owned.borrow();
+        assert_eq!(RelPath::new("test".into()).unwrap(), borrowed);
+    }
+
+    #[test]
+    fn relbuf_partialeq() {
+        let path: PathBuf = "test".into();
+        let relbuf = RelPathBuf::assert("test".into());
+        assert_eq!(relbuf, path);
+    }
+
+    #[test]
+    fn relbuf_try_from_utf8_fail() {
+        let path: Utf8PathBuf = "/".into();
+        let relbuf = RelPathBuf::try_from(path.clone());
+        assert_eq!(Err(path), relbuf);
+    }
+
+    #[test]
+    fn relbuf_pop() {
+        let mut relbuf = RelPathBuf::assert("test/test".into());
+        let expected = RelPathBuf::assert("test".into());
+        relbuf.pop();
+        assert_eq!(expected, relbuf);
+    }
+
+    #[test]
+    fn relbuf_push() {
+        let mut relbuf = RelPathBuf::assert("test".into());
+        let expected = RelPathBuf::assert("test/push".into());
+        relbuf.push("push");
+        assert_eq!(expected, relbuf);
+    }
+
+    #[test]
+    fn relbuf_display() {
+        let relbuf = RelPathBuf::assert("test".into());
+        let display = format!("{relbuf:#}");
+        assert_eq!("test", display);
+    }
+
+    #[test]
+    fn rel_toowned() {
+        let rel = RelPath::new("test".into()).unwrap();
+        let relbuf = RelPathBuf::assert("test".into());
+        let owned: RelPathBuf = rel.to_owned();
+        assert_eq!(relbuf, owned);
+    }
+
+    #[test]
+    #[should_panic = "We explicitly do not provide canonicalization API, as that is almost always a wrong solution, see #14430"]
+    #[expect(clippy::diverging_sub_expression, deprecated, reason = "test")]
+    fn canonicalize_panics() {
+        let rel1 = RelPath::new("test".into()).unwrap();
+        _ = rel1.canonicalize();
+    }
+
+    #[test]
+    fn rel_starts_with() {
+        let rel1 = RelPath::new("test/path".into()).unwrap();
+        let rel2 = RelPath::new("test".into()).unwrap();
+        let rel3 = RelPath::new("wrong".into()).unwrap();
+        assert!(rel1.starts_with(rel2));
+        assert!(!rel1.starts_with(rel3));
+    }
+
+    #[test]
+    fn rel_ends_with() {
+        let rel = RelPath::new("test/path".into()).unwrap();
+        let rel1 = RelPath::new("path".into()).unwrap();
+        let rel2 = RelPath::new("wrong".into()).unwrap();
+        assert!(rel.ends_with(rel1));
+        assert!(!rel.ends_with(rel2));
+    }
+
+    #[test]
+    fn rel_asref_rel() {
+        let relbuf: &RelPath = RelPath::new("test".into()).unwrap();
+        let osstr: &OsStr = relbuf.as_ref();
+        assert_eq!(OsStr::new("test"), osstr);
+    }
+
+    #[test]
+    fn rel_tryfrom_utf8() {
+        let expect: &RelPath = RelPath::new("test".into()).unwrap();
+        let rel: &RelPath = Utf8Path::new("test").try_into().unwrap();
+        assert_eq!(expect, rel);
+    }
+
+    #[test]
+    fn rel_tryfrom_utf8_err() {
+        let utf8 = Utf8Path::new("/");
+        let result: Result<&RelPath, _> = utf8.try_into();
+        assert_eq!(Err(utf8), result);
+    }
+
+    #[test]
+    fn rel_name_and_extension() {
+        let rel = RelPath::new("name.extension".into()).unwrap();
+        let (name, extension) = rel.name_and_extension().unwrap();
+        assert_eq!("name", name);
+        assert_eq!(Some("extension"), extension);
+    }
+
+    #[test]
+    #[should_panic = "not implemented: use Display instead"]
+    #[expect(clippy::diverging_sub_expression, deprecated, reason = "test")]
+    fn rel_display_panics() {
+        let rel = RelPath::new("name.extension".into()).unwrap();
+        _ = rel.display();
+    }
+
+    #[test]
+    #[should_panic = "not implemented: use std::fs::metadata().is_ok() instead"]
+    #[expect(clippy::diverging_sub_expression, deprecated, reason = "test")]
+    fn rel_exists() {
+        let rel = RelPath::new("name.extension".into()).unwrap();
+        _ = rel.exists();
+    }
+
+    #[test]
+    fn rel_components() {
+        let rel = RelPath::new("name.extension".into()).unwrap();
+        let components = rel.components();
+        let vec: Vec<_> = components.map(|component| component.to_string()).collect();
+        assert_eq!(vec!["name.extension"], vec);
+    }
+
+    #[test]
+    fn rel_display() {
+        let rel = RelPath::new("test".into()).unwrap();
+        let display = format!("{rel:#}");
+        assert_eq!("test", display);
+    }
+}

--- a/crates/paths/src/relative.rs
+++ b/crates/paths/src/relative.rs
@@ -397,6 +397,10 @@ mod tests {
     use super::*;
     use std::{ffi::OsStr, path::PathBuf};
 
+    fn root_utf8() -> &'static Utf8Path {
+        crate::AbsPath::root().as_utf8_path()
+    }
+
     #[test]
     fn utf_from_relbuf() {
         let path: PathBuf = "test".into();
@@ -445,7 +449,7 @@ mod tests {
 
     #[test]
     fn relbuf_try_from_utf8_fail() {
-        let path: Utf8PathBuf = "/".into();
+        let path: Utf8PathBuf = root_utf8().to_owned();
         let relbuf = RelPathBuf::try_from(path.clone());
         assert_eq!(Err(path), relbuf);
     }
@@ -523,7 +527,7 @@ mod tests {
 
     #[test]
     fn rel_tryfrom_utf8_err() {
-        let utf8 = Utf8Path::new("/");
+        let utf8 = root_utf8();
         let result: Result<&RelPath, _> = utf8.try_into();
         assert_eq!(Err(utf8), result);
     }

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "stdx"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+description = "Missing batteries for standard libraries for wgsl-analyzer."
+repository.workspace = true
+license.workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+backtrace = { version = "0.3.76", optional = true }
+crossbeam-channel.workspace = true
+crossbeam-utils = "0.8.21"
+itertools.workspace = true
+jod-thread = "1.0.0"
+tracing.workspace = true
+# Think twice before adding anything here
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+miow = "0.6.1"
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation"] }
+
+[features]
+# Uncomment to enable for the whole crate graph
+# default = [ "backtrace" ]
+force-always-assert = []
+
+[lints]
+workspace = true

--- a/crates/stdx/Cargo.toml
+++ b/crates/stdx/Cargo.toml
@@ -19,10 +19,10 @@ jod-thread = "1.0.0"
 tracing.workspace = true
 # Think twice before adding anything here
 
-[target.'cfg(unix)'.dependencies]
+[target."cfg(unix)".dependencies]
 libc.workspace = true
 
-[target.'cfg(windows)'.dependencies]
+[target."cfg(windows)".dependencies]
 miow = "0.6.1"
 windows-sys = { version = "0.61.2", features = ["Win32_Foundation"] }
 

--- a/crates/stdx/src/anymap.rs
+++ b/crates/stdx/src/anymap.rs
@@ -1,0 +1,359 @@
+//! This file is a port of only the necessary features from <https://github.com/chris-morgan/anymap> version 1.0.0-beta.2 for use within wgsl-analyzer.
+//!
+//! Copyright © 2014–2022 Chris Morgan.
+//! COPYING: <https://github.com/chris-morgan/anymap/blob/master/COPYING>
+//! Note that the license is changed from `Blue Oak Model 1.0.0 or MIT or Apache-2.0` to `MIT OR Apache-2.0`.
+//!
+//! This implementation provides a safe and convenient store for one value of each type.
+//!
+//! Your starting point is [`Map`]. It has an example.
+//!
+//! # Cargo features
+//!
+//! This implementation has two independent features, each of which provides an implementation providing
+//! types `Map`, `AnyMap`, `OccupiedEntry`, `VacantEntry`, `Entry` and `RawMap`:
+//!
+//! - **std** (default, *enabled* in this build):
+//!   an implementation using `std::collections::hash_map`, placed in the crate root
+//!   (for example, `anymap::AnyMap`).
+
+#![warn(missing_docs, unused_results)]
+
+use core::hash::Hasher;
+
+/// A hasher designed to eke a little more speed out, given `TypeId`'s known characteristics.
+///
+/// Specifically, this is a no-op hasher that expects to be fed a u64's worth of
+/// randomly-distributed bits. It works well for `TypeId` (eliminating start-up time, so that my
+/// `get_missing` benchmark is ~30ns rather than ~900ns, and being a good deal faster after that, so
+/// that my `insert_and_get_on_260_types` benchmark is ~12μs instead of ~21.5μs), but will
+/// panic in debug mode and always emit zeros in release mode for any other sorts of inputs, so
+/// yeah, do not use it!
+#[derive(Default)]
+pub struct TypeIdHasher {
+    value: u64,
+}
+
+impl Hasher for TypeIdHasher {
+    #[inline]
+    fn write(
+        &mut self,
+        bytes: &[u8],
+    ) {
+        // This expects to receive exactly one 64-bit value, and there is no realistic chance of
+        // that changing, but I do not want to depend on something that is not expressly part of the
+        // contract for safety. But I am OK with release builds putting everything in one bucket
+        // if it *did* change (and debug builds panicking).
+        debug_assert_eq!(bytes.len(), 8);
+        #[expect(clippy::host_endian_bytes, reason = "not relevant")]
+        if let Ok(array) = bytes.try_into() {
+            self.value = u64::from_ne_bytes(array);
+        }
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.value
+    }
+}
+
+use core::any::{Any, TypeId};
+use core::hash::BuildHasherDefault;
+use core::marker::PhantomData;
+
+use ::std::collections::hash_map;
+
+/// Raw access to the underlying `HashMap`.
+///
+/// This alias is provided for convenience because of the ugly third generic parameter.
+#[expect(clippy::disallowed_types, reason = "Uses a custom hasher")]
+pub type RawMap<A> = hash_map::HashMap<TypeId, Box<A>, BuildHasherDefault<TypeIdHasher>>;
+
+/// A collection containing zero or one values for any given type and allowing convenient,
+/// type-safe access to those values.
+///
+/// The type parameter `A` allows you to use a different value type; normally you will want
+/// it to be `core::any::Any` (also known as `std::any::Any`), but there are other choices:
+///
+/// - You can add on `+ Send` or `+ Send + Sync` (for example, `Map<dyn Any + Send>`)
+///   to add those auto traits.
+///
+/// Cumulatively, there are thus six forms of map:
+///
+/// - `[Map]<dyn [core::any::Any]>`,
+///   also spelled [`AnyMap`] for convenience.
+/// - `[Map]<dyn [core::any::Any] + Send>`
+/// - `[Map]<dyn [core::any::Any] + Send + Sync>`
+///
+/// ## Example
+///
+/// Here, the [`AnyMap`] convenience alias is used;
+/// the first line could use `[anymap::Map][Map]::<[core::any::Any]>::default()`
+/// instead if desired.
+///
+/// ```rust
+/// # use stdx::anymap;
+/// let mut data = anymap::AnyMap::default();
+/// assert_eq!(data.get(), None::<&i32>);
+/// ```
+///
+/// Values containing non-static references are not permitted.
+#[derive(Debug)]
+pub struct Map<A: ?Sized + Downcast = dyn Any> {
+    raw: RawMap<A>,
+}
+
+/// The most common type of `Map`: just using `Any`; `[Map]<dyn [Any]>`.
+///
+/// Why is this a separate type alias rather than a default value for `Map<A>`?
+/// `Map::default()` does not seem to be happy to infer that it should go with the default
+/// value. It is a bit sad, really. Ah well, I guess this approach will do.
+pub type AnyMap = Map<dyn Any>;
+
+impl<A: ?Sized + Downcast> Default for Map<A> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            raw: RawMap::with_hasher(BuildHasherDefault::default()),
+        }
+    }
+}
+
+impl<A: ?Sized + Downcast> Map<A> {
+    /// Returns a reference to the value stored in the collection for the type `T`,
+    /// if it exists.
+    #[inline]
+    #[must_use]
+    pub fn get<T>(&self) -> Option<&T>
+    where
+        T: IntoBox<A>,
+    {
+        self.raw
+            .get(&TypeId::of::<T>())
+        	// SAFETY: T does match the trait object because `T: IntoBox<A>`.
+            .map(|any| unsafe { any.downcast_unchecked_ref::<T>() })
+    }
+
+    /// Gets the entry for the given type in the collection for in-place manipulation.
+    #[inline]
+    pub fn entry<T>(&mut self) -> Entry<'_, A, T>
+    where
+        T: IntoBox<A>,
+    {
+        match self.raw.entry(TypeId::of::<T>()) {
+            hash_map::Entry::Occupied(entry) => Entry::Occupied(OccupiedEntry {
+                inner: entry,
+                type_: PhantomData,
+            }),
+            hash_map::Entry::Vacant(entry) => Entry::Vacant(VacantEntry {
+                inner: entry,
+                type_: PhantomData,
+            }),
+        }
+    }
+}
+
+/// A view into a single occupied location in an `Map`.
+pub struct OccupiedEntry<'map, A: ?Sized + Downcast, V: 'map> {
+    inner: hash_map::OccupiedEntry<'map, TypeId, Box<A>>,
+    type_: PhantomData<V>,
+}
+
+/// A view into a single empty location in an `Map`.
+pub struct VacantEntry<'map, A: ?Sized + Downcast, V: 'map> {
+    inner: hash_map::VacantEntry<'map, TypeId, Box<A>>,
+    type_: PhantomData<V>,
+}
+
+/// A view into a single location in an `Map`, which may be vacant or occupied.
+pub enum Entry<'map, A: ?Sized + Downcast, V> {
+    /// An occupied Entry.
+    Occupied(OccupiedEntry<'map, A, V>),
+    /// A vacant Entry.
+    Vacant(VacantEntry<'map, A, V>),
+}
+
+impl<'map, A: ?Sized + Downcast, V: IntoBox<A>> Entry<'map, A, V> {
+    /// Ensures a value is in the entry by inserting the result of the default function if
+    /// empty, and returns a mutable reference to the value in the entry.
+    #[inline]
+    pub fn or_insert_with<Default>(
+        self,
+        default: Default,
+    ) -> &'map mut V
+    where
+        Default: FnOnce() -> V,
+    {
+        match self {
+            Entry::Occupied(inner) => inner.into_mut(),
+            Entry::Vacant(inner) => inner.insert(default()),
+        }
+    }
+}
+
+impl<'map, A: ?Sized + Downcast, V: IntoBox<A>> OccupiedEntry<'map, A, V> {
+    /// Converts the `OccupiedEntry` into a mutable reference to the value in the entry
+    /// with a lifetime bound to the collection itself.
+    #[inline]
+    #[must_use]
+    pub fn into_mut(self) -> &'map mut V {
+        // SAFETY: T does match the trait object because `V: IntoBox<A>`.
+        unsafe { self.inner.into_mut().downcast_unchecked_mut() }
+    }
+}
+
+impl<'map, A: ?Sized + Downcast, V: IntoBox<A>> VacantEntry<'map, A, V> {
+    /// Sets the value of the entry with the `VacantEntry`'s key,
+    /// and returns a mutable reference to it.
+    #[inline]
+    pub fn insert(
+        self,
+        value: V,
+    ) -> &'map mut V {
+        // SAFETY: T does match the trait object because `V: IntoBox<A>`.
+        unsafe { self.inner.insert(value.into_box()).downcast_unchecked_mut() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn varieties() {
+        fn assert_send<T>()
+        where
+            T: Send,
+        {
+        }
+        fn assert_sync<T>()
+        where
+            T: Sync,
+        {
+        }
+        fn assert_debug<T>()
+        where
+            T: ::core::fmt::Debug,
+        {
+        }
+        assert_send::<Map<dyn Any + Send>>();
+        assert_send::<Map<dyn Any + Send + Sync>>();
+        assert_sync::<Map<dyn Any + Send + Sync>>();
+        assert_debug::<Map<dyn Any>>();
+        assert_debug::<Map<dyn Any + Send>>();
+        assert_debug::<Map<dyn Any + Send + Sync>>();
+    }
+
+    #[test]
+    fn type_id_hasher() {
+        use core::any::TypeId;
+        use core::hash::Hash as _;
+        fn verify_hashing_with(type_id: TypeId) {
+            let mut hasher = TypeIdHasher::default();
+            type_id.hash(&mut hasher);
+            _ = hasher.finish();
+        }
+        // Pick a variety of types, just to demonstrate that it is all sane. Normal, zero-sized, unsized, &c.
+        verify_hashing_with(TypeId::of::<usize>());
+        verify_hashing_with(TypeId::of::<()>());
+        verify_hashing_with(TypeId::of::<str>());
+        verify_hashing_with(TypeId::of::<&str>());
+        verify_hashing_with(TypeId::of::<Vec<u8>>());
+    }
+}
+
+/// Methods for downcasting from an `Any`-like trait object.
+///
+/// This should only be implemented on trait objects for subtraits of `Any`, though you can
+/// implement it for other types and it will work fine, so long as your implementation is correct.
+pub trait Downcast {
+    /// Gets the `TypeId` of `self`.
+    fn type_id(&self) -> TypeId;
+
+    // Note the bound through these downcast methods is 'static, rather than the inexpressible
+    // concept of Self-but-as-a-trait (where Self is `dyn Trait`). This is sufficient, exceeding
+    // TypeId's requirements. Sure, you *can* do CloneAny.downcast_unchecked::<NotClone>() and the
+    // type system will not protect you, but that does not introduce any unsafety: the method is
+    // already unsafe because you can specify the wrong type, and if this were exposing safe
+    // downcasting, CloneAny.downcast::<NotClone>() would just return an error, which is just as
+    // correct.
+    //
+    // Now in theory we could also add T: ?Sized, but that does not play nicely with the common
+    // implementation, so I am doing without it.
+
+    /// Downcast from `&Any` to `&T`, without checking the type matches.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `T` matches the trait object, on pain of *undefined behavior*.
+    unsafe fn downcast_unchecked_ref<T>(&self) -> &T
+    where
+        T: 'static;
+
+    /// Downcast from `&mut Any` to `&mut T`, without checking the type matches.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `T` matches the trait object, on pain of *undefined behavior*.
+    unsafe fn downcast_unchecked_mut<T>(&mut self) -> &mut T
+    where
+        T: 'static;
+}
+
+/// A trait for the conversion of an object into a boxed trait object.
+pub trait IntoBox<A: ?Sized + Downcast>: Any {
+    /// Convert self into the appropriate boxed form.
+    fn into_box(self) -> Box<A>;
+}
+
+macro_rules! implement {
+    ($any_trait:ident $(+ $auto_traits:ident)*) => {
+        impl Downcast for dyn $any_trait $(+ $auto_traits)* {
+            #[inline]
+            fn type_id(&self) -> TypeId {
+                self.type_id()
+            }
+
+            /// Returns a reference to the underlying value without checking its type.
+            ///
+            /// # Safety
+            ///
+            /// The caller **must** ensure that the actual type of the underlying object is `T`.
+            /// If the type is incorrect, this will result in undefined behavior due to an invalid cast.
+            ///
+            /// This method performs an unchecked cast from the trait object to the concrete type.
+            #[inline]
+            unsafe fn downcast_unchecked_ref<T>(&self) -> &T where T: 'static {
+                // SAFETY:
+                // The caller guarantees that `self` is a `T`. We cast from a trait object to T accordingly.
+                unsafe { &*std::ptr::from_ref::<Self>(self).cast::<T>() }
+            }
+
+            /// Returns a mutable reference to the underlying value without checking its type.
+            ///
+            /// # Safety
+            ///
+            /// The caller **must** ensure that the actual type of the underlying object is `T`.
+            /// If the type is incorrect, this will result in undefined behavior due to an invalid cast.
+            ///
+            /// This method performs an unchecked cast from the trait object to the concrete type.
+            #[inline]
+            unsafe fn downcast_unchecked_mut<T>(&mut self) -> &mut T where T: 'static {
+                // SAFETY:
+                // The caller guarantees that `self` is a `T`. We cast from a trait object to T accordingly.
+                unsafe { &mut *std::ptr::from_mut::<Self>(self).cast::<T>() }
+            }
+        }
+
+        impl<T: $any_trait $(+ $auto_traits)*> IntoBox<dyn $any_trait $(+ $auto_traits)*> for T {
+            #[inline]
+            fn into_box(self) -> Box<dyn $any_trait $(+ $auto_traits)*> {
+                Box::new(self)
+            }
+        }
+    }
+}
+
+implement!(Any);
+implement!(Any + Send);
+implement!(Any + Send + Sync);

--- a/crates/stdx/src/assert.rs
+++ b/crates/stdx/src/assert.rs
@@ -1,0 +1,115 @@
+// Vendored from https://github.com/matklad/always-assert/commit/4cf564eea6fcf18b30c3c3483a611004dc03afbb
+//! Recoverable assertions, inspired by [the use of `assert()` in
+//! SQLite](https://www.sqlite.org/assert.html).
+//!
+//! `never!` and `always!` return the actual value of the condition if
+//! `debug_assertions` are disabled.
+//!
+//! Use them when terminating on assertion failure is worse than continuing.
+//!
+//! One example would be a critical application like a database:
+//!
+//! ```ignore
+//! use stdx::never;
+//!
+//! fn apply_transaction(&mut self, tx: Transaction) -> Result<(), TransactionAborted> {
+//!     let delta = self.compute_delta(&tx);
+//!
+//!     if never!(!self.check_internal_invariant(&delta)) {
+//!         // Ok, something in this transaction messed up our internal state.
+//!         // This really shouldn't be happening, and this signifies a bug.
+//!         // Luckily, we can recover by just rejecting the transaction.
+//!         return abort_transaction(tx);
+//!     }
+//!     self.commit(delta);
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Another example is assertions about non-critical functionality in usual apps:
+//!
+//! ```ignore
+//! use stdx::never;
+//!
+//! let english_message = "super app installed!"
+//! let mut local_message = localize(english_message);
+//! if never!(local_message.is_empty(), "missing localization for {}", english_message) {
+//!     // We localized all the messages but this one slipper through the cracks?
+//!     // Better to show the english one then than to fail outright;
+//!     local_message = english_message;
+//! }
+//! println!("{}", local_message);
+//! ```
+
+/// Asserts that the condition is always true and returns its actual value.
+///
+/// If the condition is true does nothing and evaluates to true.
+///
+/// If the condition is false:
+/// * panics if `force` feature or `debug_assertions` are enabled,
+/// * logs an error if the `tracing` feature is enabled,
+/// * evaluates to false.
+///
+/// Accepts `format!` style arguments.
+#[macro_export]
+macro_rules! always {
+    ($cond:expr) => {
+        $crate::always!($cond, "assertion failed: {}", stringify!($cond))
+    };
+
+    ($cond:expr, $fmt:literal $($argument:tt)*) => {{
+        let cond = $cond;
+        if cfg!(debug_assertions) || $crate::assert::__FORCE {
+            assert!(cond, $fmt $($argument)*);
+        }
+        if !cond {
+            $crate::assert::__tracing_error!($fmt $($argument)*);
+        }
+        cond
+    }};
+}
+
+/// Asserts that the condition is never true and returns its actual value.
+///
+/// If the condition is false does nothing and evaluates to false.
+///
+/// If the condition is true:
+/// * panics if `force` feature or `debug_assertions` are enabled,
+/// * logs an error if the `tracing` feature is enabled,
+/// * evaluates to true.
+///
+/// Accepts `format!` style arguments.
+///
+/// Empty condition is equivalent to false:
+///
+/// ```ignore
+/// never!("oups") ~= unreachable!("oups")
+/// ```
+#[macro_export]
+macro_rules! never {
+    (true $($tt:tt)*) => { $crate::never!((true) $($tt)*) };
+    (false $($tt:tt)*) => { $crate::never!((false) $($tt)*) };
+    () => { $crate::never!("assertion failed: entered unreachable code") };
+    ($fmt:literal $(, $($argument:tt)*)?) => {{
+        if cfg!(debug_assertions) || $crate::assert::__FORCE {
+            unreachable!($fmt $(, $($argument)*)?);
+        }
+        $crate::assert::__tracing_error!($fmt $(, $($argument)*)?);
+    }};
+
+    ($cond:expr) => {{
+        let cond = !$crate::always!(!$cond);
+        cond
+    }};
+
+    ($cond:expr, $fmt:literal $($argument:tt)*) => {{
+        let cond = !$crate::always!(!$cond, $fmt $($argument)*);
+        cond
+    }};
+}
+
+#[doc(hidden)]
+pub use tracing::error as __tracing_error;
+
+#[doc(hidden)]
+pub const __FORCE: bool = cfg!(feature = "force-always-assert");

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -1,5 +1,7 @@
 //! Missing batteries for standard libraries.
 
+#![warn(unused)]
+
 use std::borrow::Cow;
 use std::process::Command;
 use std::{cmp::Ordering, ops, time::Instant};

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -1,0 +1,521 @@
+//! Missing batteries for standard libraries.
+
+use std::borrow::Cow;
+use std::process::Command;
+use std::{cmp::Ordering, ops, time::Instant};
+use std::{hash, io as sio};
+
+mod macros;
+
+pub mod anymap;
+pub mod assert;
+pub mod non_empty_vec;
+pub mod panic_context;
+pub mod process;
+pub mod rand;
+pub mod tempfile;
+pub mod thread;
+pub mod variance;
+
+pub use itertools;
+
+#[must_use]
+pub const fn is_ci() -> bool {
+    option_env!("CI").is_some()
+}
+
+#[expect(
+    clippy::impl_trait_in_params,
+    reason = "API - generic parameter is not bound to parameters so it must be written"
+)]
+pub fn hash_once<Hasher>(thing: impl std::hash::Hash) -> u64
+where
+    Hasher: std::hash::Hasher + Default,
+{
+    hash::BuildHasher::hash_one(&hash::BuildHasherDefault::<Hasher>::default(), thing)
+}
+
+#[must_use]
+#[expect(clippy::print_stderr, reason = "only visible to developers")]
+pub fn timeit(label: &'static str) -> impl Drop {
+    let start = Instant::now();
+    defer(move || eprintln!("{label}: {:.2}", start.elapsed().as_nanos()))
+}
+
+/// Prints backtrace to stderr, useful for debugging.
+#[expect(clippy::print_stderr, reason = "only visible to developers")]
+pub fn print_backtrace() {
+    #[cfg(feature = "backtrace")]
+    #[expect(clippy::use_debug, reason = "only visible to developers")]
+    {
+        eprintln!("{:?}", backtrace::Backtrace::new());
+    }
+
+    #[cfg(not(feature = "backtrace"))]
+    eprintln!(
+        r#"Enable the backtrace feature.
+Uncomment `default = [ "backtrace" ]` in `crates/stdx/Cargo.toml`.
+"#
+    );
+}
+
+pub trait TupleExt {
+    type Head;
+    type Tail;
+    fn head(self) -> Self::Head;
+    fn tail(self) -> Self::Tail;
+}
+
+impl<T, U> TupleExt for (T, U) {
+    type Head = T;
+    type Tail = U;
+
+    fn head(self) -> Self::Head {
+        self.0
+    }
+
+    fn tail(self) -> Self::Tail {
+        self.1
+    }
+}
+
+impl<T, U, V> TupleExt for (T, U, V) {
+    type Head = T;
+    type Tail = V;
+
+    fn head(self) -> Self::Head {
+        self.0
+    }
+
+    fn tail(self) -> Self::Tail {
+        self.2
+    }
+}
+
+impl<T> TupleExt for &T
+where
+    T: TupleExt + Copy,
+{
+    type Head = T::Head;
+    type Tail = T::Tail;
+    fn head(self) -> Self::Head {
+        (*self).head()
+    }
+    fn tail(self) -> Self::Tail {
+        (*self).tail()
+    }
+}
+
+pub fn to_lower_snake_case(string: &str) -> String {
+    to_snake_case(string, char::to_lowercase)
+}
+
+pub fn to_upper_snake_case(string: &str) -> String {
+    to_snake_case(string, char::to_uppercase)
+}
+
+// Code partially taken from rust/compiler/rustc_lint/src/nonstandard_style.rs
+// commit: 9626f2b
+fn to_snake_case<F, I>(
+    mut string: &str,
+    change_case: F,
+) -> String
+where
+    F: Fn(char) -> I,
+    I: Iterator<Item = char>,
+{
+    let mut words = vec![];
+
+    // Preserve leading underscores
+    string = string.trim_start_matches(|character: char| {
+        if character == '_' {
+            words.push(String::new());
+            true
+        } else {
+            false
+        }
+    });
+
+    for string in string.split('_') {
+        let mut last_upper = false;
+        let mut buffer = String::new();
+
+        if string.is_empty() {
+            continue;
+        }
+
+        for character in string.chars() {
+            if !buffer.is_empty() && buffer != "'" && character.is_uppercase() && !last_upper {
+                words.push(buffer);
+                buffer = String::new();
+            }
+
+            last_upper = character.is_uppercase();
+            buffer.extend(change_case(character));
+        }
+
+        words.push(buffer);
+    }
+
+    words.join("_")
+}
+
+// Taken from rustc.
+#[must_use]
+pub fn to_camel_case(identifier: &str) -> String {
+    identifier
+        .trim_matches('_')
+        .split('_')
+        .filter(|component| !component.is_empty())
+        .map(|component| {
+            let mut camel_cased_component = String::with_capacity(component.len());
+
+            let mut new_word = true;
+            let mut prev_is_lower_case = true;
+
+            for character in component.chars() {
+                // Preserve the case if an uppercase letter follows a lowercase letter, so that
+                // `camelCase` is converted to `CamelCase`.
+                if prev_is_lower_case && character.is_uppercase() {
+                    new_word = true;
+                }
+
+                if new_word {
+                    camel_cased_component.extend(character.to_uppercase());
+                } else {
+                    camel_cased_component.extend(character.to_lowercase());
+                }
+
+                prev_is_lower_case = character.is_lowercase();
+                new_word = false;
+            }
+
+            camel_cased_component
+        })
+        .fold(
+            (String::new(), None),
+            |(mut accumulator, previous): (_, Option<String>), next| {
+                // separate two components with an underscore if their boundary cannot
+                // be distinguished using an uppercase/lowercase case distinction
+                let join = previous
+                    .and_then(|previous| {
+                        let first = next.chars().next()?;
+                        let last = previous.chars().last()?;
+                        Some(!char_has_case(last) && !char_has_case(first))
+                    })
+                    .unwrap_or(false);
+                accumulator.push_str(if join { "_" } else { "" });
+                accumulator.push_str(&next);
+                (accumulator, Some(next))
+            },
+        )
+        .0
+}
+
+// Taken from rustc.
+#[must_use]
+pub const fn char_has_case(character: char) -> bool {
+    character.is_lowercase() || character.is_uppercase()
+}
+
+#[must_use]
+pub fn is_upper_snake_case(string: &str) -> bool {
+    string
+        .chars()
+        .all(|character| character.is_uppercase() || character == '_' || character.is_numeric())
+}
+
+pub fn replace(
+    buffer: &mut String,
+    from: char,
+    to: &str,
+) {
+    let replace_count = buffer.chars().filter(|&ch| ch == from).count();
+    if replace_count == 0 {
+        return;
+    }
+    let from_len = from.len_utf8();
+    let additional = to.len().saturating_sub(from_len);
+    buffer.reserve(additional * replace_count);
+
+    let mut end = buffer.len();
+    while let Some(index) = buffer[..end].rfind(from) {
+        buffer.replace_range(index..index + from_len, to);
+        end = index;
+    }
+}
+
+#[must_use]
+pub fn trim_indent(mut text: &str) -> String {
+    if text.starts_with('\n') {
+        text = &text[1..];
+    }
+    let indent = indent_of(text);
+    text.split_inclusive('\n')
+        .map(|line| {
+            if line.len() <= indent {
+                line.trim_start_matches(' ')
+            } else {
+                &line[indent..]
+            }
+        })
+        .collect()
+}
+
+#[must_use]
+fn indent_of(text: &str) -> usize {
+    text.lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|trimmed_line| trimmed_line.len() - trimmed_line.trim_start().len())
+        .min()
+        .unwrap_or(0)
+}
+
+#[must_use]
+pub fn dedent_by(
+    spaces: usize,
+    text: &str,
+) -> String {
+    text.split_inclusive('\n')
+        .map(|line| {
+            let trimmed = line.trim_start_matches(' ');
+            if line.len() - trimmed.len() <= spaces {
+                trimmed
+            } else {
+                &line[spaces..]
+            }
+        })
+        .collect()
+}
+
+/// Indent non empty lines, including the first line.
+#[must_use]
+pub fn indent_string(
+    string: &str,
+    indent_level: u8,
+) -> String {
+    if indent_level == 0 || string.is_empty() {
+        return string.to_owned();
+    }
+    let indent_str = "    ".repeat(indent_level.into());
+    string
+        .split_inclusive('\n')
+        .map(|line| {
+            if line.trim_end().is_empty() {
+                Cow::Borrowed(line)
+            } else {
+                format!("{indent_str}{line}").into()
+            }
+        })
+        .collect()
+}
+
+pub fn equal_range_by<T, F>(
+    slice: &[T],
+    mut key: F,
+) -> ops::Range<usize>
+where
+    F: FnMut(&T) -> Ordering,
+{
+    let start = slice.partition_point(|item| key(item) == Ordering::Less);
+    let length = slice[start..].partition_point(|item| key(item) == Ordering::Equal);
+    start..start + length
+}
+
+/// Constructs a type that, when dropped, calls `function()`.
+#[must_use]
+pub fn defer<Function>(function: Function) -> impl Drop
+where
+    Function: FnOnce(),
+{
+    struct Droppable<F: FnOnce()>(Option<F>);
+
+    impl<F: FnOnce()> Drop for Droppable<F> {
+        fn drop(&mut self) {
+            if let Some(function) = self.0.take() {
+                function();
+            }
+        }
+    }
+    Droppable(Some(function))
+}
+
+/// A [`std::process::Child`] wrapper that will kill the child on drop.
+#[cfg_attr(not(target_arch = "wasm32"), repr(transparent))]
+#[derive(Debug)]
+pub struct JodChild(pub std::process::Child);
+
+impl ops::Deref for JodChild {
+    type Target = std::process::Child;
+
+    fn deref(&self) -> &std::process::Child {
+        &self.0
+    }
+}
+
+impl ops::DerefMut for JodChild {
+    fn deref_mut(&mut self) -> &mut std::process::Child {
+        &mut self.0
+    }
+}
+
+impl Drop for JodChild {
+    fn drop(&mut self) {
+        let _unused1 = self.0.kill();
+        let _unused2 = self.0.wait();
+    }
+}
+
+impl JodChild {
+    pub fn spawn(mut command: Command) -> sio::Result<Self> {
+        command.spawn().map(Self)
+    }
+
+    #[must_use]
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn into_inner(self) -> std::process::Child {
+        // SAFETY: repr transparent, except on WASM
+        unsafe { std::mem::transmute::<Self, std::process::Child>(self) }
+    }
+}
+
+// feature: iter_order_by
+// Iterator::eq_by
+// https://github.com/rust-lang/rust/issues/64295
+pub fn iter_eq_by<I, I2, F>(
+    this: I2,
+    other: I,
+    mut eq: F,
+) -> bool
+where
+    I: IntoIterator,
+    I2: IntoIterator,
+    F: FnMut(I2::Item, I::Item) -> bool,
+{
+    let mut other = other.into_iter();
+    let mut this = this.into_iter();
+
+    loop {
+        let Some(an_item) = this.next() else {
+            return other.next().is_none();
+        };
+
+        let Some(another_item) = other.next() else {
+            return false;
+        };
+
+        if !eq(an_item, another_item) {
+            return false;
+        }
+    }
+}
+
+/// Returns all final segments of the argument, longest first.
+pub fn slice_tails<T>(this: &[T]) -> impl Iterator<Item = &[T]> {
+    (0..this.len()).map(|index| &this[index..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trim_indent_works() {
+        assert_eq!(trim_indent(""), "");
+        assert_eq!(
+            trim_indent(
+                "
+            hello
+            world
+"
+            ),
+            "hello\nworld\n"
+        );
+        assert_eq!(
+            trim_indent(
+                "
+            hello
+            world"
+            ),
+            "hello\nworld"
+        );
+        assert_eq!(trim_indent("    hello\n    world\n"), "hello\nworld\n");
+        assert_eq!(
+            trim_indent(
+                "
+            fn main() {
+                return 92;
+            }
+        "
+            ),
+            "fn main() {\n    return 92;\n}\n"
+        );
+    }
+
+    #[test]
+    fn dedent_works() {
+        assert_eq!(dedent_by(0, ""), "");
+        assert_eq!(dedent_by(1, ""), "");
+        assert_eq!(dedent_by(2, ""), "");
+        assert_eq!(dedent_by(0, "foo"), "foo");
+        assert_eq!(dedent_by(2, "foo"), "foo");
+        assert_eq!(dedent_by(2, "  foo"), "foo");
+        assert_eq!(dedent_by(2, "    foo"), "  foo");
+        assert_eq!(dedent_by(2, "    foo\nbar"), "  foo\nbar");
+        assert_eq!(dedent_by(2, "foo\n    bar"), "foo\n  bar");
+        assert_eq!(dedent_by(2, "foo\n\n    bar"), "foo\n\n  bar");
+        assert_eq!(dedent_by(2, "foo\n.\n    bar"), "foo\n.\n  bar");
+        assert_eq!(dedent_by(2, "foo\n .\n    bar"), "foo\n.\n  bar");
+        assert_eq!(dedent_by(2, "foo\n   .\n    bar"), "foo\n .\n  bar");
+    }
+
+    #[test]
+    fn indent_of_works() {
+        assert_eq!(indent_of(""), 0);
+        assert_eq!(indent_of(" "), 0);
+        assert_eq!(indent_of(" x"), 1);
+        assert_eq!(indent_of(" x\n"), 1);
+        assert_eq!(indent_of(" x\ny"), 0);
+        assert_eq!(indent_of(" x\n y"), 1);
+        assert_eq!(indent_of(" x\n  y"), 1);
+        assert_eq!(indent_of("  x\n  y"), 2);
+        assert_eq!(indent_of("  x\n  y\n"), 2);
+        assert_eq!(indent_of("  x\n\n  y\n"), 2);
+    }
+
+    #[expect(clippy::non_ascii_literal, reason = "the point of the test")]
+    #[test]
+    fn replace_works() {
+        #[track_caller]
+        fn test_replace(
+            src: &str,
+            from: char,
+            to: &str,
+            expected: &str,
+        ) {
+            let mut source = src.to_owned();
+            replace(&mut source, from, to);
+            assert_eq!(source, expected, "from: {from:?}, to: {to:?}");
+        }
+
+        test_replace("", 'a', "b", "");
+        test_replace("", 'a', "😀", "");
+        test_replace("", '😀', "a", "");
+        test_replace("a", 'a', "b", "b");
+        test_replace("aa", 'a', "b", "bb");
+        test_replace("ada", 'a', "b", "bdb");
+        test_replace("a", 'a', "😀", "😀");
+        test_replace("😀", '😀', "a", "a");
+        test_replace("😀x", '😀', "a", "ax");
+        test_replace("y😀x", '😀', "a", "yax");
+        test_replace("a,b,c", ',', ".", "a.b.c");
+        test_replace("a,b,c", ',', "..", "a..b..c");
+        test_replace("a.b.c", '.', "..", "a..b..c");
+        test_replace("a.b.c", '.', "..", "a..b..c");
+        test_replace("a😀b😀c", '😀', ".", "a.b.c");
+        test_replace("a.b.c", '.', "😀", "a😀b😀c");
+        test_replace("a.b.c", '.', "😀😀", "a😀😀b😀😀c");
+        test_replace(".a.b.c.", '.', "()", "()a()b()c()");
+        test_replace(".a.b.c.", '.', "", "abc");
+    }
+}

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -2,9 +2,8 @@
 
 #![warn(unused)]
 
-use std::borrow::Cow;
 use std::process::Command;
-use std::{cmp::Ordering, ops, time::Instant};
+use std::{cmp::Ordering, ops};
 use std::{hash, io as sio};
 
 mod macros;
@@ -37,28 +36,13 @@ where
     hash::BuildHasher::hash_one(&hash::BuildHasherDefault::<Hasher>::default(), thing)
 }
 
+#[cfg(test)]
 #[must_use]
 #[expect(clippy::print_stderr, reason = "only visible to developers")]
 pub fn timeit(label: &'static str) -> impl Drop {
+    use std::time::Instant;
     let start = Instant::now();
     defer(move || eprintln!("{label}: {:.2}", start.elapsed().as_nanos()))
-}
-
-/// Prints backtrace to stderr, useful for debugging.
-#[expect(clippy::print_stderr, reason = "only visible to developers")]
-pub fn print_backtrace() {
-    #[cfg(feature = "backtrace")]
-    #[expect(clippy::use_debug, reason = "only visible to developers")]
-    {
-        eprintln!("{:?}", backtrace::Backtrace::new());
-    }
-
-    #[cfg(not(feature = "backtrace"))]
-    eprintln!(
-        r#"Enable the backtrace feature.
-Uncomment `default = [ "backtrace" ]` in `crates/stdx/Cargo.toml`.
-"#
-    );
 }
 
 pub trait TupleExt {
@@ -220,13 +204,6 @@ pub const fn char_has_case(character: char) -> bool {
     character.is_lowercase() || character.is_uppercase()
 }
 
-#[must_use]
-pub fn is_upper_snake_case(string: &str) -> bool {
-    string
-        .chars()
-        .all(|character| character.is_uppercase() || character == '_' || character.is_numeric())
-}
-
 pub fn replace(
     buffer: &mut String,
     from: char,
@@ -285,28 +262,6 @@ pub fn dedent_by(
                 trimmed
             } else {
                 &line[spaces..]
-            }
-        })
-        .collect()
-}
-
-/// Indent non empty lines, including the first line.
-#[must_use]
-pub fn indent_string(
-    string: &str,
-    indent_level: u8,
-) -> String {
-    if indent_level == 0 || string.is_empty() {
-        return string.to_owned();
-    }
-    let indent_str = "    ".repeat(indent_level.into());
-    string
-        .split_inclusive('\n')
-        .map(|line| {
-            if line.trim_end().is_empty() {
-                Cow::Borrowed(line)
-            } else {
-                format!("{indent_str}{line}").into()
             }
         })
         .collect()
@@ -422,6 +377,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn to_camel_case_works() {
+        assert_eq!(to_camel_case("___"), "");
+        assert_eq!(to_camel_case("hello_world"), "HelloWorld");
+        assert_eq!(to_camel_case("camelCase"), "CamelCase");
+        assert_eq!(to_camel_case("XML_http"), "XmlHttp");
+        assert_eq!(to_camel_case("123_456"), "123_456");
+        assert_eq!(to_camel_case("__foo___bar__"), "FooBar");
+    }
+
+    #[test]
+    fn to_snake_case_works() {
+        assert_eq!(to_lower_snake_case("_"), "");
+        assert_eq!(to_lower_snake_case("HelloWorld"), "hello_world");
+        assert_eq!(to_lower_snake_case("_FooBar"), "_foo_bar");
+        assert_eq!(to_upper_snake_case("_"), "");
+        assert_eq!(to_upper_snake_case("HelloWorld"), "HELLO_WORLD");
+        assert_eq!(to_upper_snake_case("_FooBar"), "_FOO_BAR");
+    }
+
+    #[test]
     fn trim_indent_works() {
         assert_eq!(trim_indent(""), "");
         assert_eq!(
@@ -519,5 +494,31 @@ mod tests {
         test_replace("a.b.c", '.', "😀😀", "a😀😀b😀😀c");
         test_replace(".a.b.c.", '.', "()", "()a()b()c()");
         test_replace(".a.b.c.", '.', "", "abc");
+    }
+
+    #[test]
+    fn equal_range_by_edge_cases() {
+        assert_eq!(equal_range_by(&[], |_: &i32| Ordering::Equal), 0..0);
+        assert_eq!(equal_range_by(&[2, 2, 3], |index| index.cmp(&2)), 0..2);
+        assert_eq!(
+            equal_range_by(&[1, 2, 2, 2, 3], |index| index.cmp(&2)),
+            1..4
+        );
+        assert_eq!(equal_range_by(&[1, 2, 2], |index| index.cmp(&2)), 1..3);
+        assert_eq!(equal_range_by(&[1, 3], |index| index.cmp(&2)), 1..1);
+        assert_eq!(equal_range_by(&[2, 3], |index| index.cmp(&1)), 0..0);
+        assert_eq!(equal_range_by(&[1, 2], |index| index.cmp(&3)), 2..2);
+        assert_eq!(equal_range_by(&[2, 2, 2], |index| index.cmp(&2)), 0..3);
+    }
+
+    #[test]
+    fn defer_works() {
+        let data = std::rc::Rc::new(std::cell::RefCell::new(String::new()));
+        {
+            let _to_drop = defer(|| data.borrow_mut().push('a'));
+            data.borrow_mut().push('b');
+        }
+        data.borrow_mut().push('c');
+        assert_eq!(data.take(), "bac");
     }
 }

--- a/crates/stdx/src/macros.rs
+++ b/crates/stdx/src/macros.rs
@@ -1,0 +1,145 @@
+//! Convenience macros.
+
+/// Appends formatted string to a `String`.
+#[macro_export]
+macro_rules! format_to {
+    ($buf:expr) => ();
+    ($buf:expr, $literal:literal $($argument:tt)*) => {
+        {
+            use ::std::fmt::Write as _;
+            // We cannot do ::std::fmt::Write::write_fmt($buf, format_args!($literal $($argument)*))
+            // unfortunately, as that loses out on autoref behavior.
+            _ = $buf.write_fmt(format_args!($literal $($argument)*))
+        }
+    };
+}
+
+/// Appends formatted string to a `String` and returns the `String`.
+///
+/// Useful for folding iterators into a `String`.
+#[macro_export]
+macro_rules! format_to_accumulator {
+    ($buf:expr, $literal:literal $($argument:tt)*) => {
+        {
+            use ::std::fmt::Write as _;
+            // We cannot do ::std::fmt::Write::write_fmt($buf, format_args!($literal $($argument)*))
+            // unfortunately, as that loses out on autoref behavior.
+            _ = $buf.write_fmt(format_args!($literal $($argument)*));
+            $buf
+        }
+    };
+}
+
+/// Generates `From` impls that wrap values in, or map variants between, enums.
+///
+/// Enum mappings with `Source => Target` rename the variant and convert its payload with `.into()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// impl_from!(Struct, Union, Enum for Adt);
+/// impl_from!(impl<'db> Item, InternedItem<'db> for ItemId<'db>);
+/// impl_from!(AssocItem { Function, Const, TypeAlias } for Item);
+/// impl_from!(AdtId { StructId => Struct, EnumId => Enum } for Adt);
+/// ```
+#[macro_export]
+macro_rules! impl_from {
+    (
+        impl<$lifetime:lifetime>
+        $source:ident $(<$source_lifetime:lifetime>)?
+        { $($source_variant:ident $(=> $target_variant:ident)?),* $(,)? }
+        for $target:ident<$target_lifetime:lifetime>
+    ) => {
+        impl<$lifetime> From<$source$(<$source_lifetime>)?> for $target<$target_lifetime> {
+            fn from(value: $source$(<$source_lifetime>)?) -> Self {
+                match value {
+                    $(
+                        $source::$source_variant(value) => $crate::impl_from!(
+                            @map_enum_variant $target, value, $source_variant
+                            $(=> $target_variant)?
+                        ),
+                    )*
+                }
+            }
+        }
+    };
+    (
+        $source:ident
+        { $($source_variant:ident $(=> $target_variant:ident)?),* $(,)? }
+        for $target:ident
+    ) => {
+        impl From<$source> for $target {
+            fn from(value: $source) -> Self {
+                match value {
+                    $(
+                        $source::$source_variant(value) => $crate::impl_from!(
+                            @map_enum_variant $target, value, $source_variant
+                            $(=> $target_variant)?
+                        ),
+                    )*
+                }
+            }
+        }
+    };
+    (@map_enum_variant $target:ident, $value:ident, $variant:ident) => {
+        $target::$variant($value)
+    };
+    (
+        @map_enum_variant $target:ident, $value:ident,
+        $source_variant:ident => $target_variant:ident
+    ) => {
+        $target::$target_variant($value.into())
+    };
+    (
+        impl<$lifetime:lifetime>
+        $(
+            $variant:ident $(<$variant_lifetime:lifetime>)?
+            $(($($sub_variant:ident $(<$sub_variant_lifetime:lifetime>)?),*))?
+        ),*
+        for $enum:ident<$enum_lifetime:lifetime>
+    ) => {
+        $(
+            impl<$lifetime> From<$variant$(<$variant_lifetime>)?> for $enum<$enum_lifetime> {
+                fn from(it: $variant$(<$variant_lifetime>)?) -> $enum<$enum_lifetime> {
+                    $enum::$variant(it)
+                }
+            }
+            $($(
+                impl<$lifetime> From<$sub_variant$(<$sub_variant_lifetime>)?>
+                    for $enum<$enum_lifetime>
+                {
+                    fn from(
+                        it: $sub_variant$(<$sub_variant_lifetime>)?,
+                    ) -> $enum<$enum_lifetime> {
+                        $enum::$variant($variant::$sub_variant(it))
+                    }
+                }
+            )*)?
+        )*
+    };
+    ($($variant:ident $(($($sub_variant:ident),*))?),* for $enum:ident) => {
+        $(
+            impl From<$variant> for $enum {
+                fn from(it: $variant) -> $enum {
+                    $enum::$variant(it)
+                }
+            }
+            $($(
+                impl From<$sub_variant> for $enum {
+                    fn from(it: $sub_variant) -> $enum {
+                        $enum::$variant($variant::$sub_variant(it))
+                    }
+                }
+            )*)?
+        )*
+    };
+    ($($variant:ident$(<$V:ident>)?),* for $enum:ident) => {
+        $(
+            impl$(<$V>)? From<$variant$(<$V>)?> for $enum$(<$V>)? {
+                fn from(it: $variant$(<$V>)?) -> $enum$(<$V>)? {
+                    $enum::$variant(it)
+                }
+            }
+        )*
+    }
+}

--- a/crates/stdx/src/non_empty_vec.rs
+++ b/crates/stdx/src/non_empty_vec.rs
@@ -1,0 +1,46 @@
+//! See [`NonEmptyVec`].
+
+/// A [`Vec`] that is guaranteed to at least contain one element.
+pub struct NonEmptyVec<T> {
+    first: T,
+    rest: Vec<T>,
+}
+
+impl<T> NonEmptyVec<T> {
+    #[inline]
+    pub const fn new(first: T) -> Self {
+        Self {
+            first,
+            rest: Vec::new(),
+        }
+    }
+
+    #[inline]
+    pub fn last_mut(&mut self) -> &mut T {
+        self.rest.last_mut().unwrap_or(&mut self.first)
+    }
+
+    #[inline]
+    pub fn pop(&mut self) -> Option<T> {
+        self.rest.pop()
+    }
+
+    #[inline]
+    pub fn push(
+        &mut self,
+        value: T,
+    ) {
+        self.rest.push(value);
+    }
+
+    #[inline]
+    #[expect(clippy::len_without_is_empty, reason = "makes no sense for this type")]
+    pub const fn len(&self) -> usize {
+        1 + self.rest.len()
+    }
+
+    #[inline]
+    pub fn into_last(mut self) -> T {
+        self.rest.pop().unwrap_or(self.first)
+    }
+}

--- a/crates/stdx/src/non_empty_vec.rs
+++ b/crates/stdx/src/non_empty_vec.rs
@@ -44,3 +44,35 @@ impl<T> NonEmptyVec<T> {
         self.rest.pop().unwrap_or(self.first)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::NonEmptyVec;
+
+    #[test]
+    fn non_empty_vec() {
+        let mut vec = NonEmptyVec::new(1);
+        assert_eq!(vec.len(), 1);
+        assert_eq!(*vec.last_mut(), 1);
+        assert_eq!(vec.pop(), None);
+        assert_eq!(vec.into_last(), 1);
+
+        let mut vec = NonEmptyVec::new(1);
+        vec.push(2);
+        vec.push(3);
+
+        assert_eq!(vec.len(), 3);
+        assert_eq!(*vec.last_mut(), 3);
+        assert_eq!(vec.pop(), Some(3));
+        assert_eq!(vec.len(), 2);
+        assert_eq!(*vec.last_mut(), 2);
+        assert_eq!(vec.into_last(), 2);
+
+        let mut vec = NonEmptyVec::new(1);
+        vec.push(2);
+        assert_eq!(vec.pop(), Some(2));
+        assert_eq!(*vec.last_mut(), 1);
+        assert_eq!(vec.pop(), None);
+        assert_eq!(vec.into_last(), 1);
+    }
+}

--- a/crates/stdx/src/panic_context.rs
+++ b/crates/stdx/src/panic_context.rs
@@ -1,0 +1,47 @@
+//! A micro-crate to enhance panic messages with context info.
+
+use std::{cell::RefCell, panic, sync::Once};
+
+/// Dummy for leveraging RAII cleanup to pop frames.
+#[must_use]
+pub struct PanicContext {
+    // prevent arbitrary construction
+    _priv: (),
+}
+
+impl Drop for PanicContext {
+    fn drop(&mut self) {
+        with_ctx(|context| assert!(context.pop().is_some()));
+    }
+}
+
+pub fn enter(frame: String) -> PanicContext {
+    #[expect(clippy::print_stderr, reason = "already panicking anyway")]
+    fn set_hook() {
+        let default_hook = panic::take_hook();
+        panic::set_hook(Box::new(move |panic_info| {
+            with_ctx(|context| {
+                if !context.is_empty() {
+                    eprintln!("Panic context:");
+                    for frame in context.iter() {
+                        eprintln!("> {frame}\n");
+                    }
+                }
+            });
+            default_hook(panic_info);
+        }));
+    }
+
+    static SET_HOOK: Once = Once::new();
+    SET_HOOK.call_once(set_hook);
+
+    with_ctx(|context| context.push(frame));
+    PanicContext { _priv: () }
+}
+
+fn with_ctx(function: impl FnOnce(&mut Vec<String>)) {
+    thread_local! {
+        static CTX: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+    }
+    CTX.with(|context| function(&mut context.borrow_mut()));
+}

--- a/crates/stdx/src/process.rs
+++ b/crates/stdx/src/process.rs
@@ -229,7 +229,7 @@ mod implementation {
                 if status.token() == 0 {
                     // SAFETY: TODO
                     unsafe {
-                        out_pipe.complete(*status);
+                        out_pipe.complete(status);
                     }
                     data(true, out_pipe.dst, out_pipe.done);
                     // SAFETY: TODO
@@ -239,7 +239,7 @@ mod implementation {
                 } else {
                     // SAFETY: TODO
                     unsafe {
-                        error_pipe.complete(*status);
+                        error_pipe.complete(status);
                     }
                     data(false, error_pipe.dst, error_pipe.done);
                     // SAFETY: TODO

--- a/crates/stdx/src/process.rs
+++ b/crates/stdx/src/process.rs
@@ -1,0 +1,337 @@
+//! Read both stdout and stderr of child without deadlocks.
+//!
+//! <https://github.com/rust-lang/cargo/blob/905af549966f23a9288e9993a85d1249a5436556/crates/cargo-util/src/read2.rs>
+//! <https://github.com/rust-lang/cargo/blob/58a961314437258065e23cb6316dfc121d96fb71/crates/cargo-util/src/process_builder.rs#L231>
+
+#![expect(clippy::doc_paragraphs_missing_punctuation, reason = "false positive")]
+
+use std::{
+    io,
+    process::{ChildStderr, ChildStdout, Command, Output, Stdio},
+};
+
+use crate::JodChild;
+
+pub fn streaming_output(
+    out: ChildStdout,
+    error: ChildStderr,
+    on_stdout_line: &mut dyn FnMut(&str),
+    on_stderr_line: &mut dyn FnMut(&str),
+    on_end_of_file: &mut dyn FnMut(),
+) -> io::Result<(Vec<u8>, Vec<u8>)> {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    implementation::read2(out, error, &mut |is_out, data, end_of_file| {
+        let index = if end_of_file {
+            data.len()
+        } else {
+            match data.iter().rposition(|&byte| byte == b'\n') {
+                Some(index) => index + 1,
+                None => return,
+            }
+        };
+        {
+            // scope for new_lines
+            let new_lines = {
+                let destination = if is_out { &mut stdout } else { &mut stderr };
+                let start = destination.len();
+                let data = data.drain(..index);
+                destination.extend(data);
+                &destination[start..]
+            };
+            for line in String::from_utf8_lossy(new_lines).lines() {
+                if is_out {
+                    on_stdout_line(line);
+                } else {
+                    on_stderr_line(line);
+                }
+            }
+            if end_of_file {
+                on_end_of_file();
+            }
+        }
+    })?;
+    Ok((stdout, stderr))
+}
+
+/// # Panics
+///
+/// Panics if `cmd` is not configured to have `stdout` and `stderr` as `piped`.
+pub fn spawn_with_streaming_output(
+    mut cmd: Command,
+    on_stdout_line: &mut dyn FnMut(&str),
+    on_stderr_line: &mut dyn FnMut(&str),
+) -> io::Result<Output> {
+    let cmd = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null());
+
+    let mut child = JodChild(cmd.spawn()?);
+    let (stdout, stderr) = streaming_output(
+        child.stdout.take().unwrap(),
+        child.stderr.take().unwrap(),
+        on_stdout_line,
+        on_stderr_line,
+        &mut || (),
+    )?;
+    let status = child.wait()?;
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+#[cfg(all(unix, not(target_arch = "wasm32")))]
+mod implementation {
+    use std::{
+        io::{self, prelude::*},
+        mem,
+        os::unix::prelude::*,
+        process::{ChildStderr, ChildStdout},
+    };
+
+    /// Reads from both stdout and stderr pipes of a child process concurrently,
+    /// using non-blocking I/O and `poll(2)` to multiplex between them.
+    ///
+    /// The provided `data` callback is invoked repeatedly with accumulated output
+    /// until both pipes have reached `EOF`.
+    pub(crate) fn read2(
+        mut out_pipe: ChildStdout,
+        mut error_pipe: ChildStderr,
+        data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
+    ) -> io::Result<()> {
+        // SAFETY: We assume `as_raw_fd()` returns valid file descriptors.
+        // Setting them to non-blocking mode is safe as long as they are valid.
+        unsafe {
+            libc::fcntl(out_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
+        }
+        // SAFETY: We assume `as_raw_fd()` returns valid file descriptors.
+        // Setting them to non-blocking mode is safe as long as they are valid.
+        unsafe {
+            libc::fcntl(error_pipe.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK);
+        }
+        let mut out_done = false;
+        let mut error_done = false;
+        let mut out = Vec::new();
+        let mut error = Vec::new();
+
+        // SAFETY: `pollfd` is a plain old data type and zero initialization is valid.
+        let mut fds: [libc::pollfd; 2] = unsafe { mem::zeroed() };
+        fds[0].fd = out_pipe.as_raw_fd();
+        fds[0].events = libc::POLLIN;
+        fds[1].fd = error_pipe.as_raw_fd();
+        fds[1].events = libc::POLLIN;
+        let mut nfds = 2;
+        let mut errfd = 1;
+
+        while nfds > 0 {
+            // wait for either pipe to become readable using `select`
+            // SAFETY: `fds` points to two properly initialized pollfd structs.
+            // `poll` will block until one of the fds becomes ready.
+            let return_code = unsafe { libc::poll(fds.as_mut_ptr(), nfds, -1) };
+            if return_code == -1 {
+                let error = io::Error::last_os_error();
+                if error.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(error);
+            }
+
+            // Read as much as we can from each pipe, ignoring EWOULDBLOCK or
+            // EAGAIN. If we hit EOF, then this will happen because the underlying
+            // reader will return Ok(0), in which case we'll see `Ok` ourselves. In
+            // this case we flip the other fd back into blocking mode and read
+            // whatever's leftover on that file descriptor.
+            let handle = |result: io::Result<_>| match result {
+                Ok(_) => Ok(true),
+                Err(error) => {
+                    if error.kind() == io::ErrorKind::WouldBlock {
+                        Ok(false)
+                    } else {
+                        Err(error)
+                    }
+                },
+            };
+            if !error_done && fds[errfd].revents != 0 && handle(error_pipe.read_to_end(&mut error))?
+            {
+                error_done = true;
+                nfds -= 1;
+            }
+            data(false, &mut error, error_done);
+            if !out_done && fds[0].revents != 0 && handle(out_pipe.read_to_end(&mut out))? {
+                out_done = true;
+                fds[0].fd = error_pipe.as_raw_fd(); // Switch to monitor stderr only
+                errfd = 0;
+                nfds -= 1;
+            }
+            data(true, &mut out, out_done);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+mod implementation {
+    use std::{
+        io,
+        os::windows::prelude::*,
+        process::{ChildStderr, ChildStdout},
+        slice,
+    };
+
+    use miow::{
+        Overlapped,
+        iocp::{CompletionPort, CompletionStatus},
+        pipe::NamedPipe,
+    };
+    use windows_sys::Win32::Foundation::ERROR_BROKEN_PIPE;
+
+    struct Pipe<'buffer> {
+        dst: &'buffer mut Vec<u8>,
+        overlapped: Overlapped,
+        pipe: NamedPipe,
+        done: bool,
+    }
+
+    pub(crate) fn read2(
+        out_pipe: ChildStdout,
+        error_pipe: ChildStderr,
+        data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
+    ) -> io::Result<()> {
+        let mut out = Vec::new();
+        let mut error = Vec::new();
+
+        let port = CompletionPort::new(1)?;
+        port.add_handle(0, &out_pipe)?;
+        port.add_handle(1, &error_pipe)?;
+
+        // SAFETY: TODO
+        let mut out_pipe = unsafe { Pipe::new(out_pipe, &mut out) };
+        // SAFETY: TODO
+        let mut error_pipe = unsafe { Pipe::new(error_pipe, &mut error) };
+
+        // SAFETY: TODO
+        unsafe {
+            out_pipe.read()?;
+        }
+        // SAFETY: TODO
+        unsafe {
+            error_pipe.read()?;
+        }
+
+        let mut status = [CompletionStatus::zero(), CompletionStatus::zero()];
+
+        while !out_pipe.done || !error_pipe.done {
+            for status in port.get_many(&mut status, None)? {
+                if status.token() == 0 {
+                    // SAFETY: TODO
+                    unsafe {
+                        out_pipe.complete(*status);
+                    }
+                    data(true, out_pipe.dst, out_pipe.done);
+                    // SAFETY: TODO
+                    unsafe {
+                        out_pipe.read()?;
+                    }
+                } else {
+                    // SAFETY: TODO
+                    unsafe {
+                        error_pipe.complete(*status);
+                    }
+                    data(false, error_pipe.dst, error_pipe.done);
+                    // SAFETY: TODO
+                    unsafe {
+                        error_pipe.read()?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    impl<'buffer> Pipe<'buffer> {
+        unsafe fn new<P: IntoRawHandle>(
+            pipe: P,
+            dst: &'buffer mut Vec<u8>,
+        ) -> Self {
+            // SAFETY: `pipe`is required to be a valid `NamedPipe`.
+            let pipe = unsafe { NamedPipe::from_raw_handle(pipe.into_raw_handle()) };
+            Pipe {
+                dst,
+                pipe,
+                overlapped: Overlapped::zero(),
+                done: false,
+            }
+        }
+
+        unsafe fn read(&mut self) -> io::Result<()> {
+            let dst = unsafe { slice_to_end(self.dst) };
+            match unsafe { self.pipe.read_overlapped(dst, self.overlapped.raw()) } {
+                Ok(_) => Ok(()),
+                Err(error) => {
+                    if error.raw_os_error() == Some(ERROR_BROKEN_PIPE as i32) {
+                        self.done = true;
+                        Ok(())
+                    } else {
+                        Err(error)
+                    }
+                },
+            }
+        }
+
+        /// # Safety
+        /// `self.dst` must have a capacity of at least `self.dst.len() + status.bytes_transferred()`.
+        unsafe fn complete(
+            &mut self,
+            status: &CompletionStatus,
+        ) {
+            let new_length = self
+                .dst
+                .len()
+                .checked_add(status.bytes_transferred().try_into().unwrap())
+                .unwrap();
+            // SAFETY: the responsibility lies on the callsite to make sure that the vec
+            // has enough capacity to make this a valid operation.
+            unsafe {
+                self.dst.set_len(new_length);
+            }
+            if status.bytes_transferred() == 0 {
+                self.done = true;
+            }
+        }
+    }
+
+    /// Seems safe enough. :D
+    unsafe fn slice_to_end(vector: &mut Vec<u8>) -> &mut [u8] {
+        if vector.capacity() == 0 {
+            vector.reserve(16);
+        }
+        if vector.capacity() == vector.len() {
+            vector.reserve(1);
+        }
+        // SAFETY: invariants hold because this gets a pointer within the Vec's capacity
+        let data = unsafe { vector.as_mut_ptr().add(vector.len()) };
+        let length = vector.capacity() - vector.len();
+        // SAFETY: invariants have been checked and tested
+        unsafe { slice::from_raw_parts_mut(data, length) }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod implementation {
+    use std::{
+        io,
+        process::{ChildStderr, ChildStdout},
+    };
+
+    pub(crate) fn read2(
+        _out_pipe: ChildStdout,
+        _err_pipe: ChildStderr,
+        _data: &mut dyn FnMut(bool, &mut Vec<u8>, bool),
+    ) -> io::Result<()> {
+        panic!("no processes on wasm")
+    }
+}

--- a/crates/stdx/src/rand.rs
+++ b/crates/stdx/src/rand.rs
@@ -1,0 +1,27 @@
+//! We don't use `rand` because that is too many things for us.
+//!
+//! `oorandom` is used instead, but it's missing these two utilities.
+//! Switching to `fastrand` or our own small PRNG may be good because only xor-shift is needed.
+
+pub fn shuffle<T, RandIndex>(
+    slice: &mut [T],
+    mut rand_index: RandIndex,
+) where
+    RandIndex: FnMut(usize) -> usize,
+{
+    let mut remaining = slice.len() - 1;
+    while remaining > 0 {
+        let index = rand_index(remaining);
+        slice.swap(remaining, index);
+        remaining -= 1;
+    }
+}
+
+#[must_use]
+pub fn seed() -> u64 {
+    use std::hash::{BuildHasher as _, Hasher as _};
+    #[expect(clippy::disallowed_types, reason = "TODO")]
+    std::collections::hash_map::RandomState::new()
+        .build_hasher()
+        .finish()
+}

--- a/crates/stdx/src/tempfile.rs
+++ b/crates/stdx/src/tempfile.rs
@@ -1,0 +1,220 @@
+//! A temporary named file that will be deleted on drop, and on operating systems that support that,
+//! also when the process exits (including being killed).
+
+use std::{
+    fs::File,
+    io,
+    path::{Path, PathBuf},
+};
+
+pub struct NamedTempFile {
+    _file: Option<File>,
+    path: PathBuf,
+    delete_on_drop: bool,
+}
+
+impl NamedTempFile {
+    pub fn new(prefix: &str) -> io::Result<Self> {
+        imp::create(prefix)
+    }
+
+    /// Creates a new [`NamedTempFile`] that is a copy of an existing file.
+    pub fn new_from_existing(
+        prefix: &str,
+        existing: &Path,
+    ) -> io::Result<Self> {
+        let result = Self::new(prefix)?;
+        std::fs::copy(existing, &result.path)?;
+        Ok(result)
+    }
+
+    /// Creates a [`NamedTempFile`] from a path, without deleting it on drop.
+    #[inline]
+    #[must_use]
+    pub const fn from_path(path: PathBuf) -> Self {
+        Self {
+            _file: None,
+            path,
+            delete_on_drop: false,
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for NamedTempFile {
+    fn drop(&mut self) {
+        if self.delete_on_drop && std::fs::remove_file(&self.path).is_err() {
+            tracing::info!("cannot remove temporary file {}", self.path.display());
+        }
+    }
+}
+
+pub struct NamedTempDir {
+    path: PathBuf,
+}
+
+impl NamedTempDir {
+    #[expect(
+        clippy::create_dir,
+        reason = "easy to change if this ends up causing a bug later"
+    )]
+    pub fn new(prefix: &str) -> io::Result<Self> {
+        general_imp::create(prefix, |_options, path| std::fs::create_dir(path))
+            .map(|((), path)| Self { path })
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for NamedTempDir {
+    fn drop(&mut self) {
+        if std::fs::remove_dir_all(&self.path).is_err() {
+            tracing::info!("cannot remove temporary directory {}", self.path.display());
+        }
+    }
+}
+
+mod general_imp {
+    use std::{
+        fs::OpenOptions,
+        io::{self, ErrorKind},
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU32, Ordering},
+    };
+
+    static INTERNAL_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    pub(super) fn create<T>(
+        prefix: &str,
+        mut create: impl FnMut(OpenOptions, &Path) -> io::Result<T>,
+    ) -> io::Result<(T, PathBuf)> {
+        let temp_dir = std::env::temp_dir().canonicalize()?;
+        let pid = std::process::id();
+        loop {
+            let path = temp_dir.join(format!(
+                "{prefix}{pid:x}-{:x}",
+                INTERNAL_COUNTER.fetch_add(1, Ordering::AcqRel),
+            ));
+            let mut open_options = OpenOptions::new();
+            open_options.create_new(true);
+            match create(open_options, &path) {
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {},
+                Err(error) => {
+                    return Err(io::Error::new(
+                        error.kind(),
+                        format!(
+                            "error creating directory {}: {error}",
+                            path.to_string_lossy()
+                        ),
+                    ));
+                },
+                Ok(file) => {
+                    return Ok((file, path));
+                },
+            }
+        }
+    }
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+))]
+mod imp {
+    use std::{
+        ffi::CString,
+        io,
+        os::{
+            fd::{AsRawFd as _, RawFd},
+            unix::ffi::OsStrExt as _,
+        },
+    };
+
+    use super::{NamedTempFile, PathBuf, general_imp};
+
+    #[cfg(target_os = "linux")]
+    fn path_after_unlink(fd: RawFd) -> PathBuf {
+        PathBuf::from(format!("/proc/self/fd/{fd}"))
+    }
+
+    #[cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
+    fn path_after_unlink(fd: RawFd) -> PathBuf {
+        PathBuf::from(format!("/dev/fd/{fd}"))
+    }
+
+    pub(super) fn create(prefix: &str) -> io::Result<NamedTempFile> {
+        let (file, mut path) = general_imp::create(prefix, |options, path| options.open(path))?;
+        let mut delete_on_drop = true;
+        if let Ok(original_path) = CString::new(path.as_os_str().as_bytes()) {
+            // Unlinking the file will *not* remove it per the POSIX specification since it is open.
+            // We cannot use `std::fs::remove_file()`, since, while currently using `unlink()`, it does
+            // not guarantee it will use it.
+            // SAFETY: unlink is being given a valid pointer.
+            let unlink = unsafe { libc::unlink(original_path.as_ptr()) };
+            if unlink == 0 {
+                path = path_after_unlink(file.as_raw_fd());
+                delete_on_drop = false;
+            }
+        }
+        Ok(NamedTempFile {
+            _file: Some(file),
+            path,
+            delete_on_drop,
+        })
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    use super::*;
+
+    const FILE_ATTRIBUTE_TEMPORARY: u32 = 0x100;
+    const FILE_FLAG_DELETE_ON_CLOSE: u32 = 0x04000000;
+
+    pub(super) fn create(prefix: &str) -> io::Result<NamedTempFile> {
+        let (file, path) = general_imp::create(prefix, |mut options, path| {
+            options
+                .attributes(FILE_ATTRIBUTE_TEMPORARY)
+                .custom_flags(FILE_FLAG_DELETE_ON_CLOSE)
+                .open(path)
+        })?;
+        Ok(NamedTempFile {
+            _file: Some(file),
+            path,
+            delete_on_drop: false,
+        })
+    }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    windows,
+)))]
+mod imp {
+    use super::*;
+
+    pub(super) fn create(prefix: &str) -> io::Result<NamedTempFile> {
+        let (file, path) = general_imp::create(prefix, |options, path| options.open(path))?;
+        Ok(NamedTempFile {
+            _file: Some(file),
+            path,
+            delete_on_drop: true,
+        })
+    }
+}

--- a/crates/stdx/src/thread.rs
+++ b/crates/stdx/src/thread.rs
@@ -1,0 +1,145 @@
+//! A utility module for working with threads that automatically joins threads upon drop
+//! and abstracts over operating system quality of service (`QoS`) APIs
+//! through the concept of a “thread intent”.
+//!
+//! The intent of a thread is frozen at thread creation time,
+//! i.e. there is no API to change the intent of a thread once it has been spawned.
+//!
+//! As a system, wgsl-analyzer should have the property that
+//! old manual scheduling APIs are replaced entirely by `QoS`.
+//! To maintain this invariant, we panic when it is clear that
+//! old scheduling APIs have been used.
+//!
+//! Moreover, we also want to ensure that every thread has an intent set explicitly
+//! to force a decision about its importance to the system.
+//! Thus, [`ThreadIntent`] has no default value
+//! and every entry point to creating a thread requires a [`ThreadIntent`] upfront.
+
+use std::fmt;
+
+mod intent;
+mod pool;
+
+pub use intent::ThreadIntent;
+pub use pool::Pool;
+
+/// # Panics
+///
+/// Panics if failed to spawn the thread.
+pub fn spawn<Function, T>(
+    intent: ThreadIntent,
+    name: String,
+    function: Function,
+) -> JoinHandle<T>
+where
+    Function: (FnOnce() -> T) + Send + 'static,
+    T: Send + 'static,
+{
+    Builder::new(intent, name)
+        .spawn(function)
+        .expect("failed to spawn thread")
+}
+
+pub const DEFAULT_STACK_SIZE: usize = 16 * 0x0400 * 0x0400;
+
+pub struct Builder {
+    intent: ThreadIntent,
+    inner: jod_thread::Builder,
+    allow_leak: bool,
+}
+
+impl Builder {
+    #[must_use]
+    pub fn new<Name>(
+        intent: ThreadIntent,
+        name: Name,
+    ) -> Self
+    where
+        Name: Into<String>,
+    {
+        Self {
+            intent,
+            inner: jod_thread::Builder::new()
+                .name(name.into())
+                .stack_size(DEFAULT_STACK_SIZE),
+            allow_leak: false,
+        }
+    }
+
+    #[must_use]
+    pub fn stack_size(
+        self,
+        size: usize,
+    ) -> Self {
+        Self {
+            inner: self.inner.stack_size(size),
+            ..self
+        }
+    }
+
+    /// Whether dropping should detach the thread
+    /// instead of joining it.
+    #[must_use]
+    pub fn allow_leak(
+        self,
+        allow_leak: bool,
+    ) -> Self {
+        Self { allow_leak, ..self }
+    }
+
+    pub fn spawn<Function, T>(
+        self,
+        function: Function,
+    ) -> std::io::Result<JoinHandle<T>>
+    where
+        Function: (FnOnce() -> T) + Send + 'static,
+        T: Send + 'static,
+    {
+        let inner_handle = self.inner.spawn(move || {
+            self.intent.apply_to_current_thread();
+            function()
+        })?;
+
+        Ok(JoinHandle {
+            inner: Some(inner_handle),
+            allow_leak: self.allow_leak,
+        })
+    }
+}
+
+pub struct JoinHandle<T = ()> {
+    // `inner` is an `Option` so that we can
+    // take ownership of the contained `JoinHandle`.
+    inner: Option<jod_thread::JoinHandle<T>>,
+    allow_leak: bool,
+}
+
+impl<T> JoinHandle<T> {
+    /// # Panics
+    ///
+    /// Panics if there is no thread to join.
+    #[must_use]
+    pub fn join(mut self) -> T {
+        self.inner.take().unwrap().join()
+    }
+}
+
+impl<T> Drop for JoinHandle<T> {
+    fn drop(&mut self) {
+        if !self.allow_leak {
+            return;
+        }
+        if let Some(join_handle) = self.inner.take() {
+            join_handle.detach();
+        }
+    }
+}
+
+impl<T> fmt::Debug for JoinHandle<T> {
+    fn fmt(
+        &self,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        formatter.pad("JoinHandle { .. }")
+    }
+}

--- a/crates/stdx/src/thread/intent.rs
+++ b/crates/stdx/src/thread/intent.rs
@@ -1,0 +1,311 @@
+#![expect(
+    clippy::missing_const_for_fn,
+    reason = "const trait impl is not stable"
+)]
+//! An opaque façade around platform-specific Quality of Service APIs.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+// Please maintain order from least to most priority for the derived `Ord` impl.
+pub enum ThreadIntent {
+    /// Any thread which does work that is not in the critical path of the user typing
+    /// (for example, processing Go To Definition).
+    Worker,
+
+    /// Any thread which does work caused by the user typing
+    /// (for example, processing syntax highlighting).
+    LatencySensitive,
+}
+
+impl ThreadIntent {
+    // These APIs must remain private;
+    // we only want consumers to set thread intent
+    // either during thread creation or using our pool impl.
+
+    pub(super) fn apply_to_current_thread(self) {
+        let class = thread_intent_to_qos_class(self);
+        set_current_thread_qos_class(class);
+    }
+
+    pub(super) fn assert_is_used_on_current_thread(self) {
+        if IS_QOS_AVAILABLE {
+            let class = thread_intent_to_qos_class(self);
+            assert_eq!(get_current_thread_qos_class(), Some(class));
+        }
+    }
+}
+
+use imp::QoSClass;
+
+const IS_QOS_AVAILABLE: bool = imp::IS_QOS_AVAILABLE;
+
+#[expect(clippy::semicolon_if_nothing_returned, reason = "thin wrapper")]
+fn set_current_thread_qos_class(class: QoSClass) {
+    imp::set_current_thread_qos_class(class)
+}
+
+fn get_current_thread_qos_class() -> Option<QoSClass> {
+    imp::get_current_thread_qos_class()
+}
+
+fn thread_intent_to_qos_class(intent: ThreadIntent) -> QoSClass {
+    imp::thread_intent_to_qos_class(intent)
+}
+
+// All Apple platforms use XNU as their kernel
+// and thus have the concept of [QoS](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/EnergyGuide-iOS/PrioritizeWorkWithQoS.html).
+#[cfg(target_vendor = "apple")]
+mod imp {
+    use super::ThreadIntent;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    // Please maintain order from least to most priority for the derived `Ord` impl.
+    pub(super) enum QoSClass {
+        // Documentation adapted from https://github.com/apple-oss-distributions/libpthread/blob/67e155c94093be9a204b69637d198eceff2c7c46/include/sys/qos.h#L55
+        //
+        /// TLDR: invisible maintenance tasks.
+        ///
+        /// Contract:
+        ///
+        /// * **You do not care about how long it takes for work to finish.**
+        /// * **You do not care about work being deferred temporarily.**
+        ///   (for example, if the device's battery is in a critical state)
+        ///
+        /// Examples:
+        ///
+        /// * in a video editor:
+        ///   creating periodic backups of project files
+        /// * in a browser:
+        ///   cleaning up cached sites which have not been accessed in a long time
+        /// * in a collaborative word processor:
+        ///   creating a searchable index of all documents
+        ///
+        /// Use this QoS class for background tasks
+        /// which the user did not initiate themselves
+        /// and which are invisible to the user.
+        /// It is expected that this work will take significant time to complete:
+        /// minutes or even hours.
+        ///
+        /// This QoS class provides the most energy and thermally-efficient execution possible.
+        /// All other work is prioritized over background tasks.
+        Background,
+
+        /// TLDR: tasks that do not block using your app.
+        ///
+        /// Contract:
+        ///
+        /// * **Your app remains useful even as the task is executing.**
+        ///
+        /// Examples:
+        ///
+        /// * in a video editor:
+        ///   exporting a video to disk –
+        ///   the user can still work on the timeline
+        /// * in a browser:
+        ///   automatically extracting a downloaded zip file –
+        ///   the user can still switch tabs
+        /// * in a collaborative word processor:
+        ///   downloading images embedded in a document –
+        ///   the user can still make edits
+        ///
+        /// Use this QoS class for tasks which
+        /// may or may not be initiated by the user,
+        /// but whose result is visible.
+        /// It is expected that this work will take a few seconds to a few minutes.
+        /// Typically your app will include a progress bar
+        /// for tasks using this class.
+        ///
+        /// This QoS class provides a balance between
+        /// performance, responsiveness, and efficiency.
+        Utility,
+
+        /// TLDR: tasks that block using your app.
+        ///
+        /// Contract:
+        ///
+        /// * **You need this work to complete
+        ///   before the user can keep interacting with your app.**
+        /// * **Your work will not take more than a few seconds to complete.**
+        ///
+        /// Examples:
+        ///
+        /// * in a video editor:
+        ///   opening a saved project
+        /// * in a browser:
+        ///   loading a list of the user's bookmarks and top sites
+        ///   when a new tab is created
+        /// * in a collaborative word processor:
+        ///   running a search on the document's content
+        ///
+        /// Use this QoS class for tasks which were initiated by the user
+        /// and block the usage of your app while they are in progress.
+        /// It is expected that this work will take a few seconds or less to complete;
+        /// not long enough to cause the user to switch to something else.
+        /// Your app will likely indicate progress on these tasks
+        /// through the display of placeholder content or modals.
+        ///
+        /// This QoS class is not energy-efficient.
+        /// Rather, it provides responsiveness
+        /// by prioritizing work above other tasks on the system
+        /// except for critical user-interactive work.
+        UserInitiated,
+
+        /// TLDR: render loops and nothing else.
+        ///
+        /// Contract:
+        ///
+        /// * **You absolutely need this work to complete immediately
+        ///   or your app will appear to freeze.**
+        /// * **Your work will always complete virtually instantaneously.**
+        ///
+        /// Examples:
+        ///
+        /// * the main thread in a GUI application
+        /// * the update & render loop in a game
+        /// * a secondary thread which progresses an animation
+        ///
+        /// Use this QoS class for any work which, if delayed,
+        /// will make your user interface unresponsive.
+        /// It is expected that this work will be virtually instantaneous.
+        ///
+        /// This QoS class is not energy-efficient.
+        /// Specifying this class is a request to run with
+        /// nearly all available system CPU and I/O bandwidth even under contention.
+        UserInteractive,
+    }
+
+    pub(super) const IS_QOS_AVAILABLE: bool = true;
+
+    pub(super) fn set_current_thread_qos_class(class: QoSClass) {
+        let class = match class {
+            QoSClass::UserInteractive => libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE,
+            QoSClass::UserInitiated => libc::qos_class_t::QOS_CLASS_USER_INITIATED,
+            QoSClass::Utility => libc::qos_class_t::QOS_CLASS_UTILITY,
+            QoSClass::Background => libc::qos_class_t::QOS_CLASS_BACKGROUND,
+        };
+
+        // SAFETY: Undocumented
+        let code = unsafe { libc::pthread_set_qos_class_self_np(class, 0) };
+
+        if code == 0 {
+            return;
+        }
+
+        // SAFETY: Undocumented
+        let errno = unsafe { libc::__error() };
+        // SAFETY: Undocumented
+        let errno_value = unsafe { *errno };
+
+        #[expect(clippy::unreachable, reason = "makes sense here")]
+        match errno_value {
+            libc::EPERM => {
+                // This thread has been excluded from the QoS system
+                // due to a previous call to a function such as `pthread_setschedparam`
+                // which is incompatible with QoS.
+                //
+                // Panic instead of returning an error
+                // to maintain the invariant that we only use QoS APIs.
+                panic!(
+                    "tried to set QoS of thread which has opted out of QoS (os error {errno_value})"
+                )
+            },
+
+            libc::EINVAL => {
+                // This is returned if we pass something other than a qos_class_t
+                // to `pthread_set_qos_class_self_np`.
+                //
+                // This is impossible, so again panic.
+                unreachable!(
+                    "invalid qos_class_t value was passed to pthread_set_qos_class_self_np"
+                )
+            },
+
+            _ => {
+                // `pthread_set_qos_class_self_np`'s documentation
+                // does not mention any other errors.
+                unreachable!(
+                    "`pthread_set_qos_class_self_np` returned unexpected error {errno_value}"
+                )
+            },
+        }
+    }
+
+    pub(super) fn get_current_thread_qos_class() -> Option<QoSClass> {
+        // SAFETY: undocumented
+        let current_thread = unsafe { libc::pthread_self() };
+        let mut qos_class_raw = libc::qos_class_t::QOS_CLASS_UNSPECIFIED;
+        // SAFETY: undocumented
+        let code = unsafe {
+            libc::pthread_get_qos_class_np(
+                current_thread,
+                &raw mut qos_class_raw,
+                std::ptr::null_mut(),
+            )
+        };
+
+        #[expect(clippy::unreachable, reason = "See comment below")]
+        if code != 0 {
+            // `pthread_get_qos_class_np`'s documentation states that
+            // an error value is placed into errno if the return code is not zero.
+            // However, it never states what errors are possible.
+            // Inspecting the source[0] shows that, as of this writing, it always returns zero.
+            //
+            // Whatever errors the function could report in future are likely to be
+            // ones which we cannot handle anyway
+            //
+            // 0: https://github.com/apple-oss-distributions/libpthread/blob/67e155c94093be9a204b69637d198eceff2c7c46/src/qos.c#L171-L177
+            // SAFETY: undocumented
+            let errno = unsafe { libc::__error() };
+            // SAFETY: undocumented
+            let errno_value = unsafe { *errno };
+            unreachable!("`pthread_get_qos_class_np` failed unexpectedly (os error {errno_value})");
+        }
+
+        match qos_class_raw {
+            libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE => Some(QoSClass::UserInteractive),
+            libc::qos_class_t::QOS_CLASS_USER_INITIATED => Some(QoSClass::UserInitiated),
+            libc::qos_class_t::QOS_CLASS_DEFAULT => None, // QoS has never been set
+            libc::qos_class_t::QOS_CLASS_UTILITY => Some(QoSClass::Utility),
+            libc::qos_class_t::QOS_CLASS_BACKGROUND => Some(QoSClass::Background),
+
+            libc::qos_class_t::QOS_CLASS_UNSPECIFIED => {
+                // Using manual scheduling APIs causes threads to “opt out” of QoS.
+                // At this point they become incompatible with QoS,
+                // and as such have the “unspecified” QoS class.
+                //
+                // Panic instead of returning an error
+                // to maintain the invariant that we only use QoS APIs.
+                panic!("tried to get QoS of thread which has opted out of QoS")
+            },
+        }
+    }
+
+    pub(super) const fn thread_intent_to_qos_class(intent: ThreadIntent) -> QoSClass {
+        match intent {
+            ThreadIntent::Worker => QoSClass::Utility,
+            ThreadIntent::LatencySensitive => QoSClass::UserInitiated,
+        }
+    }
+}
+
+// FIXME: Windows has [QoS APIs](https://learn.microsoft.com/en-us/windows/win32/procthread/quality-of-service), we should use them!
+#[cfg(not(target_vendor = "apple"))]
+mod imp {
+    use super::ThreadIntent;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub(super) enum QoSClass {
+        Default,
+    }
+
+    pub(super) const IS_QOS_AVAILABLE: bool = false;
+
+    pub(super) fn set_current_thread_qos_class(_: QoSClass) {}
+
+    pub(super) fn get_current_thread_qos_class() -> Option<QoSClass> {
+        None
+    }
+
+    pub(super) fn thread_intent_to_qos_class(_: ThreadIntent) -> QoSClass {
+        QoSClass::Default
+    }
+}

--- a/crates/stdx/src/thread/pool.rs
+++ b/crates/stdx/src/thread/pool.rs
@@ -46,10 +46,8 @@ impl Pool {
     #[must_use]
     pub fn new(threads: usize) -> Self {
         const INITIAL_INTENT: ThreadIntent = ThreadIntent::Worker;
-
         let (job_sender, job_receiver) = crossbeam_channel::unbounded();
         let extant_tasks = Arc::new(AtomicUsize::new(0));
-
         let mut handles = Vec::with_capacity(threads);
         for index in 0..threads {
             let handle = Builder::new(INITIAL_INTENT, format!("Worker{index}"))
@@ -71,7 +69,6 @@ impl Pool {
                     }
                 })
                 .expect("failed to spawn thread");
-
             handles.push(handle);
         }
 
@@ -99,7 +96,6 @@ impl Pool {
             }
             function()
         });
-
         let job = Job {
             requested_intent: intent,
             function: boxed_function,
@@ -159,7 +155,6 @@ impl<'scope> Scope<'_, 'scope> {
             function();
             drop(wg);
         });
-
         let job = Job {
             requested_intent: intent,
             // SAFETY: leaking is inherently safe
@@ -172,5 +167,137 @@ impl<'scope> Scope<'_, 'scope> {
         };
         self.pool.extant_tasks.fetch_add(1, Ordering::SeqCst);
         self.pool.job_sender.send(job).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        thread,
+        time::Duration,
+    };
+
+    fn wait_for_empty(pool: &Pool) {
+        while !pool.is_empty() {
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn new_creates_empty_pool() {
+        let pool = Pool::new(2);
+        assert_eq!(pool.len(), 0);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn spawn_executes_function() {
+        let pool = Pool::new(1);
+        let executed = Arc::new(AtomicBool::new(false));
+        let executed_clone = Arc::clone(&executed);
+        pool.spawn(ThreadIntent::Worker, move || {
+            executed_clone.store(true, Ordering::SeqCst);
+        });
+        wait_for_empty(&pool);
+        assert!(executed.load(Ordering::SeqCst));
+        assert_eq!(pool.len(), 0);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn spawn_changes_thread_intent() {
+        let pool = Pool::new(1);
+        let executed = Arc::new(AtomicBool::new(false));
+        let first_executed = Arc::clone(&executed);
+        pool.spawn(ThreadIntent::Worker, move || {
+            first_executed.store(true, Ordering::SeqCst);
+        });
+        wait_for_empty(&pool);
+        let second_executed = Arc::clone(&executed);
+        pool.spawn(ThreadIntent::LatencySensitive, move || {
+            second_executed.store(true, Ordering::SeqCst);
+        });
+        wait_for_empty(&pool);
+        assert!(executed.load(Ordering::SeqCst));
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn spawn_handles_panicking_function() {
+        let pool = Pool::new(1);
+        pool.spawn(ThreadIntent::Worker, || panic!());
+        wait_for_empty(&pool);
+        assert_eq!(pool.len(), 0);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn scoped_executes_borrowing_function() {
+        let pool = Pool::new(1);
+        let value = 42;
+        let result = pool.scoped(|scope| {
+            scope.spawn(ThreadIntent::Worker, || {
+                assert_eq!(value, 42);
+            });
+            value + 1
+        });
+        assert_eq!(result, 43);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn scoped_executes_multiple_functions() {
+        let pool = Pool::new(2);
+        let value = Arc::new(AtomicUsize::new(0));
+        pool.scoped(|scope| {
+            let first = Arc::clone(&value);
+            let second = Arc::clone(&value);
+            scope.spawn(ThreadIntent::Worker, move || {
+                first.fetch_add(1, Ordering::SeqCst);
+            });
+            scope.spawn(ThreadIntent::LatencySensitive, move || {
+                second.fetch_add(1, Ordering::SeqCst);
+            });
+        });
+        assert_eq!(value.load(Ordering::SeqCst), 2);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn scoped_handles_panicking_function() {
+        let pool = Pool::new(1);
+        pool.scoped(|scope| {
+            scope.spawn(ThreadIntent::Worker, || panic!());
+        });
+        assert_eq!(pool.len(), 0);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn scoped_returns_result_after_tasks_finish() {
+        let pool = Pool::new(2);
+        let value = Arc::new(AtomicUsize::new(0));
+        let result = pool.scoped(|scope| {
+            let value_clone = Arc::clone(&value);
+            scope.spawn(ThreadIntent::Worker, move || {
+                value_clone.store(7, Ordering::SeqCst);
+            });
+            11
+        });
+        assert_eq!(result, 11);
+        assert_eq!(value.load(Ordering::SeqCst), 7);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn zero_thread_pool_starts_empty() {
+        let pool = Pool::new(0);
+        assert_eq!(pool.len(), 0);
+        assert!(pool.is_empty());
     }
 }

--- a/crates/stdx/src/thread/pool.rs
+++ b/crates/stdx/src/thread/pool.rs
@@ -1,0 +1,176 @@
+//! [`Pool`] implements a basic custom thread pool
+//! inspired by the [`threadpool` crate](http://docs.rs/threadpool).
+//! When you spawn a task you specify a thread intent
+//! so the pool can schedule it to run on a thread with that intent.
+//! wgsl-analyzer uses this to prioritize work based on latency requirements.
+//!
+//! The thread pool is implemented entirely using
+//! the threading utilities in [`crate::thread`].
+
+use std::{
+    marker::PhantomData,
+    panic::{self, UnwindSafe},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use crossbeam_channel::{Receiver, Sender};
+use crossbeam_utils::sync::WaitGroup;
+
+use crate::thread::{Builder, JoinHandle, ThreadIntent};
+
+pub struct Pool {
+    // `_handles` is never read: the field is present
+    // only for its `Drop` impl.
+
+    // The worker threads exit once the channel closes;
+    // make sure to keep `job_sender` above `handles`
+    // so that the channel is actually closed
+    // before we join the worker threads!
+    job_sender: Sender<Job>,
+    _handles: Box<[JoinHandle]>,
+    extant_tasks: Arc<AtomicUsize>,
+}
+
+struct Job {
+    requested_intent: ThreadIntent,
+    function: Box<dyn FnOnce() + Send + UnwindSafe + 'static>,
+}
+
+impl Pool {
+    /// # Panics
+    ///
+    /// Panics if job panics.
+    #[must_use]
+    pub fn new(threads: usize) -> Self {
+        const INITIAL_INTENT: ThreadIntent = ThreadIntent::Worker;
+
+        let (job_sender, job_receiver) = crossbeam_channel::unbounded();
+        let extant_tasks = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::with_capacity(threads);
+        for index in 0..threads {
+            let handle = Builder::new(INITIAL_INTENT, format!("Worker{index}"))
+                .allow_leak(true)
+                .spawn({
+                    let extant_tasks = Arc::clone(&extant_tasks);
+                    let job_receiver: Receiver<Job> = job_receiver.clone();
+                    move || {
+                        let mut current_intent = INITIAL_INTENT;
+                        for job in job_receiver {
+                            if job.requested_intent != current_intent {
+                                job.requested_intent.apply_to_current_thread();
+                                current_intent = job.requested_intent;
+                            }
+                            // discard the panic, we should have logged the backtrace already
+                            drop(panic::catch_unwind(job.function));
+                            extant_tasks.fetch_sub(1, Ordering::SeqCst);
+                        }
+                    }
+                })
+                .expect("failed to spawn thread");
+
+            handles.push(handle);
+        }
+
+        Self {
+            job_sender,
+            _handles: handles.into_boxed_slice(),
+            extant_tasks,
+        }
+    }
+
+    /// # Panics
+    ///
+    /// Panics if job panics.
+    pub fn spawn<Function>(
+        &self,
+        intent: ThreadIntent,
+        function: Function,
+    ) where
+        Function: FnOnce() + Send + UnwindSafe + 'static,
+    {
+        #[expect(clippy::semicolon_if_nothing_returned, reason = "thin wrapper")]
+        let boxed_function = Box::new(move || {
+            if cfg!(debug_assertions) {
+                intent.assert_is_used_on_current_thread();
+            }
+            function()
+        });
+
+        let job = Job {
+            requested_intent: intent,
+            function: boxed_function,
+        };
+        self.extant_tasks.fetch_add(1, Ordering::SeqCst);
+        self.job_sender.send(job).unwrap();
+    }
+
+    pub fn scoped<'pool, 'scope, Function, Result>(
+        &'pool self,
+        function: Function,
+    ) -> Result
+    where
+        Function: FnOnce(&Scope<'pool, 'scope>) -> Result,
+    {
+        let wait_group = WaitGroup::new();
+        let scope = Scope {
+            pool: self,
+            wg: wait_group,
+            _marker: PhantomData,
+        };
+        let result = function(&scope);
+        scope.wg.wait();
+        result
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.extant_tasks.load(Ordering::SeqCst)
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+pub struct Scope<'pool, 'scope> {
+    pool: &'pool Pool,
+    wg: WaitGroup,
+    _marker: PhantomData<fn(&'scope ()) -> &'scope ()>,
+}
+
+impl<'scope> Scope<'_, 'scope> {
+    pub fn spawn<F>(
+        &self,
+        intent: ThreadIntent,
+        function: F,
+    ) where
+        F: 'scope + FnOnce() + Send + UnwindSafe,
+    {
+        let wg = self.wg.clone();
+        let boxed_function = Box::new(move || {
+            if cfg!(debug_assertions) {
+                intent.assert_is_used_on_current_thread();
+            }
+            function();
+            drop(wg);
+        });
+
+        let job = Job {
+            requested_intent: intent,
+            // SAFETY: leaking is inherently safe
+            function: unsafe {
+                std::mem::transmute::<
+                    Box<dyn 'scope + FnOnce() + Send + UnwindSafe>,
+                    Box<dyn 'static + FnOnce() + Send + UnwindSafe>,
+                >(boxed_function)
+            },
+        };
+        self.pool.extant_tasks.fetch_add(1, Ordering::SeqCst);
+        self.pool.job_sender.send(job).unwrap();
+    }
+}

--- a/crates/stdx/src/variance.rs
+++ b/crates/stdx/src/variance.rs
@@ -46,8 +46,8 @@ macro_rules! phantom_type {
         impl<T> fmt::Debug for $name<T>
             where T: ?Sized
         {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{}<{}>", stringify!($name), type_name::<T>())
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "{}<{}>", stringify!($name), type_name::<T>())
             }
         }
 
@@ -120,8 +120,8 @@ macro_rules! phantom_lifetime {
         impl Variance for $name<'_> {}
 
         impl fmt::Debug for $name<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{}", stringify!($name))
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "{}", stringify!($name))
             }
         }
     )*};

--- a/crates/stdx/src/variance.rs
+++ b/crates/stdx/src/variance.rs
@@ -243,7 +243,7 @@ pub trait Variance: sealed::Sealed + Default {}
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,ignore
 /// #![feature(phantom_variance_markers)]
 ///
 /// use core::marker::{PhantomCovariant, variance};

--- a/crates/stdx/src/variance.rs
+++ b/crates/stdx/src/variance.rs
@@ -1,0 +1,272 @@
+#![expect(clippy::single_char_lifetime_names, reason = "really generic")]
+//! This is a copy of [`std::marker::variance`].
+
+use std::any::type_name;
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
+
+macro_rules! first_token {
+    ($first:tt $($rest:tt)*) => {
+        $first
+    };
+}
+macro_rules! phantom_type {
+    ($(
+        $(#[$attr:meta])*
+        pub struct $name:ident <$t:ident> ($($inner:tt)*);
+    )*) => {$(
+        $(#[$attr])*
+        pub struct $name<$t>($($inner)*) where T: ?Sized;
+
+        impl<T> $name<T>
+            where T: ?Sized
+        {
+            /// Constructs a new instance of the variance marker.
+            pub const fn new() -> Self {
+                Self(PhantomData)
+            }
+        }
+
+        impl<T> self::sealed::Sealed for $name<T> where T: ?Sized {
+            const VALUE: Self = Self::new();
+        }
+
+        impl<T> Variance for $name<T> where T: ?Sized {}
+
+        impl<T> Default for $name<T>
+            where T: ?Sized
+        {
+            fn default() -> Self {
+                Self(PhantomData)
+            }
+        }
+
+        impl<T> fmt::Debug for $name<T>
+            where T: ?Sized
+        {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}<{}>", stringify!($name), type_name::<T>())
+            }
+        }
+
+        impl<T> Clone for $name<T>
+            where T: ?Sized
+        {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<T> Copy for $name<T> where T: ?Sized {}
+
+        impl<T> PartialEq for $name<T>
+            where T: ?Sized
+        {
+            fn eq(&self, _: &Self) -> bool {
+                true
+            }
+        }
+
+        impl<T> Eq for $name<T> where T: ?Sized {}
+
+        #[expect(clippy::non_canonical_partial_ord_impl, reason = "all are equal")]
+        impl<T> PartialOrd for $name<T>
+            where T: ?Sized
+        {
+            fn partial_cmp(&self, _: &Self) -> Option<Ordering> {
+                Some(Ordering::Equal)
+            }
+        }
+
+        impl<T> Ord for $name<T>
+            where T: ?Sized
+        {
+            fn cmp(&self, _: &Self) -> Ordering {
+                Ordering::Equal
+            }
+        }
+
+        impl<T> Hash for $name<T>
+            where T: ?Sized
+        {
+            fn hash<H>(&self, _: &mut H) where H: Hasher {}
+        }
+    )*};
+}
+
+macro_rules! phantom_lifetime {
+    ($(
+        $(#[$attr:meta])*
+        pub struct $name:ident <$lt:lifetime> ($($inner:tt)*);
+    )*) => {$(
+        $(#[$attr])*
+
+        #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name<$lt>($($inner)*);
+
+        impl $name<'_> {
+            /// Constructs a new instance of the variance marker.
+            pub const fn new() -> Self {
+                Self(first_token!($($inner)*)(PhantomData))
+            }
+        }
+
+        impl self::sealed::Sealed for $name<'_> {
+            const VALUE: Self = Self::new();
+        }
+
+        impl Variance for $name<'_> {}
+
+        impl fmt::Debug for $name<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", stringify!($name))
+            }
+        }
+    )*};
+}
+
+phantom_lifetime! {
+    /// Zero-sized type used to mark a lifetime as covariant.
+    ///
+    /// Covariant lifetimes must live at least as long as declared. See [the reference][1] for more
+    /// information.
+    ///
+    /// [1]: https://doc.rust-lang.org/stable/reference/subtyping.html#variance
+    ///
+    /// ## Layout
+    ///
+    /// For all `'a`, the following are guaranteed:
+    /// * `size_of::<PhantomCovariantLifetime<'a>>() == 0`
+    /// * `align_of::<PhantomCovariantLifetime<'a>>() == 1`
+
+    pub struct PhantomCovariantLifetime<'a>(PhantomCovariant<&'a ()>);
+    /// Zero-sized type used to mark a lifetime as contravariant.
+    ///
+    /// Contravariant lifetimes must live at most as long as declared. See [the reference][1] for
+    /// more information.
+    ///
+    /// [1]: https://doc.rust-lang.org/stable/reference/subtyping.html#variance
+    ///
+    /// ## Layout
+    ///
+    /// For all `'a`, the following are guaranteed:
+    /// * `size_of::<PhantomContravariantLifetime<'a>>() == 0`
+    /// * `align_of::<PhantomContravariantLifetime<'a>>() == 1`
+
+    pub struct PhantomContravariantLifetime<'a>(PhantomContravariant<&'a ()>);
+    /// Zero-sized type used to mark a lifetime as invariant.
+    ///
+    /// Invariant lifetimes must be live for the exact length declared, neither shorter nor longer.
+    /// See [the reference][1] for more information.
+    ///
+    /// [1]: https://doc.rust-lang.org/stable/reference/subtyping.html#variance
+    ///
+    /// ## Layout
+    ///
+    /// For all `'a`, the following are guaranteed:
+    /// * `size_of::<PhantomInvariantLifetime<'a>>() == 0`
+    /// * `align_of::<PhantomInvariantLifetime<'a>>() == 1`
+
+    pub struct PhantomInvariantLifetime<'a>(PhantomInvariant<&'a ()>);
+
+}
+
+phantom_type! {
+    /// Zero-sized type used to mark a type parameter as covariant.
+    ///
+    /// Types used as part of the return value from a function are covariant. If the type is _also_
+    /// passed as a parameter then it is [invariant][PhantomInvariant]. See [the reference][1] for
+    /// more information.
+    ///
+    /// [1]: https://doc.rust-lang.org/stable/reference/subtyping.html#variance
+    ///
+    /// ## Layout
+    ///
+    /// For all `T`, the following are guaranteed:
+    /// * `size_of::<PhantomCovariant<T>>() == 0`
+    /// * `align_of::<PhantomCovariant<T>>() == 1`
+
+    pub struct PhantomCovariant<T>(PhantomData<fn() -> T>);
+    /// Zero-sized type used to mark a type parameter as contravariant.
+    ///
+    /// Types passed as arguments to a function are contravariant. If the type is _also_ part of the
+    /// return value from a function then it is [invariant][PhantomInvariant]. See [the
+    /// reference][1] for more information.
+    ///
+    /// [1]: https://doc.rust-lang.org/stable/reference/subtyping.html#variance
+    ///
+    /// ## Layout
+    ///
+    /// For all `T`, the following are guaranteed:
+    /// * `size_of::<PhantomContravariant<T>>() == 0`
+    /// * `align_of::<PhantomContravariant<T>>() == 1`
+
+    pub struct PhantomContravariant<T>(PhantomData<fn(T)>);
+    /// Zero-sized type used to mark a type parameter as invariant.
+    ///
+    /// Types that are both passed as an argument _and_ used as part of the return value from a
+    /// function are invariant. See [the reference][1] for more information.
+    ///
+    /// [1]: https://doc.rust-lang.org/stable/reference/subtyping.html#variance
+    ///
+    /// ## Layout
+    ///
+    /// For all `T`, the following are guaranteed:
+    /// * `size_of::<PhantomInvariant<T>>() == 0`
+    /// * `align_of::<PhantomInvariant<T>>() == 1`
+
+    pub struct PhantomInvariant<T>(PhantomData<fn(T) -> T>);
+
+}
+
+mod sealed {
+
+    pub trait Sealed {
+        const VALUE: Self;
+    }
+}
+/// A marker trait for phantom variance types.
+pub trait Variance: sealed::Sealed + Default {}
+/// Construct a variance marker; equivalent to [`Default::default`].
+///
+/// This type can be any of the following. You generally should not need to explicitly name the
+/// type, however.
+///
+/// - [`PhantomCovariant`]
+/// - [`PhantomContravariant`]
+/// - [`PhantomInvariant`]
+/// - [`PhantomCovariantLifetime`]
+/// - [`PhantomContravariantLifetime`]
+/// - [`PhantomInvariantLifetime`]
+///
+/// # Example
+///
+/// ```rust
+/// #![feature(phantom_variance_markers)]
+///
+/// use core::marker::{PhantomCovariant, variance};
+///
+/// struct BoundFn<F, P, R>
+/// where
+///     F: Fn(P) -> R,
+/// {
+///     function: F,
+///     parameter: P,
+///     return_value: PhantomCovariant<R>,
+/// }
+///
+/// let bound_fn = BoundFn {
+///     function: core::convert::identity,
+///     parameter: 5u8,
+///     return_value: variance(),
+/// };
+/// ```
+#[must_use]
+pub const fn variance<T>() -> T
+where
+    T: Variance,
+{
+    T::VALUE
+}

--- a/crates/vfs/src/file_set.rs
+++ b/crates/vfs/src/file_set.rs
@@ -84,9 +84,10 @@ impl FileSet {
 impl fmt::Debug for FileSet {
     fn fmt(
         &self,
-        f: &mut fmt::Formatter<'_>,
+        formatter: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
-        f.debug_struct("FileSet")
+        formatter
+            .debug_struct("FileSet")
             .field("n_files", &self.files.len())
             .finish_non_exhaustive()
     }

--- a/crates/vfs/src/vfs_path.rs
+++ b/crates/vfs/src/vfs_path.rs
@@ -415,7 +415,8 @@ impl VirtualPath {
         <_ as AsRef<paths::Utf8Path>>::as_ref(&self.0)
             .strip_prefix(&base.0)
             .ok()
-            .map(RelPath::new_unchecked)
+            // SAFETY: stripping a non-empty prefix from the beginning of any path yields a relative path
+            .map(|stripped| unsafe { RelPath::new_unchecked(stripped) })
     }
 
     /// Remove the last component of `self`.

--- a/crates/wgsl-analyzer/src/config.rs
+++ b/crates/wgsl-analyzer/src/config.rs
@@ -36,7 +36,7 @@ use lsp_types::{ClientCapabilities as LspClientCapabilities, ClientInfo};
 use paths::Utf8PathBuf;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use stdx::format_to_acc;
+use stdx::format_to_accumulator;
 use triomphe::Arc;
 use vfs::{AbsPath, AbsPathBuf};
 
@@ -113,13 +113,13 @@ config_data! {
     Clone, Copy, Debug, Serialize, Deserialize, Default, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
 pub enum NagaVersionConfig {
-    #[serde(rename = "0.27")]
-    Naga27,
     #[serde(rename = "0.28")]
     Naga28,
     #[default]
     #[serde(rename = "0.29")]
     Naga29,
+    #[serde(rename = "0.30")]
+    Naga30,
     #[serde(rename = "main")]
     NagaMain,
 }
@@ -598,9 +598,9 @@ impl Config {
             naga_parsing_enabled: *self.diagnostics_external_naga_parsing(),
             naga_validation_enabled: *self.diagnostics_external_naga_validation_errors(),
             naga_version: match self.diagnostics_external_naga_version() {
-                NagaVersionConfig::Naga27 => NagaVersion::Naga27,
                 NagaVersionConfig::Naga28 => NagaVersion::Naga28,
                 NagaVersionConfig::Naga29 => NagaVersion::Naga29,
+                NagaVersionConfig::Naga30 => NagaVersion::Naga30,
                 NagaVersionConfig::NagaMain => NagaVersion::NagaMain,
             },
             tint_enabled: *self.diagnostics_external_tintErrors(),
@@ -962,7 +962,7 @@ fn field_props(
         },
         "NagaVersionConfig" => set! {
             "type": "string",
-            "enum": ["0.27", "0.28", "0.29", "main"],
+            "enum": ["0.28", "0.29", "0.30", "main"],
             "enumDescriptions": [
                 "Naga version 27",
                 "Naga version 28",
@@ -1218,12 +1218,12 @@ fn manual(fields: &[SchemaField]) -> String {
             let name = format!("wgsl-analyzer.{id}");
             let doc = doc_comment_to_string(documentation);
             if default.contains('\n') {
-                format_to_acc!(
+                format_to_accumulator!(
                     accumulator,
                     "## {name} \n\nDefault:\n```json\n{default}\n```\n\n{doc}\n"
                 )
             } else {
-                format_to_acc!(accumulator, "## {name}\n\nDefault: `{default}`\n\n{doc}\n")
+                format_to_accumulator!(accumulator, "## {name}\n\nDefault: `{default}`\n\n{doc}\n")
             }
         },
     )
@@ -1233,7 +1233,7 @@ fn doc_comment_to_string(doc: &[&str]) -> String {
     doc.iter()
         .map(|iterator| iterator.strip_prefix(' ').unwrap_or(iterator))
         .fold(String::new(), |mut out, line| {
-            format_to_acc!(out, "{line}\n")
+            format_to_accumulator!(out, "{line}\n")
         })
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -39,7 +39,7 @@ wildcards = "deny"
 deny = []
 
 [sources]
-unknown-registry = "warn"
-unknown-git = "warn"
+unknown-registry = "deny"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["git+https://github.com/gfx-rs/wgpu"]

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -477,9 +477,9 @@
 						"default": "0.29",
 						"type": "string",
 						"enum": [
-							"0.27",
 							"0.28",
 							"0.29",
+							"0.30",
 							"main"
 						],
 						"enumDescriptions": [


### PR DESCRIPTION
# Objective

wgsl-analyzer uses no git dependencies. (nagamain is on the chopping block but not removed here)

## Solution

Vendor the two last things, which are very small.

- paths is a utility crate which I want to improve to suit our use case in ways that would be too much churn for r-a.
- stdx is a utility crate which I have already made some changes to in terms of documentation, must_use, const, minor lints, and others. We can remove things that have been added to std or add more utilities that we need without forcing r-a to also have those changes.

This is more appropriate now that we have already vendored vfs and vfs-notify for other reasons.

## Testing

CI is sufficient
